### PR TITLE
Upload broken symlinks fixed

### DIFF
--- a/artifactory/auth/cert/loader.go
+++ b/artifactory/auth/cert/loader.go
@@ -11,7 +11,7 @@ import (
 )
 
 func loadCertificates(caCertPool *x509.CertPool, certificatesDirPath string) error {
-	if !fileutils.IsPathExists(false, certificatesDirPath) {
+	if !fileutils.IsPathExists(certificatesDirPath, false) {
 		return nil
 	}
 	files, err := ioutil.ReadDir(certificatesDirPath)

--- a/artifactory/auth/cert/loader.go
+++ b/artifactory/auth/cert/loader.go
@@ -11,7 +11,7 @@ import (
 )
 
 func loadCertificates(caCertPool *x509.CertPool, certificatesDirPath string) error {
-	if !fileutils.IsPathExists(certificatesDirPath) {
+	if !fileutils.IsPathExists(false, certificatesDirPath) {
 		return nil
 	}
 	files, err := ioutil.ReadDir(certificatesDirPath)

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -248,7 +248,7 @@ func (ds *DownloadService) isFileAcceptRange(downloadFileDetails *httpclient.Dow
 }
 
 func shouldDownloadFile(localFilePath, md5, sha1 string) (bool, error) {
-	exists, err := fileutils.IsFileExists(false, localFilePath)
+	exists, err := fileutils.IsFileExists(localFilePath, false)
 	if err != nil {
 		return false, err
 	}
@@ -273,7 +273,7 @@ func removeIfSymlink(localSymlinkPath string) error {
 
 func createLocalSymlink(localPath, localFileName, symlinkArtifact string, symlinkChecksum bool, symlinkContentChecksum string, logMsgPrefix string) error {
 	if symlinkChecksum && symlinkContentChecksum != "" {
-		if !fileutils.IsPathExists(false, symlinkArtifact) {
+		if !fileutils.IsPathExists(symlinkArtifact, false) {
 			return errorutils.CheckError(errors.New("Symlink validation failed, target doesn't exist: " + symlinkArtifact))
 		}
 		file, err := os.Open(symlinkArtifact)
@@ -292,7 +292,7 @@ func createLocalSymlink(localPath, localFileName, symlinkArtifact string, symlin
 		}
 	}
 	localSymlinkPath := filepath.Join(localPath, localFileName)
-	isFileExists, err := fileutils.IsFileExists(false, localSymlinkPath)
+	isFileExists, err := fileutils.IsFileExists(localSymlinkPath, false)
 	if err != nil {
 		return err
 	}

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -248,7 +248,7 @@ func (ds *DownloadService) isFileAcceptRange(downloadFileDetails *httpclient.Dow
 }
 
 func shouldDownloadFile(localFilePath, md5, sha1 string) (bool, error) {
-	exists, err := fileutils.IsFileExists(localFilePath)
+	exists, err := fileutils.IsFileExists(false, localFilePath)
 	if err != nil {
 		return false, err
 	}
@@ -273,7 +273,7 @@ func removeIfSymlink(localSymlinkPath string) error {
 
 func createLocalSymlink(localPath, localFileName, symlinkArtifact string, symlinkChecksum bool, symlinkContentChecksum string, logMsgPrefix string) error {
 	if symlinkChecksum && symlinkContentChecksum != "" {
-		if !fileutils.IsPathExists(symlinkArtifact) {
+		if !fileutils.IsPathExists(false, symlinkArtifact) {
 			return errorutils.CheckError(errors.New("Symlink validation failed, target doesn't exist: " + symlinkArtifact))
 		}
 		file, err := os.Open(symlinkArtifact)
@@ -292,7 +292,7 @@ func createLocalSymlink(localPath, localFileName, symlinkArtifact string, symlin
 		}
 	}
 	localSymlinkPath := filepath.Join(localPath, localFileName)
-	isFileExists, err := fileutils.IsFileExists(localSymlinkPath)
+	isFileExists, err := fileutils.IsFileExists(false, localSymlinkPath)
 	if err != nil {
 		return err
 	}

--- a/artifactory/services/download_test.go
+++ b/artifactory/services/download_test.go
@@ -69,10 +69,10 @@ func flatDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "a.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "a.in")) {
 		t.Error("Missing file a.in")
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
 		t.Error("Missing file b.in")
 	}
 
@@ -86,10 +86,10 @@ func flatDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir2, "test", "a.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "test", "a.in")) {
 		t.Error("Missing file a.in")
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir2, "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "b.in")) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -108,11 +108,11 @@ func recursiveDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "a.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "a.in")) {
 		t.Error("Missing file a.in")
 	}
 
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
 		t.Error("Missing file b.in")
 	}
 
@@ -126,11 +126,11 @@ func recursiveDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if fileutils.IsPathExists(filepath.Join(workingDir2, "a.in")) {
+	if fileutils.IsPathExists(false, filepath.Join(workingDir2, "a.in")) {
 		t.Error("Should not download a.in")
 	}
 
-	if !fileutils.IsPathExists(filepath.Join(workingDir2, "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "b.in")) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -149,11 +149,11 @@ func placeholderDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "test", "a", "a.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "test", "a", "a.in")) {
 		t.Error("Missing file a.in")
 	}
 
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "b", "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b", "b.in")) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -171,11 +171,11 @@ func includeDirsDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "test")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "test")) {
 		t.Error("Missing test folder")
 	}
 
-	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
 		t.Error("Missing file b.in")
 	}
 }

--- a/artifactory/services/download_test.go
+++ b/artifactory/services/download_test.go
@@ -69,10 +69,10 @@ func flatDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "a.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "a.in"), false) {
 		t.Error("Missing file a.in")
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 
@@ -86,10 +86,10 @@ func flatDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "test", "a.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir2, "test", "a.in"), false) {
 		t.Error("Missing file a.in")
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir2, "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -108,11 +108,11 @@ func recursiveDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "a.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "a.in"), false) {
 		t.Error("Missing file a.in")
 	}
 
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 
@@ -126,11 +126,11 @@ func recursiveDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if fileutils.IsPathExists(false, filepath.Join(workingDir2, "a.in")) {
+	if fileutils.IsPathExists(filepath.Join(workingDir2, "a.in"), false) {
 		t.Error("Should not download a.in")
 	}
 
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir2, "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir2, "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -149,11 +149,11 @@ func placeholderDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "test", "a", "a.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "test", "a", "a.in"), false) {
 		t.Error("Missing file a.in")
 	}
 
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b", "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "b", "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 }
@@ -171,11 +171,11 @@ func includeDirsDownload(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "test")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "test"), false) {
 		t.Error("Missing test folder")
 	}
 
-	if !fileutils.IsPathExists(false, filepath.Join(workingDir, "b.in")) {
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "b.in"), false) {
 		t.Error("Missing file b.in")
 	}
 }

--- a/artifactory/services/gitlfsclean_test.go
+++ b/artifactory/services/gitlfsclean_test.go
@@ -1,8 +1,8 @@
 package services
 
 import (
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +52,7 @@ func getCliDotGitPath(t *testing.T) string {
 		t.Error("Failed to get current dir.")
 	}
 	dotGitPath := filepath.Join(workingDir, "..", "..")
-	dotGitExists, err := fileutils.IsDirExists(filepath.Join(dotGitPath, ".git"))
+	dotGitExists, err := fileutils.IsDirExists(false, filepath.Join(dotGitPath, ".git"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/artifactory/services/gitlfsclean_test.go
+++ b/artifactory/services/gitlfsclean_test.go
@@ -52,7 +52,7 @@ func getCliDotGitPath(t *testing.T) string {
 		t.Error("Failed to get current dir.")
 	}
 	dotGitPath := filepath.Join(workingDir, "..", "..")
-	dotGitExists, err := fileutils.IsDirExists(false, filepath.Join(dotGitPath, ".git"))
+	dotGitExists, err := fileutils.IsDirExists(filepath.Join(dotGitPath, ".git"), false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -244,23 +244,17 @@ func createUploadTask(taskData *uploadTaskData) error {
 	}
 	var task parallel.TaskFunc
 
+	// Get symlink target (returns empty string if regular file) - Used in upload name / symlinks properties
 	symlinkPath, err := fspatterns.GetFileSymlinkPath(taskData.path)
 	if err != nil {
 		return err
 	}
 
-	// If preserving symlinks, use root path name for upload (symlink itself)
-	if taskData.uploadParams.IsSymlink() {
+	// If preserving symlinks or symlink target is empty, use root path name for upload (symlink itself / regular file)
+	if taskData.uploadParams.IsSymlink() || symlinkPath == "" {
 		taskData.target = getUploadTarget(taskData.path, taskData.target, taskData.uploadParams.IsFlat())
-
 	} else {
-		// If symlink target is empty, use root path name for upload
-		if symlinkPath == "" {
-			taskData.target = getUploadTarget(taskData.path, taskData.target, taskData.uploadParams.IsFlat())
-		} else {
-			// Use symlink target for upload
-			taskData.target = getUploadTarget(symlinkPath, taskData.target, taskData.uploadParams.IsFlat())
-		}
+		taskData.target = getUploadTarget(symlinkPath, taskData.target, taskData.uploadParams.IsFlat())
 	}
 
 	artifact := clientutils.Artifact{LocalPath: taskData.path, TargetPath: taskData.target, Symlink: symlinkPath}

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -112,9 +112,10 @@ func addSymlinkProps(artifact clientutils.Artifact, uploadParams UploadParams) (
 		sha1Property := ""
 		fileInfo, err := os.Stat(artifact.LocalPath)
 		if err != nil {
-			return "", err
-		}
-		if !fileInfo.IsDir() {
+			if !os.IsNotExist(err) { // If error occurred, but not due to nonexistence of Symlink target -> return empty
+				return "", err
+			}
+		} else if !fileInfo.IsDir() { // If Symlink target exists -> get SHA1 if isn't a directory
 			file, err := os.Open(artifact.LocalPath)
 			errorutils.CheckError(err)
 			if err != nil {
@@ -140,21 +141,21 @@ func collectFilesForUpload(uploadParams UploadParams, producer parallel.Runner, 
 		uploadParams.SetTarget(uploadParams.GetTarget() + "/")
 	}
 	uploadParams.SetPattern(clientutils.ReplaceTildeWithUserHome(uploadParams.GetPattern()))
-	rootPath, err := fspatterns.GetRootPath(uploadParams.GetPattern(), uploadParams.IsRegexp())
+	rootPath, err := fspatterns.GetRootPath(uploadParams.GetPattern(), uploadParams.IsRegexp(), uploadParams.IsSymlink())
 	if err != nil {
 		errorsQueue.AddError(err)
 		return
 	}
 
-	isDir, err := fileutils.IsDir(rootPath)
+	isDir, err := fileutils.IsDir(uploadParams.IsSymlink(), rootPath)
 	if err != nil {
 		errorsQueue.AddError(err)
 		return
 	}
 
-	// If the path is a single file then return it or it is a link and preserve symbolic links is set to true
-	if !isDir || (uploadParams.IsSymlink() && fileutils.IsPathSymlink(uploadParams.GetPattern())) {
-		artifact := fspatterns.GetSingleFileToUpload(rootPath, uploadParams.GetTarget(), uploadParams.IsFlat())
+	// If the path is a single file return it or it is a link and preserve symbolic links is set to true
+	if !isDir || (uploadParams.IsSymlink() && fileutils.IsPathSymlink(rootPath)) {
+		artifact := fspatterns.GetSingleFileToUpload(rootPath, uploadParams.GetTarget(), uploadParams.IsFlat(), uploadParams.IsSymlink())
 		props, err := addSymlinkProps(artifact, uploadParams)
 		if err != nil {
 			errorsQueue.AddError(err)
@@ -238,12 +239,13 @@ func createUploadTask(taskData *uploadTaskData) error {
 		taskData.target = strings.Replace(taskData.target, "{"+strconv.Itoa(i)+"}", group, -1)
 	}
 	var task parallel.TaskFunc
-	taskData.target = getUploadTarget(taskData.uploadParams.IsFlat(), taskData.path, taskData.target)
-	// If case taskData.path is a symlink we get the symlink link path.
+
 	symlinkPath, e := fspatterns.GetFileSymlinkPath(taskData.path)
 	if e != nil {
 		return e
 	}
+	taskData.target = getUploadTarget(taskData.uploadParams.IsFlat(), taskData.uploadParams.IsSymlink(), taskData.path, taskData.target, symlinkPath)
+
 	artifact := clientutils.Artifact{LocalPath: taskData.path, TargetPath: taskData.target, Symlink: symlinkPath}
 	props, e := addSymlinkProps(artifact, taskData.uploadParams)
 	if e != nil {
@@ -262,13 +264,19 @@ func createUploadTask(taskData *uploadTaskData) error {
 	return nil
 }
 
-func getUploadTarget(isFlat bool, path, target string) string {
+func getUploadTarget(isFlat, considerSymLink bool, rootPath, target, symlinkPath string) string {
 	if strings.HasSuffix(target, "/") {
+		var fileRootPath string
+		if considerSymLink || (symlinkPath == "") { // If preserving symlinks, or no symlink target (regular file / broken symlink)
+			fileRootPath = rootPath // Use root file name for upload
+		} else { // Valid symlink and not preserving
+			fileRootPath = symlinkPath // Use symlink target name for upload
+		}
 		if isFlat {
-			fileName, _ := fileutils.GetFileAndDirFromPath(path)
+			fileName, _ := fileutils.GetFileAndDirFromPath(fileRootPath)
 			target += fileName
 		} else {
-			target += clientutils.TrimPath(path)
+			target += clientutils.TrimPath(fileRootPath)
 		}
 	}
 	return target
@@ -284,18 +292,14 @@ func addPropsToTargetPath(targetPath, props, debConfig string) (string, error) {
 }
 
 func prepareUploadData(baseTargetPath, localPath, props string, uploadParams UploadParams, logMsgPrefix string) (fileInfo os.FileInfo, targetPath string, fileName string, err error) {
-	fileName, _ = fileutils.GetFileAndDirFromPath(baseTargetPath)
+	fileName, _ = fileutils.GetFileAndDirFromPath(localPath)
 	targetPath, err = addPropsToTargetPath(baseTargetPath, props, uploadParams.GetDebian())
 	if errorutils.CheckError(err) != nil {
 		return
 	}
 	log.Info(logMsgPrefix+"Uploading artifact:", localPath)
-	file, err := os.Open(localPath)
-	defer file.Close()
-	if errorutils.CheckError(err) != nil {
-		return
-	}
-	fileInfo, err = file.Stat()
+
+	fileInfo, err = os.Lstat(localPath)
 	errorutils.CheckError(err)
 	return
 }
@@ -307,27 +311,22 @@ func (us *UploadService) uploadFile(localPath, targetPath, props string, uploadP
 	if err != nil {
 		return utils.FileInfo{}, false, err
 	}
-	file, err := os.Open(localPath)
-	defer file.Close()
-	if errorutils.CheckError(err) != nil {
-		return utils.FileInfo{}, false, err
-	}
+
 	var checksumDeployed bool = false
 	var resp *http.Response
 	var details *fileutils.FileDetails
 	var body []byte
 	httpClientsDetails := us.ArtDetails.CreateHttpClientDetails()
-	fileStat, err := os.Lstat(localPath)
 	if errorutils.CheckError(err) != nil {
 		return utils.FileInfo{}, false, err
 	}
-	if uploadParams.IsSymlink() && fileutils.IsFileSymlink(fileStat) {
+	if uploadParams.IsSymlink() && fileutils.IsFileSymlink(fileInfo) {
 		resp, details, body, err = us.uploadSymlink(targetPath, httpClientsDetails, uploadParams)
 		if err != nil {
 			return utils.FileInfo{}, false, err
 		}
 	} else {
-		resp, details, body, checksumDeployed, err = us.doUpload(file, localPath, targetPath, logMsgPrefix, httpClientsDetails, fileInfo, uploadParams)
+		resp, details, body, checksumDeployed, err = us.doUpload(localPath, targetPath, logMsgPrefix, httpClientsDetails, fileInfo, uploadParams)
 	}
 	if err != nil {
 		return utils.FileInfo{}, false, err
@@ -342,11 +341,11 @@ func (us *UploadService) uploadSymlink(targetPath string, httpClientsDetails htt
 	if err != nil {
 		return
 	}
-	resp, body, err = utils.UploadFile(nil, "", targetPath, us.ArtDetails, details, httpClientsDetails, us.client, us.Retries)
+	resp, body, err = utils.UploadFile("", targetPath, us.ArtDetails, details, httpClientsDetails, us.client, us.Retries)
 	return
 }
 
-func (us *UploadService) doUpload(file *os.File, localPath, targetPath, logMsgPrefix string, httpClientsDetails httputils.HttpClientDetails, fileInfo os.FileInfo, uploadParams UploadParams) (*http.Response, *fileutils.FileDetails, []byte, bool, error) {
+func (us *UploadService) doUpload(localPath, targetPath, logMsgPrefix string, httpClientsDetails httputils.HttpClientDetails, fileInfo os.FileInfo, uploadParams UploadParams) (*http.Response, *fileutils.FileDetails, []byte, bool, error) {
 	var details *fileutils.FileDetails
 	var checksumDeployed bool
 	var resp *http.Response
@@ -362,7 +361,7 @@ func (us *UploadService) doUpload(file *os.File, localPath, targetPath, logMsgPr
 	}
 	if !us.DryRun && !checksumDeployed {
 		var body []byte
-		resp, body, err = utils.UploadFile(file, localPath, targetPath, us.ArtDetails, details, httpClientsDetails, us.client, us.Retries)
+		resp, body, err = utils.UploadFile(localPath, targetPath, us.ArtDetails, details, httpClientsDetails, us.client, us.Retries)
 		if err != nil {
 			return resp, details, body, checksumDeployed, err
 		}

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 )
@@ -20,11 +19,11 @@ import (
 const ARTIFACTORY_SYMLINK = "symlink.dest"
 const SYMLINK_SHA1 = "symlink.destsha1"
 
-func UploadFile(f *os.File, localPath, url string, artifactoryDetails auth.ArtifactoryDetails, details *fileutils.FileDetails,
+func UploadFile(localPath, url string, artifactoryDetails auth.ArtifactoryDetails, details *fileutils.FileDetails,
 	httpClientsDetails httputils.HttpClientDetails, client *httpclient.HttpClient, retries int) (*http.Response, []byte, error) {
 	var err error
 	if details == nil {
-		details, err = fileutils.GetFileDetails(f.Name())
+		details, err = fileutils.GetFileDetails(localPath)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/bintray/services/download.go
+++ b/bintray/services/download.go
@@ -250,7 +250,7 @@ func (ds *DownloadService) downloadBintrayFile(downloadParams *DownloadFileParam
 }
 
 func shouldDownloadFile(localFilePath string, remoteFileDetails *fileutils.FileDetails) (bool, error) {
-	exists, err := fileutils.IsFileExists(false, localFilePath)
+	exists, err := fileutils.IsFileExists(localFilePath, false)
 	if err != nil {
 		return false, err
 	}

--- a/bintray/services/download.go
+++ b/bintray/services/download.go
@@ -14,10 +14,10 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
-	"path/filepath"
 )
 
 func NewDownloadService(client *httpclient.HttpClient) *DownloadService {
@@ -228,12 +228,12 @@ func (ds *DownloadService) downloadBintrayFile(downloadParams *DownloadFileParam
 		if redirectUrl != "" {
 			err = nil
 			concurrentDownloadFlags := httpclient.ConcurrentDownloadFlags{
-				DownloadPath: redirectUrl,
-				FileName:     	   localFileName,
-				LocalFileName:     localFileName,
-				LocalPath:    	   localPath,
-				FileSize:          details.Size,
-				SplitCount:        ds.SplitCount}
+				DownloadPath:  redirectUrl,
+				FileName:      localFileName,
+				LocalFileName: localFileName,
+				LocalPath:     localPath,
+				FileSize:      details.Size,
+				SplitCount:    ds.SplitCount}
 
 			err = client.DownloadFileConcurrently(concurrentDownloadFlags, "", httpClientsDetails)
 			if err != nil {
@@ -250,7 +250,7 @@ func (ds *DownloadService) downloadBintrayFile(downloadParams *DownloadFileParam
 }
 
 func shouldDownloadFile(localFilePath string, remoteFileDetails *fileutils.FileDetails) (bool, error) {
-	exists, err := fileutils.IsFileExists(localFilePath)
+	exists, err := fileutils.IsFileExists(false, localFilePath)
 	if err != nil {
 		return false, err
 	}

--- a/bintray/services/upload.go
+++ b/bintray/services/upload.go
@@ -188,7 +188,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 	}
 
 	rootPath := clientutils.GetRootPath(uploadDetails.Pattern, uploadDetails.UseRegExp)
-	if !fileutils.IsPathExists(rootPath) {
+	if !fileutils.IsPathExists(false, rootPath) {
 		err := errorutils.CheckError(errors.New("Path does not exist: " + rootPath))
 		if err != nil {
 			return nil, err
@@ -199,7 +199,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 
 	artifacts := []clientutils.Artifact{}
 	// If the path is a single file then return it
-	dir, err := fileutils.IsDir(rootPath)
+	dir, err := fileutils.IsDir(false, rootPath)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 	}
 
 	for _, filePath := range paths {
-		dir, err := fileutils.IsDir(filePath)
+		dir, err := fileutils.IsDir(false, filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/bintray/services/upload.go
+++ b/bintray/services/upload.go
@@ -188,7 +188,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 	}
 
 	rootPath := clientutils.GetRootPath(uploadDetails.Pattern, uploadDetails.UseRegExp)
-	if !fileutils.IsPathExists(false, rootPath) {
+	if !fileutils.IsPathExists(rootPath, false) {
 		err := errorutils.CheckError(errors.New("Path does not exist: " + rootPath))
 		if err != nil {
 			return nil, err
@@ -199,7 +199,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 
 	artifacts := []clientutils.Artifact{}
 	// If the path is a single file then return it
-	dir, err := fileutils.IsDir(false, rootPath)
+	dir, err := fileutils.IsDirExists(rootPath, false)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (us *UploadService) getFilesToUpload(uploadDetails *UploadParams) ([]client
 	}
 
 	for _, filePath := range paths {
-		dir, err := fileutils.IsDir(false, filePath)
+		dir, err := fileutils.IsDirExists(filePath, false)
 		if err != nil {
 			return nil, err
 		}

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -334,7 +334,7 @@ func (jc *HttpClient) DownloadFileConcurrently(flags ConcurrentDownloadFlags, lo
 		flags.LocalFileName = filepath.Join(flags.LocalPath, flags.LocalFileName)
 	}
 
-	if fileutils.IsPathExists(false, flags.LocalFileName) {
+	if fileutils.IsPathExists(flags.LocalFileName, false) {
 		err := os.Remove(flags.LocalFileName)
 		if errorutils.CheckError(err) != nil {
 			return err

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -334,7 +334,7 @@ func (jc *HttpClient) DownloadFileConcurrently(flags ConcurrentDownloadFlags, lo
 		flags.LocalFileName = filepath.Join(flags.LocalPath, flags.LocalFileName)
 	}
 
-	if fileutils.IsPathExists(flags.LocalFileName) {
+	if fileutils.IsPathExists(false, flags.LocalFileName) {
 		err := os.Remove(flags.LocalFileName)
 		if errorutils.CheckError(err) != nil {
 			return err

--- a/utils/io/fileutils/listfiles.go
+++ b/utils/io/fileutils/listfiles.go
@@ -20,7 +20,7 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc, visited map[string]boo
 	if err != nil {
 		realPath = path
 	}
-	isRealPathDir, err := IsDir(realPath)
+	isRealPathDir, err := IsDir(false, realPath)
 	if err != nil {
 		return err
 	}

--- a/utils/io/fileutils/listfiles.go
+++ b/utils/io/fileutils/listfiles.go
@@ -20,7 +20,7 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc, visited map[string]boo
 	if err != nil {
 		realPath = path
 	}
-	isRealPathDir, err := IsDir(false, realPath)
+	isRealPathDir, err := IsDirExists(realPath, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed jfrog-cli-go #229.

Added the ability to upload broken symlinks with --symlinks=true.

Fixed an issue where when --symlinks=false, the symlink target would be uploaded given the symlink name instead of the target name.
