### PR TITLE
add support for repo creation/deletion and metadata calculation in bintray

### DIFF
--- a/bintray/manager.go
+++ b/bintray/manager.go
@@ -85,6 +85,10 @@ func (sm *ServicesManager) IsVersionExists(path *versions.Path) (bool, error) {
 	return sm.newVersionService().IsVersionExists(path)
 }
 
+func (sm *ServicesManager) CalcMetadata(path *versions.Path) (bool, error) {
+	return sm.newVersionService().CalcMetadata(path)
+}
+
 func (sm *ServicesManager) newPackageService() *packages.PackageService {
 	packageService := packages.NewService(sm.client)
 	packageService.BintrayDetails = sm.config.GetBintrayDetails()

--- a/bintray/manager.go
+++ b/bintray/manager.go
@@ -121,13 +121,13 @@ func (sm *ServicesManager) IsRepoExists(path *repositories.Path) (bool, error) {
 	return repositoryService.IsRepoExists(path)
 }
 
-func (sm *ServicesManager) CreateReposIfNeeded(path *repositories.Path, params *repositories.Params, repoConfig string) (bool, error) {
+func (sm *ServicesManager) CreateReposIfNeeded(path *repositories.Path, params *repositories.Config, repoConfig string) (bool, error) {
 	repositoryService := repositories.NewService(sm.client)
 	repositoryService.BintrayDetails = sm.config.GetBintrayDetails()
 	return repositoryService.CreateReposIfNeeded(path, params, repoConfig)
 }
 
-func (sm *ServicesManager) ExecCreateRepoRest(path *repositories.Path, params *repositories.Params, repoConfig string) (bool, error) {
+func (sm *ServicesManager) ExecCreateRepoRest(path *repositories.Path, params *repositories.Config, repoConfig string) (bool, error) {
 	repositoryService := repositories.NewService(sm.client)
 	repositoryService.BintrayDetails = sm.config.GetBintrayDetails()
 	return repositoryService.ExecCreateRepoRest(path, params, repoConfig)

--- a/bintray/manager.go
+++ b/bintray/manager.go
@@ -117,6 +117,24 @@ func (sm *ServicesManager) IsRepoExists(path *repositories.Path) (bool, error) {
 	return repositoryService.IsRepoExists(path)
 }
 
+func (sm *ServicesManager) CreateReposIfNeeded(path *repositories.Path, params *repositories.Params, repoConfig string) (bool, error) {
+	repositoryService := repositories.NewService(sm.client)
+	repositoryService.BintrayDetails = sm.config.GetBintrayDetails()
+	return repositoryService.CreateReposIfNeeded(path, params, repoConfig)
+}
+
+func (sm *ServicesManager) ExecCreateRepoRest(path *repositories.Path, params *repositories.Params, repoConfig string) (bool, error) {
+	repositoryService := repositories.NewService(sm.client)
+	repositoryService.BintrayDetails = sm.config.GetBintrayDetails()
+	return repositoryService.ExecCreateRepoRest(path, params, repoConfig)
+}
+
+func (sm *ServicesManager) ExecDeleteRepoRest(path *repositories.Path) error {
+	repositoryService := repositories.NewService(sm.client)
+	repositoryService.BintrayDetails = sm.config.GetBintrayDetails()
+	return repositoryService.ExecDeleteRepoRest(path)
+}
+
 func (sm *ServicesManager) newAccessKeysService() *accesskeys.AccessKeysService {
 	accessKeysService := accesskeys.NewService(sm.client)
 	accessKeysService.BintrayDetails = sm.config.GetBintrayDetails()

--- a/bintray/services/packages/packages.go
+++ b/bintray/services/packages/packages.go
@@ -28,24 +28,24 @@ type PackageService struct {
 }
 
 type Path struct {
-	Subject string
-	Repo    string
-	Package string
+	Subject string `yaml:"subject"`
+	Repo    string `yaml:"repo"`
+	Package string `yaml:"package"`
 }
 
 type Params struct {
 	*Path
-	Desc                   string
-	Labels                 string
-	Licenses               string
-	CustomLicenses         string
-	VcsUrl                 string
-	WebsiteUrl             string
-	IssueTrackerUrl        string
-	GithubRepo             string
-	GithubReleaseNotesFile string
-	PublicDownloadNumbers  bool
-	PublicStats            bool
+	Desc                   string `yaml:"desc,omitempty"`
+	Labels                 string `yaml:"labels,omitempty"`
+	Licenses               string `yaml:"licenses"`
+	CustomLicenses         string `yaml:"customlicenses,omitempty"`
+	VcsUrl                 string `yaml:"vcsurl"`
+	WebsiteUrl             string `yaml:"websiteurl,omitempty"`
+	IssueTrackerUrl        string `yaml:"issuetrackerurl,omitempty"`
+	GithubRepo             string `yaml:"githubrepo,omitempty"`
+	PublicDownloadNumbers  bool   `yaml:"publicdownloadnumbers,omitempty"`
+	PublicStats            bool   `yaml:"publicstats,omitempty"`
+	GithubReleaseNotesFile string `yaml:"githubreleasenotesfile,omitempty"`
 }
 
 func (ps *PackageService) Create(params *Params) error {

--- a/bintray/services/repositories/repositories.go
+++ b/bintray/services/repositories/repositories.go
@@ -31,16 +31,18 @@ type Path struct {
 	Repo    string
 }
 
-// Params is the equivalent of repo config json
-type Params struct {
-	*Path
-	Type            string
-	IsPrivate       bool
-	Desc            string
-	Labels          string
-	GpgSignFiles    bool
-	GpgSignMetadata bool
-	GpgUseOwnerKey  bool
+// Config is the equivalent of repo config json
+type Config struct {
+	Type               string   `yaml:"type,omitempty"`
+	IsPrivate          bool     `yaml:"isprivate,omitempty"`
+	Desc               string   `yaml:"desc,omitempty"`
+	Labels             []string `yaml:"labels,omitempty"`
+	GpgSignFiles       bool     `yaml:"gpgsignfiles,omitempty"`
+	GpgSignMetadata    bool     `yaml:"gpgsignmetadata,omitempty"`
+	GpgUseOwnerKey     bool     `yaml:"gpguseownerkey,omitempty"`
+	RepoConfigFilePath string   `yaml:"repoconfigfilepath,omitempty"`
+	YumMetadataDepth   int      `yaml:"yum_metadata_depth,omitempty"`
+	YumGroupsFile      string   `yaml:"yum_groups_file,omitempty"`
 }
 
 // IsRepoExists -> to Check if Repo exists under owner
@@ -67,15 +69,10 @@ func (rs *RepositoryService) IsRepoExists(repositoryPath *Path) (bool, error) {
 }
 
 // CreateReposIfNeeded -> makes a call to IsRepoExists(), then creates one if needed
-func (rs *RepositoryService) CreateReposIfNeeded(repositoryPath *Path, repositoryParams *Params, configPath string) (bool, error) {
+func (rs *RepositoryService) CreateReposIfNeeded(repositoryPath *Path, repositoryParams *Config, configPath string) (bool, error) {
 	var err error
 	var existsOk bool
 
-	// var repoConfig string
-	// repo := RtTargetRepo
-	// if strings.HasSuffix(repo, "/") {
-	// 	repo = repo[0:strings.LastIndex(repo, "/")]
-	// }
 	existsOk, _ = rs.IsRepoExists(repositoryPath)
 	if !existsOk {
 		existsOk, err = rs.ExecCreateRepoRest(repositoryPath, repositoryParams, configPath)
@@ -87,7 +84,7 @@ func (rs *RepositoryService) CreateReposIfNeeded(repositoryPath *Path, repositor
 }
 
 // ExecCreateRepoRest -> creates the repo under owner (subject)
-func (rs *RepositoryService) ExecCreateRepoRest(repositoryPath *Path, repositoryParams *Params, repoConfig string) (bool, error) {
+func (rs *RepositoryService) ExecCreateRepoRest(repositoryPath *Path, repositoryParams *Config, repoConfig string) (bool, error) {
 	repoName := path.Join("repos", repositoryPath.Subject, repositoryPath.Repo)
 	content, err := ioutil.ReadFile(getRepoConfigPath(repoConfig))
 	if err != nil {

--- a/bintray/services/repositories/repositories.go
+++ b/bintray/services/repositories/repositories.go
@@ -2,28 +2,48 @@ package repositories
 
 import (
 	"errors"
-	"github.com/jfrog/jfrog-client-go/bintray/auth"
-	"github.com/jfrog/jfrog-client-go/httpclient"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"io/ioutil"
 	"net/http"
 	"path"
+
+	"github.com/jfrog/jfrog-client-go/bintray/auth"
+	"github.com/jfrog/jfrog-client-go/httpclient"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// NewService -> used for repositories package funcs
 func NewService(client *httpclient.HttpClient) *RepositoryService {
 	us := &RepositoryService{client: client}
 	return us
 }
 
+// RepositoryService holds HTTP client and bintray auth details
 type RepositoryService struct {
 	client         *httpclient.HttpClient
 	BintrayDetails auth.BintrayDetails
 }
 
+// Path is the URL path of repo
 type Path struct {
 	Subject string
 	Repo    string
 }
 
+// Params is the equivalent of repo config json
+type Params struct {
+	*Path
+	Type            string
+	IsPrivate       bool
+	Desc            string
+	Labels          string
+	GpgSignFiles    bool
+	GpgSignMetadata bool
+	GpgUseOwnerKey  bool
+}
+
+// IsRepoExists -> to Check if Repo exists under owner
 func (rs *RepositoryService) IsRepoExists(repositoryPath *Path) (bool, error) {
 	url := rs.BintrayDetails.GetApiUrl() + path.Join("repos", repositoryPath.Subject, repositoryPath.Repo)
 	httpClientsDetails := rs.BintrayDetails.CreateHttpClientDetails()
@@ -44,4 +64,73 @@ func (rs *RepositoryService) IsRepoExists(repositoryPath *Path) (bool, error) {
 	}
 
 	return false, errorutils.CheckError(errors.New("Bintray response: " + resp.Status))
+}
+
+// CreateReposIfNeeded -> makes a call to IsRepoExists(), then creates one if needed
+func (rs *RepositoryService) CreateReposIfNeeded(repositoryPath *Path, repositoryParams *Params, configPath string) (bool, error) {
+	var err error
+	var existsOk bool
+
+	// var repoConfig string
+	// repo := RtTargetRepo
+	// if strings.HasSuffix(repo, "/") {
+	// 	repo = repo[0:strings.LastIndex(repo, "/")]
+	// }
+	existsOk, _ = rs.IsRepoExists(repositoryPath)
+	if !existsOk {
+		existsOk, err = rs.ExecCreateRepoRest(repositoryPath, repositoryParams, configPath)
+		if err != nil {
+			log.Error(err)
+		}
+	}
+	return existsOk, err
+}
+
+// ExecCreateRepoRest -> creates the repo under owner (subject)
+func (rs *RepositoryService) ExecCreateRepoRest(repositoryPath *Path, repositoryParams *Params, repoConfig string) (bool, error) {
+	repoName := path.Join("repos", repositoryPath.Subject, repositoryPath.Repo)
+	content, err := ioutil.ReadFile(getRepoConfigPath(repoConfig))
+	if err != nil {
+		return false, err
+	}
+	url := rs.BintrayDetails.GetApiUrl() + repoName
+	httpClientsDetails := rs.BintrayDetails.CreateHttpClientDetails()
+	httpClientsDetails.Headers = map[string]string{"Content-Type": "application/json"}
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return false, err
+	}
+	resp, _, err := client.SendPost(url, content, httpClientsDetails)
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return false, errors.New("Fail to create repository. Reason local repository with key: " + repoName + " already exist\n")
+	}
+	log.Info("Repository", repoName, "created.")
+	return true, nil
+}
+
+// ExecDeleteRepoRest -> Deletes the repo under owner (subject)
+func (rs *RepositoryService) ExecDeleteRepoRest(repositoryPath *Path) error {
+	repoName := path.Join("repos", repositoryPath.Subject, repositoryPath.Repo)
+	url := rs.BintrayDetails.GetApiUrl() + repoName
+
+	log.Info("Deleting Repo...")
+	httpClientsDetails := rs.BintrayDetails.CreateHttpClientDetails()
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return err
+	}
+	resp, body, err := client.SendDelete(url, nil, httpClientsDetails)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errorutils.CheckError(errors.New("Bintray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+	}
+
+	log.Debug("Bintray response:", resp.Status)
+	log.Info("Deleted Repo", repositoryPath.Repo+".")
+	return nil
 }

--- a/bintray/services/repositories/utils.go
+++ b/bintray/services/repositories/utils.go
@@ -1,0 +1,11 @@
+package repositories
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func getRepoConfigPath(configPath string) string {
+	dir, _ := os.Getwd()
+	return filepath.Join(dir, configPath)
+}

--- a/bintray/services/upload.go
+++ b/bintray/services/upload.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"path"
 	"regexp"
@@ -38,22 +39,22 @@ type UploadService struct {
 
 type UploadParams struct {
 	// Files pattern to be uploaded
-	Pattern string
+	Pattern string   `yaml:"file_pattern,omitempty"`
+	Files   []string `yaml:"files,omitempty"`
 
 	// Target version details
-	*versions.Params
+	*versions.Params `yaml:"params"`
 
 	// Target local path
-	TargetPath string
+	TargetPath string `yaml:"target"`
 
-	UseRegExp          bool
-	Flat               bool
-	Recursive          bool
-	Explode            bool
-	Override           bool
-	Publish            bool
-	ShowInDownloadList bool
-	Deb                string
+	UseRegExp bool   `yaml:"regex"`
+	Flat      bool   `yaml:"flat,omitempty"`
+	Recursive bool   `yaml:"recursive,omitempty"`
+	Explode   bool   `yaml:"explode,omitempty"`
+	Override  bool   `yaml:"override,omitempty"`
+	Publish   bool   `yaml:"publish,omitempty"`
+	Deb       string `yaml:"pkgdeb"`
 }
 
 func (us *UploadService) Upload(uploadDetails *UploadParams) (totalUploaded, totalFailed int, err error) {
@@ -197,6 +198,7 @@ func uploadFile(artifact clientutils.Artifact, url, logMsgPrefix string, bintray
 		return false, err
 	}
 	log.Debug(logMsgPrefix+"Bintray response:", resp.Status)
+	fmt.Println(resp.Status, artifact)
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		log.Error(logMsgPrefix + "Bintray response: " + resp.Status + "\n" + clientutils.IndentJson(body))
 	}

--- a/bintray/services/versions/versions.go
+++ b/bintray/services/versions/versions.go
@@ -3,6 +3,10 @@ package versions
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"path"
+
 	"github.com/jfrog/jfrog-client-go/bintray/auth"
 	"github.com/jfrog/jfrog-client-go/httpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
@@ -27,19 +31,19 @@ type VersionService struct {
 }
 
 type Path struct {
-	Subject string
-	Repo    string
-	Package string
-	Version string
+	Subject string `yaml:"subject,omitempty"`
+	Repo    string `yaml:"repo,omitempty"`
+	Package string `yaml:"package,omitempty"`
+	Version string `yaml:"version"`
 }
 
 type Params struct {
-	*Path
-	Desc                     string
-	VcsTag                   string
-	Released                 string
-	GithubReleaseNotesFile   string
-	GithubUseTagReleaseNotes bool
+	*Path                    `yaml:"path"`
+	Desc                     string `yaml:"desc"`
+	VcsTag                   string `yaml:"vcstag"`
+	Released                 string `yaml:"released"`
+	GithubReleaseNotesFile   string `yaml:"githubreleasenotesfile"`
+	GithubUseTagReleaseNotes bool   `yaml:"githubusetagreleasenotes"`
 }
 
 func (vs *VersionService) Create(params *Params) error {
@@ -187,6 +191,7 @@ func (vs *VersionService) IsVersionExists(versionPath *Path) (bool, error) {
 	return false, errorutils.CheckError(errors.New("Bintray response: " + resp.Status))
 }
 
+// CalcMetadata -> to schedule metadata calculation https://bintray.com/docs/api/#calc_metadata
 func (vs *VersionService) CalcMetadata(versionPath *Path) (bool, error) {
 	metaPath := path.Join("calc_metadata", versionPath.Subject, versionPath.Repo, versionPath.Package, versionPath.Version)
 	url := vs.BintrayDetails.GetApiUrl() + metaPath
@@ -196,13 +201,14 @@ func (vs *VersionService) CalcMetadata(versionPath *Path) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	resp, _, err := client.SendPost(url, nil, httpClientsDetails)
+	resp, body, err := client.SendPost(url, nil, httpClientsDetails)
 	if err != nil {
 		return false, err
 	}
 	if resp.StatusCode != http.StatusAccepted {
-		return false, errors.New("Failed to schedule metadata calculation.\n")
+		return false, errors.New("failed to schedule metadata calculation")
 	}
+	fmt.Println(clientutils.IndentJson(body))
 	log.Info("Metadata calculation scheduled")
 	return true, nil
 }
@@ -236,7 +242,7 @@ func createVersionContent(params *Params) ([]byte, error) {
 	}
 	requestContent, err := json.Marshal(Config)
 	if err != nil {
-		return nil, errorutils.CheckError(errors.New("Failed to execute request."))
+		return nil, errorutils.CheckError(errors.New("failed to execute request"))
 	}
 	return requestContent, nil
 }

--- a/bintray/services/versions/versions.go
+++ b/bintray/services/versions/versions.go
@@ -187,6 +187,26 @@ func (vs *VersionService) IsVersionExists(versionPath *Path) (bool, error) {
 	return false, errorutils.CheckError(errors.New("Bintray response: " + resp.Status))
 }
 
+func (vs *VersionService) CalcMetadata(versionPath *Path) (bool, error) {
+	metaPath := path.Join("calc_metadata", versionPath.Subject, versionPath.Repo, versionPath.Package, versionPath.Version)
+	url := vs.BintrayDetails.GetApiUrl() + metaPath
+	httpClientsDetails := vs.BintrayDetails.CreateHttpClientDetails()
+
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return false, err
+	}
+	resp, _, err := client.SendPost(url, nil, httpClientsDetails)
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return false, errors.New("Failed to schedule metadata calculation.\n")
+	}
+	log.Info("Metadata calculation scheduled")
+	return true, nil
+}
+
 func (vs *VersionService) doCreateVersion(params *Params) (*http.Response, []byte, error) {
 	if vs.BintrayDetails.GetUser() == "" {
 		vs.BintrayDetails.SetUser(params.Subject)


### PR DESCRIPTION
Bintray in jfront-client-go didn't have support for 
- repo creation
- repo deletion
- repo exists check
- metadata calculation for versioned package files

This PR adds the same.