### PR TITLE
Build info wrong artifact name - bug fix

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -78,7 +78,7 @@ func (ds *DownloadService) DownloadFiles(downloadParams DownloadParams) ([]utils
 	expectedChan := make(chan int, 1)
 	ds.prepareTasks(producerConsumer, fileHandlerFunc, expectedChan, errorsQueue, downloadParams)
 	err := performTasks(producerConsumer, errorsQueue)
-	return utils.StripThreadId(buildDependencies), <-expectedChan, err
+	return utils.FlattenFileInfoArray(buildDependencies), <-expectedChan, err
 }
 
 func (ds *DownloadService) prepareTasks(producer parallel.Runner, fileContextHandler fileHandlerFunc, expectedChan chan int, errorsQueue *utils.ErrorsQueue, downloadParams DownloadParams) {

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -85,7 +85,7 @@ func (us *UploadService) performUploadTasks(consumer parallel.Runner, uploadSumm
 	if totalFailed > 0 {
 		log.Error("Failed uploading", strconv.Itoa(totalFailed), "artifacts.")
 	}
-	artifactsFileInfo = utils.StripThreadId(uploadSummery.FileInfo)
+	artifactsFileInfo = utils.FlattenFileInfoArray(uploadSummery.FileInfo)
 	return
 }
 

--- a/artifactory/services/utils/fileinfoutils.go
+++ b/artifactory/services/utils/fileinfoutils.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 )
 
 type FileHashes struct {
@@ -21,7 +21,8 @@ func (fileInfo *FileInfo) ToBuildArtifacts() buildinfo.Artifact {
 	artifact := buildinfo.Artifact{Checksum: &buildinfo.Checksum{}}
 	artifact.Sha1 = fileInfo.Sha1
 	artifact.Md5 = fileInfo.Md5
-	filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.LocalPath)
+	// Artifact name in build info as the name in artifactory
+	filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.ArtifactoryPath)
 	artifact.Name = filename
 	return artifact
 }

--- a/artifactory/services/utils/fileinfoutils.go
+++ b/artifactory/services/utils/fileinfoutils.go
@@ -26,3 +26,11 @@ func (fileInfo *FileInfo) ToBuildArtifacts() buildinfo.Artifact {
 	artifact.Name = filename
 	return artifact
 }
+
+func FlattenFileInfoArray(dependenciesBuildInfo [][]FileInfo) []FileInfo {
+	var buildInfo []FileInfo
+	for _, v := range dependenciesBuildInfo {
+		buildInfo = append(buildInfo, v...)
+	}
+	return buildInfo
+}

--- a/artifactory/services/utils/utils.go
+++ b/artifactory/services/utils/utils.go
@@ -1,9 +1,0 @@
-package utils
-
-func StripThreadId(dependenciesBuildInfo [][]FileInfo) []FileInfo {
-	var buildInfo []FileInfo
-	for _, v := range dependenciesBuildInfo {
-		buildInfo = append(buildInfo, v...)
-	}
-	return buildInfo
-}


### PR DESCRIPTION
Fixed the following issues:

- Artifact's local path was constructed incorrectly.
- The artifact's file name for build info was taken from local path instead of artifactory path.