### PR TITLE
Adding Diagnostics features support for cli

### DIFF
--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -1,14 +1,15 @@
 package artifactory
 
 import (
+	"io"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	rthttpclient "github.com/jfrog/jfrog-client-go/artifactory/httpclient"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/go"
+	_go "github.com/jfrog/jfrog-client-go/artifactory/services/go"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	ioutils "github.com/jfrog/jfrog-client-go/utils/io"
-	"io"
 )
 
 type ArtifactoryServicesManager struct {
@@ -158,6 +159,14 @@ func (sm *ArtifactoryServicesManager) PublishGoProject(params _go.GoParams) erro
 	goService := _go.NewGoService(sm.client)
 	goService.ArtDetails = sm.config.GetArtDetails()
 	return goService.PublishPackage(params)
+}
+
+func (sm *ArtifactoryServicesManager) Diagnostics() (*services.DiagnosisResult, error) {
+	ds := services.NewDiagnosticsService(sm.client)
+	ds.Threads = sm.config.GetThreads()
+	ds.ArtDetails = sm.config.GetArtDetails()
+	ds.Progress = sm.progress
+	return ds.StartDiagnosis()
 }
 
 func (sm *ArtifactoryServicesManager) Ping() ([]byte, error) {

--- a/artifactory/services/diagnostics.go
+++ b/artifactory/services/diagnostics.go
@@ -1,0 +1,152 @@
+package services
+
+import (
+	//"github.com/jfrog/gofrog/parallel"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/auth"
+	rthttpclient "github.com/jfrog/jfrog-client-go/artifactory/httpclient"
+
+	//"github.com/jfrog/jfrog-client-go/artifactory/services/fspatterns"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	//clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	ioutils "github.com/jfrog/jfrog-client-go/utils/io"
+
+	//"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	//"github.com/jfrog/jfrog-client-go/utils/io/fileutils/checksum"
+	//"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	//"os"
+	//"regexp"
+	//"sort"
+	//"strconv"
+	//"strings"
+)
+
+type DiagnosticsService struct {
+	client     *rthttpclient.ArtifactoryHttpClient
+	Progress   ioutils.Progress
+	ArtDetails auth.ArtifactoryDetails
+	DryRun     bool
+	Threads    int
+}
+
+func NewDiagnosticsService(client *rthttpclient.ArtifactoryHttpClient) *DiagnosticsService {
+	return &DiagnosticsService{client: client}
+}
+
+func (ds *DiagnosticsService) GetThreads() int {
+	return ds.Threads
+}
+
+func (ds *DiagnosticsService) SetThreads(threads int) {
+	ds.Threads = threads
+}
+
+func (ds *DiagnosticsService) GetJfrogHttpClient() *rthttpclient.ArtifactoryHttpClient {
+	return ds.client
+}
+
+func (ds *DiagnosticsService) SetArtDetails(artDetails auth.ArtifactoryDetails) {
+	ds.ArtDetails = artDetails
+}
+
+func (ds *DiagnosticsService) SetDryRun(isDryRun bool) {
+	ds.DryRun = isDryRun
+}
+
+func (ds *DiagnosticsService) GetSystemInfo() ([]byte, error) {
+	url, err := utils.BuildArtifactoryUrl(ds.ArtDetails.GetUrl(), "api/system", nil)
+	if err != nil {
+		return nil, err
+	}
+	httpClientDetails := ds.ArtDetails.CreateHttpClientDetails()
+	resp, respBody, _, err := ds.client.SendGet(url, true, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return respBody, errorutils.CheckError(errors.New("Artifactory response: " + resp.Status))
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+	return respBody, nil
+}
+
+func (ds *DiagnosticsService) GetSysConf() ([]byte, error) {
+	url, err := utils.BuildArtifactoryUrl(ds.ArtDetails.GetUrl(), "api/system/configuration", nil)
+	if err != nil {
+		return nil, err
+	}
+	httpClientDetails := ds.ArtDetails.CreateHttpClientDetails()
+	resp, respBody, _, err := ds.client.SendGet(url, true, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return respBody, errorutils.CheckError(errors.New("Artifactory response: " + resp.Status))
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+	return respBody, nil
+}
+
+func (ds *DiagnosticsService) GetWebServerInfo() ([]byte, error) {
+	url, err := utils.BuildArtifactoryUrl(ds.ArtDetails.GetUrl(), "api/system/configuration/webServer", nil)
+	if err != nil {
+		return nil, err
+	}
+	httpClientDetails := ds.ArtDetails.CreateHttpClientDetails()
+	resp, respBody, _, err := ds.client.SendGet(url, true, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return respBody, errorutils.CheckError(errors.New("Artifactory response: " + resp.Status))
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+	return respBody, nil
+}
+
+func (ds *DiagnosticsService) StartDiagnosis() (*DiagnosisResult, error) {
+	version, _ := ds.ArtDetails.GetVersion()
+	result := &DiagnosisResult{
+		Version: version,
+		Url:     ds.ArtDetails.GetUrl(),
+		Tasks:   make(map[string]*DiagnosisTask),
+	}
+	var tasks = make(map[string](func() ([]byte, error)))
+	tasks["SystemInfo"] = ds.GetSystemInfo
+	tasks["GetSysConf"] = ds.GetSysConf
+	tasks["GetWebServerInfo"] = ds.GetWebServerInfo
+	for taskName, task := range tasks {
+		starttime := time.Now()
+		taskResult := &DiagnosisTask{
+			Name: taskName,
+		}
+		out, err := task()
+		if err != nil {
+			taskResult.Err = err
+		} else {
+			taskResult.Output = out
+		}
+		taskResult.ElapsedTime = time.Since(starttime)
+		result.Tasks[taskName] = taskResult
+	}
+	return result, nil
+}
+
+type DiagnosisTask struct {
+	Name        string
+	Output      []byte
+	ElapsedTime time.Duration
+	Err         error
+}
+
+type DiagnosisResult struct {
+	Url     string
+	Version string
+	Tasks   map[string]*DiagnosisTask
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/nwaples/rardecode v0.0.0-20171029023500-e06696f847ae // indirect
 	github.com/pelletier/go-buffruneio v0.2.0 // indirect
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/spf13/viper v1.2.1


### PR DESCRIPTION
A new features in CLI to get a diagnosis of Artifactory after each upgrade. This command should run before and after upgrade, so that it will print the performance and stability of artifactory instance. The default command is like
jfrog  rt diagnosis 