### PR TITLE
feat: add versiondetails

### DIFF
--- a/bintray/manager.go
+++ b/bintray/manager.go
@@ -87,6 +87,10 @@ func (sm *ServicesManager) ShowVersion(path *versions.Path) error {
 	return sm.newVersionService().Show(path)
 }
 
+func (sm *ServicesManager) GetVersionDetails(path *versions.Path) (versions.PackageVersion, error) {
+	return sm.newVersionService().GetDetails(path)
+}
+
 func (sm *ServicesManager) IsVersionExists(path *versions.Path) (bool, error) {
 	return sm.newVersionService().IsVersionExists(path)
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: 

N/A

**What is the current behavior?** 

Currently there is no way to get the version information about a package without printing it to the console. For multiple use cases this would be a desired feature

**What is the new behavior?** 

* Added a `PackageVersion` struct that represents the return data from Bintray (so the results can be unmarshalled properly)
* Added method `GetDetails` which gets the details for a specific package (similar to `Show`) and returns a `PackageVersion`
* Changed `Show` to make use of `GetDetails` to reduce duplication of code and still keep method signatures correct

This PR is a prerequisite for https://github.com/jfrog/jfrog-cli-go/pull/305