### PR TITLE
Allow excluding repositories in all AQL based operations

### DIFF
--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -34,7 +34,8 @@ func GetPaths(rootPath string, isRecursive, includeDirs, isSymlink bool) ([]stri
 func PrepareExcludePathPattern(params serviceutils.FileGetter) string {
 	exclusions := params.GetExclusions()
 	if len(exclusions) == 0 {
-		exclusions = params.GetExcludePatterns() // Support legacy excluded patterns
+		// Support legacy exclude patterns. 'Exclude patterns' are deprecated and replaced by 'exclusions'.
+		exclusions = params.GetExcludePatterns()
 	}
 
 	excludePathPattern := ""

--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -32,9 +32,14 @@ func GetPaths(rootPath string, isRecursive, includeDirs, isSymlink bool) ([]stri
 
 // Transform to regexp and prepare Exclude patterns to be used
 func PrepareExcludePathPattern(params serviceutils.FileGetter) string {
+	exclusions := params.GetExclusions()
+	if len(exclusions) == 0 {
+		exclusions = params.GetExcludePatterns() // Support legacy excluded patterns
+	}
+
 	excludePathPattern := ""
-	if len(params.GetExcludePatterns()) > 0 {
-		for _, singleExcludePattern := range params.GetExcludePatterns() {
+	if len(exclusions) > 0 {
+		for _, singleExcludePattern := range exclusions {
 			if len(singleExcludePattern) > 0 {
 				singleExcludePattern = utils.ReplaceTildeWithUserHome(singleExcludePattern)
 				singleExcludePattern = utils.PrepareLocalPathForUpload(singleExcludePattern, params.IsRegexp())

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -11,24 +11,24 @@ import (
 // Returns an AQL body string to search file in Artifactory by pattern, according the the specified arguments requirements.
 func createAqlBodyForSpecWithPattern(params *ArtifactoryCommonParams) (string, error) {
 	searchPattern := prepareSourceSearchPattern(params.Pattern, params.Target, true)
-	pathFilePairs := createRepoPathFileTriples(searchPattern, params.Recursive)
+	repoPathFileTriples := createRepoPathFileTriples(searchPattern, params.Recursive)
 	includeRoot := strings.Count(searchPattern, "/") < 2
-	pathPairsSize := len(pathFilePairs)
+	repoTripleSize := len(repoPathFileTriples)
 
 	propsQueryPart, err := buildPropsQueryPart(params.Props, params.ExcludeProps)
 	if err != nil {
 		return "", err
 	}
 	itemTypeQuery := buildItemTypeQueryPart(params)
-	nePath := buildNePathPart(pathPairsSize == 0 || includeRoot)
-	excludeQuery := buildExcludeQueryPart(params.ExcludePatterns, pathPairsSize == 0 || params.Recursive, params.Recursive)
+	nePath := buildNePathPart(repoTripleSize == 0 || includeRoot)
+	excludeQuery := buildExcludeQueryPart(params, repoTripleSize == 0 || params.Recursive, params.Recursive)
 
 	json := fmt.Sprintf(`{%s"$or":[`, propsQueryPart+itemTypeQuery+nePath+excludeQuery)
 
 	// Get archive search parameters
 	archivePathFilePairs := createArchiveSearchParams(params)
 
-	json += handleRepoPathFileTriples(pathFilePairs, archivePathFilePairs, pathPairsSize) + "]}"
+	json += handleRepoPathFileTriples(repoPathFileTriples, archivePathFilePairs, repoTripleSize) + "]}"
 	return json, nil
 }
 
@@ -197,22 +197,29 @@ func buildInnerArchiveQueryPart(triple RepoPathFile, archivePath, archiveName st
 	return fmt.Sprintf(innerQueryPattern, getAqlValue(triple.repo), getAqlValue(triple.path), getAqlValue(triple.file), getAqlValue(archivePath), getAqlValue(archiveName))
 }
 
-func buildExcludeQueryPart(excludePatterns []string, useLocalPath, recursive bool) string {
-	if excludePatterns == nil {
-		return ""
-	}
+func buildExcludeQueryPart(params *ArtifactoryCommonParams, useLocalPath, recursive bool) string {
 	excludeQuery := ""
-	var excludePairs []RepoPathFile
-	for _, excludePattern := range excludePatterns {
-		excludePairs = append(excludePairs, createPathFilePairs("", prepareSearchPattern(excludePattern, false), recursive)...)
+	var excludeTriples []RepoPathFile
+	if len(params.GetExclusions()) > 0 {
+		for _, excludePattern := range params.GetExclusions() {
+			excludeTriples = append(excludeTriples, createRepoPathFileTriples(prepareSearchPattern(excludePattern, true), recursive)...)
+		}
+	} else {
+		for _, excludePattern := range params.GetExcludePatterns() {
+			excludeTriples = append(excludeTriples, createPathFilePairs("", prepareSearchPattern(excludePattern, false), recursive)...)
+		}
 	}
 
-	for _, excludePair := range excludePairs {
-		excludePath := excludePair.path
+	for _, excludeTriple := range excludeTriples {
+		excludePath := excludeTriple.path
 		if !useLocalPath && excludePath == "." {
 			excludePath = "*"
 		}
-		excludeQuery += fmt.Sprintf(`"$or":[{"path":{"$nmatch": "%s"},"name":{"$nmatch":"%s"}}],`, excludePath, excludePair.file)
+		excludeRepoStr := ""
+		if excludeTriple.repo != "" {
+			excludeRepoStr = fmt.Sprintf(`"repo":{"$nmatch":"%s"},`, excludeTriple.repo)
+		}
+		excludeQuery += fmt.Sprintf(`"$or":[{%s"path":{"$nmatch":"%s"},"name":{"$nmatch":"%s"}}],`, excludeRepoStr, excludePath, excludeTriple.file)
 	}
 	return excludeQuery
 }

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -13,22 +13,22 @@ func createAqlBodyForSpecWithPattern(params *ArtifactoryCommonParams) (string, e
 	searchPattern := prepareSourceSearchPattern(params.Pattern, params.Target, true)
 	repoPathFileTriples := createRepoPathFileTriples(searchPattern, params.Recursive)
 	includeRoot := strings.Count(searchPattern, "/") < 2
-	repoTripleSize := len(repoPathFileTriples)
+	triplesSize := len(repoPathFileTriples)
 
 	propsQueryPart, err := buildPropsQueryPart(params.Props, params.ExcludeProps)
 	if err != nil {
 		return "", err
 	}
 	itemTypeQuery := buildItemTypeQueryPart(params)
-	nePath := buildNePathPart(repoTripleSize == 0 || includeRoot)
-	excludeQuery := buildExcludeQueryPart(params, repoTripleSize == 0 || params.Recursive, params.Recursive)
+	nePath := buildNePathPart(triplesSize == 0 || includeRoot)
+	excludeQuery := buildExcludeQueryPart(params, triplesSize == 0 || params.Recursive, params.Recursive)
 
 	json := fmt.Sprintf(`{%s"$or":[`, propsQueryPart+itemTypeQuery+nePath+excludeQuery)
 
 	// Get archive search parameters
 	archivePathFilePairs := createArchiveSearchParams(params)
 
-	json += handleRepoPathFileTriples(repoPathFileTriples, archivePathFilePairs, repoTripleSize) + "]}"
+	json += handleRepoPathFileTriples(repoPathFileTriples, archivePathFilePairs, triplesSize) + "]}"
 	return json, nil
 }
 
@@ -205,6 +205,7 @@ func buildExcludeQueryPart(params *ArtifactoryCommonParams, useLocalPath, recurs
 			excludeTriples = append(excludeTriples, createRepoPathFileTriples(prepareSearchPattern(excludePattern, true), recursive)...)
 		}
 	} else {
+		// Support legacy exclude patterns. 'Exclude patterns' are deprecated and replaced by 'exclusions'.
 		for _, excludePattern := range params.GetExcludePatterns() {
 			excludeTriples = append(excludeTriples, createPathFilePairs("", prepareSearchPattern(excludePattern, false), recursive)...)
 		}

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -19,7 +19,8 @@ type Aql struct {
 type ArtifactoryCommonParams struct {
 	Aql             Aql
 	Pattern         string
-	ExcludePatterns []string // Deprecated, use Exclusions instead
+	// Deprecated, use Exclusions instead
+	ExcludePatterns []string
 	Exclusions      []string
 	Target          string
 	Props           string
@@ -40,7 +41,8 @@ type FileGetter interface {
 	GetPattern() string
 	SetPattern(pattern string)
 	GetExclusions() []string
-	GetExcludePatterns() []string // Deprecated, Use Exclusions instead
+	// Deprecated, Use Exclusions instead
+	GetExcludePatterns() []string
 	GetTarget() string
 	SetTarget(target string)
 	IsExplode() bool

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -19,7 +19,8 @@ type Aql struct {
 type ArtifactoryCommonParams struct {
 	Aql             Aql
 	Pattern         string
-	ExcludePatterns []string
+	ExcludePatterns []string // Deprecated, use Exclusions instead
+	Exclusions      []string
 	Target          string
 	Props           string
 	ExcludeProps    string
@@ -38,7 +39,8 @@ type FileGetter interface {
 	GetAql() Aql
 	GetPattern() string
 	SetPattern(pattern string)
-	GetExcludePatterns() []string
+	GetExclusions() []string
+	GetExcludePatterns() []string // Deprecated: Use Exclusions
 	GetTarget() string
 	SetTarget(target string)
 	IsExplode() bool
@@ -138,6 +140,10 @@ func (params *ArtifactoryCommonParams) GetLimit() int {
 
 func (params *ArtifactoryCommonParams) GetExcludePatterns() []string {
 	return params.ExcludePatterns
+}
+
+func (params *ArtifactoryCommonParams) GetExclusions() []string {
+	return params.Exclusions
 }
 
 func (aql *Aql) UnmarshalJSON(value []byte) error {

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -40,7 +40,7 @@ type FileGetter interface {
 	GetPattern() string
 	SetPattern(pattern string)
 	GetExclusions() []string
-	GetExcludePatterns() []string // Deprecated: Use Exclusions
+	GetExcludePatterns() []string // Deprecated, Use Exclusions instead
 	GetTarget() string
 	SetTarget(target string)
 	IsExplode() bool

--- a/tests/artifactorydownload_test.go
+++ b/tests/artifactorydownload_test.go
@@ -19,6 +19,7 @@ func TestArtifactoryDownload(t *testing.T) {
 	t.Run("placeholder", placeholderDownload)
 	t.Run("includeDirs", includeDirsDownload)
 	t.Run("excludePatterns", excludePatternsDownload)
+	t.Run("exclusionsDownload", exclusionsDownload)
 	t.Run("explodeArchive", explodeArchiveDownload)
 	artifactoryCleanup(t)
 }
@@ -223,6 +224,31 @@ func excludePatternsDownload(t *testing.T) {
 	downloadTarget := workingDir + string(filepath.Separator)
 	excludePatterns := []string{"b.in", "*.tar.gz"}
 	_, _, err = testsDownloadService.DownloadFiles(services.DownloadParams{ArtifactoryCommonParams: &utils.ArtifactoryCommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget, ExcludePatterns: excludePatterns}, Flat: true})
+	if err != nil {
+		t.Error(err)
+	}
+	if !fileutils.IsPathExists(filepath.Join(workingDir, "a.in"), false) {
+		t.Error("Missing file a.in")
+	}
+
+	if fileutils.IsPathExists(filepath.Join(workingDir, "b.in"), false) {
+		t.Error("File b.in should have been excluded")
+	}
+	if fileutils.IsPathExists(filepath.Join(workingDir, "c.tar.gz"), false) {
+		t.Error("File c.tar.gz should have been excluded")
+	}
+}
+
+func exclusionsDownload(t *testing.T) {
+	workingDir, err := ioutil.TempDir("", "downloadTests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(workingDir)
+	downloadPattern := RtTargetRepo + "*"
+	downloadTarget := workingDir + string(filepath.Separator)
+	exclusions := []string{"*b.in", "*.tar.gz"}
+	_, _, err = testsDownloadService.DownloadFiles(services.DownloadParams{ArtifactoryCommonParams: &utils.ArtifactoryCommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget, Exclusions: exclusions}, Flat: true})
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/artifactorydownload_test.go
+++ b/tests/artifactorydownload_test.go
@@ -19,7 +19,7 @@ func TestArtifactoryDownload(t *testing.T) {
 	t.Run("placeholder", placeholderDownload)
 	t.Run("includeDirs", includeDirsDownload)
 	t.Run("excludePatterns", excludePatternsDownload)
-	t.Run("exclusionsDownload", exclusionsDownload)
+	t.Run("exclusions", exclusionsDownload)
 	t.Run("explodeArchive", explodeArchiveDownload)
 	artifactoryCleanup(t)
 }


### PR DESCRIPTION
Allow excluding repositories in all AQL based operations:
1. Add new `--exclusions` flag, and `exclusions` field in fileSpec.
2. Deprecate `--exclude-patterns` flag and `excludePatterns` field in fileSpec.
