### PR TITLE
Added caddyshack needed features to support latest JFrog CLI

### DIFF
--- a/artifactory/auth/rtdetails.go
+++ b/artifactory/auth/rtdetails.go
@@ -222,7 +222,7 @@ func (rt *artifactoryDetails) getArtifactoryVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, body, _, err := client.SendGet(rt.GetUrl()+"api/system/version", true, rt.CreateHttpClientDetails())
+	resp, body, _, err := client.SendGetWithRetryOnTimeout(rt.GetUrl()+"api/system/version", true, rt.CreateHttpClientDetails())
 	if err != nil {
 		return "", err
 	}

--- a/artifactory/services/go/go.go
+++ b/artifactory/services/go/go.go
@@ -82,6 +82,10 @@ func (gp *GoParams) GetInfoPath() string {
 	return gp.InfoPath
 }
 
+func (gp *GoParams) GetIgnoreIntermediateForbiddenErrors() bool {
+	return gp.IgnoreIntermediateForbiddenErrors
+}
+
 func NewGoParams() GoParams {
 	return GoParams{}
 }

--- a/artifactory/services/go/go.go
+++ b/artifactory/services/go/go.go
@@ -39,14 +39,15 @@ func (gs *GoService) PublishPackage(params GoParams) error {
 }
 
 type GoParams struct {
-	ZipPath    string
-	ModPath    string
-	InfoPath   string
-	ModContent []byte
-	Version    string
-	Props      string
-	TargetRepo string
-	ModuleId   string
+	ZipPath                           string
+	ModPath                           string
+	InfoPath                          string
+	ModContent                        []byte
+	Version                           string
+	Props                             string
+	TargetRepo                        string
+	ModuleId                          string
+	IgnoreIntermediateForbiddenErrors bool
 }
 
 func (gp *GoParams) GetZipPath() string {

--- a/artifactory/services/go/publishzipandmod.go
+++ b/artifactory/services/go/publishzipandmod.go
@@ -43,12 +43,12 @@ func (pwa *publishZipAndModApi) PublishPackage(params GoParams, client *rthttpcl
 	moduleId := strings.Split(params.GetModuleId(), ":")
 	uploadInfoFile := version.NewVersion(pwa.artifactoryVersion).AtLeast(ArtifactoryMinSupportedVersionForInfoFile) && params.GetInfoPath() != ""
 	// Upload zip file
-	err = pwa.upload(params.IgnoreIntermediateForbiddenErrors, params.GetZipPath(), moduleId[0], params.GetVersion(), params.GetProps(), ".zip", url)
+	err = pwa.upload(params.GetIgnoreIntermediateForbiddenErrors(), params.GetZipPath(), moduleId[0], params.GetVersion(), params.GetProps(), ".zip", url)
 	if err != nil {
 		return err
 	}
 	// Upload mod file
-	err = pwa.upload(uploadInfoFile && params.IgnoreIntermediateForbiddenErrors, params.GetModPath(), moduleId[0], params.GetVersion(), params.GetProps(), ".mod", url)
+	err = pwa.upload(uploadInfoFile && params.GetIgnoreIntermediateForbiddenErrors(), params.GetModPath(), moduleId[0], params.GetVersion(), params.GetProps(), ".mod", url)
 	if err != nil {
 		return err
 	}

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -97,8 +97,8 @@ func (jc *HttpClient) Send(method, url string, content []byte, followRedirect, c
 func (jc *HttpClient) SendWithRetryOnTimeout(method, url string, content []byte, followRedirect, closeBody bool, httpClientsDetails httputils.HttpClientDetails) (resp *http.Response, respBody []byte, redirectUrl string, err error) {
 	var req *http.Request
 	retryExecutor := utils.RetryExecutor{
-		MaxRetries:      2,
-		RetriesInterval: 10,
+		MaxRetries:      3,
+		RetriesInterval: 0,
 		ErrorMessage:    fmt.Sprintf("Got timeout when sending HTTP %s request to: %s", method, url),
 		ExecutionHandler: func() (bool, error) {
 			log.Debug(fmt.Sprintf("Sending HTTP %s request to: %s", method, url))


### PR DESCRIPTION
- Add GET request with retry on timeout to http client
- Add HEAD request with retry on timeout to http client
- Add retry on timeout to Artifactory version retrieval method
- Add ignore forbidden error flag to Go module publish service

