### PR TITLE
"jfrog rt dl generic-local/te.tar.gz ./ --explode" fails.

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -371,7 +371,17 @@ func extractFile(downloadFileDetails *DownloadFileDetails, arch archiver.Archive
 	if err != nil {
 		return err
 	}
-	err = arch.Read(reader, downloadFileDetails.LocalPath)
+
+	// The local path to which the file is going to be extracted,
+	// needs to be absolute.
+	absolutePath, err := filepath.Abs(downloadFileDetails.LocalPath)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	// Add a trailing slash ot the local path, since it has to be a directory.
+	absolutePath = absolutePath + string(os.PathSeparator)
+
+	err = arch.Read(reader, absolutePath)
 	return errorutils.CheckError(err)
 }
 

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -378,7 +378,7 @@ func extractFile(downloadFileDetails *DownloadFileDetails, arch archiver.Archive
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	// Add a trailing slash ot the local path, since it has to be a directory.
+	// Add a trailing slash to the local path, since it has to be a directory.
 	absolutePath = absolutePath + string(os.PathSeparator)
 
 	err = arch.Read(reader, absolutePath)


### PR DESCRIPTION
This PR fixes the following issue in JFrog CLI (which uses the jfrog-client-go library).
```
$ jfrog rt dl generic-local/te.tar.gz ./ --explode
[Info] Searching items to download...
[Info] [Thread 2] Downloading generic-local/te.tar.gz
[Info] [Thread 2] Extracting archive: te.tar.gz to .
[Warn] [Thread 2] Attempt 0 - Failure occurred while downloading http://localhost:8081/artifactory/generic-local/te.tar.gz - test/: illegal file path
[Info] [Thread 2] Extracting archive: te.tar.gz to .
[Warn] [Thread 2] Attempt 1 - Failure occurred while downloading http://localhost:8081/artifactory/generic-local/te.tar.gz - test/: illegal file path
[Info] [Thread 2] Extracting archive: te.tar.gz to .
[Warn] [Thread 2] Attempt 2 - Failure occurred while downloading http://localhost:8081/artifactory/generic-local/te.tar.gz - test/: illegal file path
[Info] [Thread 2] Extracting archive: te.tar.gz to .
[Warn] [Thread 2] Attempt 3 - Failure occurred while downloading http://localhost:8081/artifactory/generic-local/te.tar.gz - test/: illegal file path
[Error] [Thread 2]  Received an error: test/: illegal file path
[Error] test/: illegal file path
{
  "status": "failure",
  "totals": {
    "success": 0,
    "failure": 1
  }
}

```