### PR TITLE
initialize upload params with non-nil embedded struct pointer

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -530,5 +530,8 @@ func (us *UploadService) createFolderInArtifactory(artifact UploadData) error {
 }
 
 func NewUploadParams() UploadParams {
-	return UploadParams{}
+	params := UploadParams{}
+	var commonParams utils.ArtifactoryCommonParams
+	params.ArtifactoryCommonParams = &commonParams
+	return params
 }


### PR DESCRIPTION
Following the docs, 
```
    params := services.NewUploadParams()
    params.Pattern = "repo/*/*.zip"
``` 
gives `panic: runtime error: invalid memory address or nil pointer dereference`
It seems that the embedded struct pointer needs to be initialized before its properties can be assigned values.

Notes: 
* This is my first PR to this repo. 
* I don't know `go` very well yet.
* I didn't see any tests around this area to update
* I'm not sure whether other areas may have a similar issue