### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The default temp dir used is  'os.TempDir()'. Use the following API to set a new
 #### Creating Artifactory Details
 ```
     rtDetails := auth.NewArtifactoryDetails()
-    rtDetails.SetUrl("http://localhost:8081/artifactory")
+    rtDetails.SetUrl("http://localhost:8081/artifactory/")
     rtDetails.SetSshKeysPath("path/to/.ssh/")
     rtDetails.SetApiKey("apikey")
     rtDetails.SetUser("user")


### PR DESCRIPTION
aqlUrl := flags.GetArtifactoryDetails().GetUrl() + "api/search/aql" (in func ExexAql)
error: rtDetails.SetUrl("http://localhost:8081/artifactory")  lack ”/“ (in README.md:33)