### PR TITLE
Fix relative path in download explode

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -391,7 +391,11 @@ func extractZip(downloadFileDetails *DownloadFileDetails, logMsgPrefix string) e
 		return err
 	}
 	log.Info(logMsgPrefix+"Extracting archive:", fileName, "to", downloadFileDetails.LocalPath)
-	err = archiver.Zip.Open(fileName, downloadFileDetails.LocalPath)
+	absLocalPath, err := filepath.Abs(downloadFileDetails.LocalPath)
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	err = archiver.Zip.Open(fileName, absLocalPath)
 	if errorutils.CheckError(err) != nil {
 		return err
 	}


### PR DESCRIPTION
When providing a relative path as target to download explode, the following error was thrown:
```
jfrog rt dl generic-local/a.zip ./ --explode


[Info] [Thread 2] Extracting archive: a.zip to .
[Warn] [Thread 2] Attempt 3 - Failure occurred while downloading http://127.0.0.1:8081/artifactory/generic-local/a.zip - tmp/ziptry/: illegal file path
[Error] [Thread 2]  Received an error: tmp/ziptry/: illegal file path
[Error] tmp/ziptry/: illegal file path
{
  "status": "failure",
  "totals": {
    "success": 0,
    "failure": 1
  }
}
```
