### PR TITLE
Support the USERPROFILE env var as the default home dir.

### DIFF
--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -281,6 +281,10 @@ func GetHomeDir() string {
 	if home != "" {
 		return home
 	}
+	home = os.Getenv("USERPROFILE")
+	if home != "" {
+		return home
+	}
 	user, err := user.Current()
 	if err == nil {
 		return user.HomeDir

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -68,7 +68,8 @@ func GetFileInfo(path string, preserveSymLink bool) (fileInfo os.FileInfo, err e
 	} else {
 		fileInfo, err = os.Stat(path)
 	}
-	return fileInfo, errorutils.CheckError(err)
+	// We should not do CheckError here, because the error is checked by the calling functions.
+	return fileInfo, err
 }
 
 func IsPathSymlink(path string) bool {
@@ -153,7 +154,7 @@ func ListFilesWithExtension(path, ext string) ([]string, error) {
 		if IsPathSymlink(filePath) {
 			// Gets the file info of the symlink.
 			file, err := GetFileInfo(filePath, false)
-			if err != nil {
+			if errorutils.CheckError(err) != nil {
 				return nil, err
 			}
 			// Checks if the symlink is a file.


### PR DESCRIPTION
Following the input https://github.com/jfrog/jfrog-cli-go/issues/382, this PR enhances the *GetHomeDir* function, so that it also uses the **USERPROFILE** environment variables (set on Windows machines) to find the user home directory.