### PR TITLE
fixed expires_in=0 (never expires)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The default temp dir used is  'os.TempDir()'. Use the following API to set a new
     params := services.NewCreateTokenParams()
     params.Scope = "api:* member-of-groups:readers"
     params.Username = "user"
-    params.ExpiresIn = 3600
+    params.ExpiresIn = 3600 // default -1 (use server default)
     params.GrantType = "client_credentials"
     params.Refreshable = true
     params.Audience = "jfrt@<serviceID1> jfrt@<serviceID2>"

--- a/artifactory/services/security.go
+++ b/artifactory/services/security.go
@@ -136,7 +136,7 @@ func buildCreateTokenUrlValues(params CreateTokenParams) url.Values {
 	if params.Audience != "" {
 		data.Set("audience", params.Audience)
 	}
-	if params.ExpiresIn != 0 {
+	if params.ExpiresIn >= 0 {
 		data.Set("expires_in", strconv.Itoa(params.ExpiresIn))
 	}
 	return data
@@ -208,7 +208,7 @@ type RevokeTokenParams struct {
 }
 
 func NewCreateTokenParams() CreateTokenParams {
-	return CreateTokenParams{}
+	return CreateTokenParams{ExpiresIn: -1}
 }
 
 func NewRefreshTokenParams() RefreshTokenParams {

--- a/artifactory/services/security_test.go
+++ b/artifactory/services/security_test.go
@@ -2,6 +2,7 @@ package services
 
 import "testing"
 
+// Test mapping ExpiresIn to expires_in request value and default handling
 func TestBuildCreateTokenUrlValuesExpiresIn(t *testing.T) {
 	tests := []struct {
 		testName string
@@ -22,6 +23,7 @@ func TestBuildCreateTokenUrlValuesExpiresIn(t *testing.T) {
 	}
 }
 
+// Test default value -1 in NewCreateTokenParams
 func TestNewCreateTokenParams(t *testing.T) {
 	values := buildCreateTokenUrlValues(NewCreateTokenParams())
 	if values.Get("expires_in") != "" {

--- a/artifactory/services/security_test.go
+++ b/artifactory/services/security_test.go
@@ -1,0 +1,30 @@
+package services
+
+import "testing"
+
+func TestBuildCreateTokenUrlValuesExpiresIn(t *testing.T) {
+	tests := []struct {
+		testName string
+		input    int
+		output   string
+	}{
+		{"never expires", 0, "0"},
+		{"expires", 1800, "1800"},
+		{"default", -1, ""},
+	}
+	for _, test := range tests {
+		values := buildCreateTokenUrlValues(CreateTokenParams{
+			ExpiresIn: test.input,
+		})
+		if values.Get("expires_in") != test.output {
+			t.Errorf("Test name: %s: Expected: %s, Got: %s", test.testName, test.output, values.Get("expires_in"))
+		}
+	}
+}
+
+func TestNewCreateTokenParams(t *testing.T) {
+	values := buildCreateTokenUrlValues(NewCreateTokenParams())
+	if values.Get("expires_in") != "" {
+		t.Errorf("default expires_in should be empty")
+	}
+}


### PR DESCRIPTION
see  #127 

Solution slightly changes behaviour for defaults. Consider following:

```
securityService := NewSecurityService(client)
securityService.CreateToken(CreateTokenParams{Username: "test"})
```
Without this MR no `expires_in` is send to the server, with this MR expires_in=0 is sent and the issued token never expires. 

If the API is used with `NewCreateTokenParams` function there is no difference.

```
securityService := NewSecurityService(client)
params := NewCreateTokenParams()
params.Username = "test"
securityService.CreateToken(params)
```

Also negative values are no more sent to the server and so the server default is used.

Maybe thats not the best solution. I am open for ideas!