### PR TITLE
SSH Authentication behaviour update

### DIFF
--- a/artifactory/auth/rtdetails.go
+++ b/artifactory/auth/rtdetails.go
@@ -28,7 +28,7 @@ type ArtifactoryDetails interface {
 	SetApiKey(apiKey string)
 	SetSshAuthHeaders(sshAuthHeaders map[string]string)
 
-	AuthenticateSsh(sshKey, sshPassphrase []byte) error
+	AuthenticateSsh(sshKey, sshPassphrase string) error
 
 	CreateHttpClientDetails() httputils.HttpClientDetails
 }
@@ -82,8 +82,8 @@ func (rt *artifactoryDetails) SetSshAuthHeaders(sshAuthHeaders map[string]string
 	rt.SshAuthHeaders = sshAuthHeaders
 }
 
-func (rt *artifactoryDetails) AuthenticateSsh(sshKey, sshPassphrase []byte) error {
-	sshHeaders, baseUrl, err := sshAuthentication(rt.Url, sshKey, sshPassphrase)
+func (rt *artifactoryDetails) AuthenticateSsh(sshKeyPath, sshPassphrase string) error {
+	sshHeaders, baseUrl, err := sshAuthentication(rt.Url, sshKeyPath, sshPassphrase)
 	if err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"os"
 	"regexp"
 	"runtime"
@@ -207,6 +208,24 @@ func GetUserHomeDir() string {
 		return strings.Replace(home, "\\", "\\\\", -1)
 	}
 	return os.Getenv("HOME")
+}
+
+func GetBoolEnvValue(flagName string, defValue bool) (bool, error) {
+	envVarValue := os.Getenv(flagName)
+	if envVarValue == "" {
+		return defValue, nil
+	}
+	val, err := strconv.ParseBool(envVarValue)
+	err = CheckErrorWithMessage(err, "can't parse environment variable "+flagName)
+	return val, err
+}
+
+func CheckErrorWithMessage(err error, message string) error {
+	if err != nil {
+		log.Error(message)
+		err = errorutils.CheckError(err)
+	}
+	return err
 }
 
 func GetMapFromStringSlice(slice []string, sep string) map[string]string {


### PR DESCRIPTION
Following Issue 83 on the CLI, the behaviour of ssh authentication was changed to:
1. Try authenticating via ssh-agent.
If failed due to any reason (No agent / connection failed / no key in agent):
2. Try authenticating via ssh-key.
If the key is encrypted, passphrase has to be passed via the --ssh-passphrase flag.