### PR TITLE
Optimize search by build without pattern

### DIFF
--- a/artifactory/services/delete.go
+++ b/artifactory/services/delete.go
@@ -62,6 +62,13 @@ func (ds *DeleteService) GetPathsToDelete(deleteParams DeleteParams) (resultItem
 		}
 		paths := utils.ReduceDirResult(tempResultItems, utils.FilterTopChainResults)
 		resultItems = append(resultItems, paths...)
+	case utils.BUILD:
+		if resultItemsTemp, e := utils.SearchBySpecWithBuild(deleteParams.GetFile(), ds); e == nil {
+			resultItems = append(resultItems, resultItemsTemp...)
+		} else {
+			err = e
+			return
+		}
 	}
 	utils.LogSearchResults(len(resultItems))
 	return

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -96,6 +96,8 @@ func (ds *DownloadService) prepareTasks(producer parallel.Runner, buildDependenc
 			switch downloadParams.GetSpecType() {
 			case utils.WILDCARD:
 				resultItems, err = ds.collectFilesUsingWildcardPattern(downloadParams)
+			case utils.BUILD:
+				resultItems, err = utils.SearchBySpecWithBuild(downloadParams.GetFile(), ds)
 			case utils.AQL:
 				resultItems, err = utils.SearchBySpecWithAql(downloadParams.GetFile(), ds, utils.SYMLINK)
 			}

--- a/artifactory/services/movecopy.go
+++ b/artifactory/services/movecopy.go
@@ -52,6 +52,8 @@ func (mc *MoveCopyService) MoveCopyServiceMoveFilesWrapper(moveSpec MoveCopyPara
 	log.Info("Searching items...")
 
 	switch moveSpec.GetSpecType() {
+	case utils.BUILD:
+		resultItems, err = utils.SearchBySpecWithBuild(moveSpec.GetFile(), mc)
 	case utils.AQL:
 		resultItems, err = utils.SearchBySpecWithAql(moveSpec.GetFile(), mc, utils.NONE)
 	case utils.WILDCARD:

--- a/artifactory/services/search.go
+++ b/artifactory/services/search.go
@@ -55,6 +55,8 @@ func SearchBySpecFiles(searchParams SearchParams, flags utils.CommonConf, requir
 	switch searchParams.GetSpecType() {
 	case utils.WILDCARD:
 		itemsFound, err = utils.SearchBySpecWithPattern(searchParams.GetFile(), flags, requiredArtifactProps)
+	case utils.BUILD:
+		itemsFound, err = utils.SearchBySpecWithBuild(searchParams.GetFile(), flags)
 	case utils.AQL:
 		itemsFound, err = utils.SearchBySpecWithAql(searchParams.GetFile(), flags, requiredArtifactProps)
 	}

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -7,6 +7,7 @@ import (
 const (
 	WILDCARD SpecType = "wildcard"
 	AQL      SpecType = "aql"
+	BUILD    SpecType = "build"
 )
 
 type SpecType string
@@ -150,6 +151,8 @@ func (aql *Aql) UnmarshalJSON(value []byte) error {
 
 func (params ArtifactoryCommonParams) GetSpecType() (specType SpecType) {
 	switch {
+	case params.Build != "" && params.Aql.ItemsFind == "" && (params.Pattern == "*" || params.Pattern == ""):
+		specType = BUILD
 	case params.Aql.ItemsFind != "":
 		specType = AQL
 	default:


### PR DESCRIPTION
Skip AQL search of all artifacts (Pattern == '*' or Pattern == '') when build name and number exist.