### PR TITLE
Add possibility to set http client timeout.

### DIFF
--- a/artifactory/config.go
+++ b/artifactory/config.go
@@ -1,6 +1,8 @@
 package artifactory
 
 import (
+	"time"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -13,6 +15,7 @@ type artifactoryServicesConfig struct {
 	minSplitSize      int64
 	splitCount        int
 	minChecksumDeploy int64
+	timeout           time.Duration
 	logger            log.Log
 }
 
@@ -53,6 +56,10 @@ func (config *artifactoryServicesConfig) GetMinChecksumDeploy() int64 {
 
 func (config *artifactoryServicesConfig) GetArtDetails() auth.ArtifactoryDetails {
 	return config.ArtifactoryDetails
+}
+
+func (config *artifactoryServicesConfig) GetTimeout() time.Duration {
+	return config.timeout
 }
 
 func (config *artifactoryServicesConfig) GetLogger() log.Log {

--- a/artifactory/configbuilder.go
+++ b/artifactory/configbuilder.go
@@ -1,6 +1,8 @@
 package artifactory
 
 import (
+	"time"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -22,6 +24,7 @@ type artifactoryServicesConfigBuilder struct {
 	splitCount        int
 	minChecksumDeploy int64
 	isDryRun          bool
+	timeout           time.Duration
 	logger            log.Log
 }
 
@@ -60,6 +63,11 @@ func (builder *artifactoryServicesConfigBuilder) SetDryRun(dryRun bool) *artifac
 	return builder
 }
 
+func (builder *artifactoryServicesConfigBuilder) SetTimeout(timeout time.Duration) *artifactoryServicesConfigBuilder {
+	builder.timeout = timeout
+	return builder
+}
+
 func (builder *artifactoryServicesConfigBuilder) Build() (Config, error) {
 	c := &artifactoryServicesConfig{}
 	c.ArtifactoryDetails = builder.ArtifactoryDetails
@@ -70,6 +78,7 @@ func (builder *artifactoryServicesConfigBuilder) Build() (Config, error) {
 	c.logger = builder.logger
 	c.certifactesPath = builder.certifactesPath
 	c.dryRun = builder.isDryRun
+	c.timeout = builder.timeout
 	return c, nil
 }
 

--- a/artifactory/httpclient.go
+++ b/artifactory/httpclient.go
@@ -1,19 +1,27 @@
 package artifactory
 
 import (
+	"net/http"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/auth/cert"
 	"github.com/jfrog/jfrog-client-go/httpclient"
-	"net/http"
 )
 
 func CreateArtifactoryHttpClient(config Config) (*httpclient.HttpClient, error) {
 	if config.GetCertifactesPath() == "" {
-		return httpclient.NewDefaultHttpClient(), nil
+		return &httpclient.HttpClient{
+			Client: &http.Client{
+				Timeout: config.GetTimeout(),
+			},
+		}, nil
 	}
 
 	transport, err := cert.GetTransportWithLoadedCert(config.GetCertifactesPath())
 	if err != nil {
 		return nil, err
 	}
-	return httpclient.NewHttpClient(&http.Client{Transport: transport}), nil
+	return httpclient.NewHttpClient(&http.Client{
+		Transport: transport,
+		Timeout:   config.GetTimeout(),
+	}), nil
 }

--- a/artifactory/interfaces.go
+++ b/artifactory/interfaces.go
@@ -1,6 +1,8 @@
 package artifactory
 
 import (
+	"time"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -15,6 +17,7 @@ type Config interface {
 	GetSplitCount() int
 	GetMinChecksumDeploy() int64
 	IsDryRun() bool
+	GetTimeout() time.Duration
 	GetArtDetails() auth.ArtifactoryDetails
 	GetLogger() log.Log
 }


### PR DESCRIPTION
It is a bad practice to use the default http client, because it has no timeout [configured](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779).

This pull request fixes this issue.