### PR TITLE
Change the way Logger is created

### DIFF
--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -19,13 +19,13 @@ const (
 
 func init() {
 	if Logger == nil {
-		Logger = NewLogger("")
+		Logger = NewLogger(INFO)
 	}
 }
 
-func NewLogger(logLevel string) Log {
+func NewLogger(logLevel LevelType) Log {
 	logger := new(jfrogLogger)
-	logger.SetLogLevel(GetCliLogLevel(logLevel))
+	logger.SetLogLevel(logLevel)
 	logger.SetOutputWriter(os.Stdout)
 	logger.SetStderrWriter(os.Stderr)
 	return logger
@@ -126,17 +126,4 @@ type Log interface {
 	Warn(a ...interface{})
 	Error(a ...interface{})
 	Output(a ...interface{})
-}
-
-func GetCliLogLevel(logLevel string) LevelType {
-	switch logLevel {
-	case "ERROR":
-		return ERROR
-	case "WARN":
-		return WARN
-	case "DEBUG":
-		return DEBUG
-	default:
-		return INFO
-	}
 }

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -19,18 +19,13 @@ const (
 
 func init() {
 	if Logger == nil {
-		Logger = NewLogger()
+		Logger = NewLogger("")
 	}
 }
 
-func NewLogger() Log {
+func NewLogger(logLevel string) Log {
 	logger := new(jfrogLogger)
-	logLevel := os.Getenv("JFROG_CLI_LOG_LEVEL")
-	if logLevel != "" {
-		logger.SetLogLevel(GetCliLogLevel(logLevel))
-	} else {
-		logger.SetLogLevel(INFO)
-	}
+	logger.SetLogLevel(GetCliLogLevel(logLevel))
 	logger.SetOutputWriter(os.Stdout)
 	logger.SetStderrWriter(os.Stderr)
 	return logger


### PR DESCRIPTION
Logger will no longer take the log-level from JFROG_CLI_LOG_LEVEL.
Instead, it will receive its log-level value from the log creator.