### PR TITLE
implement buildinfo environment filters

### DIFF
--- a/artifactory/buildinfo/buildinfo.go
+++ b/artifactory/buildinfo/buildinfo.go
@@ -1,7 +1,6 @@
 package buildinfo
 
 import (
-	"github.com/jfrog/jfrog-client-go/auth"
 	"time"
 )
 
@@ -183,24 +182,4 @@ func (partials Partials) Swap(i, j int) {
 
 type General struct {
 	Timestamp time.Time `json:"Timestamp,omitempty"`
-}
-
-type Configuration struct {
-	ArtDetails auth.ServiceDetails
-	BuildUrl   string
-	DryRun     bool
-	EnvInclude string
-	EnvExclude string
-}
-
-func (config *Configuration) GetArtifactoryDetails() auth.ServiceDetails {
-	return config.ArtDetails
-}
-
-func (config *Configuration) SetArtifactoryDetails(artDetails auth.ServiceDetails) {
-	config.ArtDetails = artDetails
-}
-
-func (config *Configuration) IsDryRun() bool {
-	return config.DryRun
 }

--- a/artifactory/buildinfo/config.go
+++ b/artifactory/buildinfo/config.go
@@ -1,0 +1,77 @@
+package buildinfo
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+type Configuration struct {
+	ArtDetails auth.ServiceDetails
+	BuildUrl   string
+	DryRun     bool
+	EnvInclude string
+	EnvExclude string
+}
+
+func (config *Configuration) GetArtifactoryDetails() auth.ServiceDetails {
+	return config.ArtDetails
+}
+
+func (config *Configuration) SetArtifactoryDetails(artDetails auth.ServiceDetails) {
+	config.ArtDetails = artDetails
+}
+
+func (config *Configuration) IsDryRun() bool {
+	return config.DryRun
+}
+
+type Filter func(map[string]string) (map[string]string, error)
+
+// IncludeFilter returns a function used to filter entries of a map based on key
+func (config Configuration) IncludeFilter(prefix string) Filter {
+	pats := strings.Split(config.EnvInclude, ";")
+	return func(tempMap map[string]string) (map[string]string, error) {
+		result := make(map[string]string)
+		for k, v := range tempMap {
+			for _, filterPattern := range pats {
+				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, prefix)))
+				if errorutils.CheckError(err) != nil {
+					return nil, err
+				}
+				if matched {
+					result[k] = v
+					break
+				}
+			}
+		}
+		return result, nil
+	}
+}
+
+// ExcludeFilter returns a function used to filter entries of a map based on key
+func (config Configuration) ExcludeFilter(prefix string) Filter {
+	pats := strings.Split(config.EnvExclude, ";")
+	return func(tempMap map[string]string) (map[string]string, error) {
+		result := make(map[string]string)
+		for k, v := range tempMap {
+			include := true
+			for _, filterPattern := range pats {
+				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, prefix)))
+				if errorutils.CheckError(err) != nil {
+					return nil, err
+				}
+				if matched {
+					include = false
+					break
+				}
+			}
+			if include {
+				result[k] = v
+			}
+		}
+		return result, nil
+	}
+}

--- a/artifactory/buildinfo/config_test.go
+++ b/artifactory/buildinfo/config_test.go
@@ -1,0 +1,180 @@
+package buildinfo_test
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInclude(t *testing.T) {
+	tests := []struct {
+		description string
+		config      buildinfo.Configuration
+		input       map[string]string
+		prefix      string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			description: "empty input",
+			config:      buildinfo.Configuration{},
+			input:       map[string]string{},
+			prefix:      "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			description: "input with no pattern",
+			config:      buildinfo.Configuration{},
+			input: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			prefix:      "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			description: "input with pattern",
+			config:      buildinfo.Configuration{EnvInclude: "*user*"},
+			input: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			prefix: "",
+			expected: map[string]string{
+				"USER": "jfrog",
+			},
+			expectError: false,
+		},
+		{
+			description: "input with bad pattern",
+			config:      buildinfo.Configuration{EnvInclude: "use[*"},
+			input: map[string]string{
+				"USER": "jfrog",
+			},
+			prefix:      "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			description: "input with prefix",
+			config:      buildinfo.Configuration{EnvInclude: "*user*"},
+			input: map[string]string{
+				"buildInfo.env.USER":     "jfrog",
+				"buildInfo.env.PASSWORD": "password",
+			},
+			prefix: "buildInfo.env.",
+			expected: map[string]string{
+				"buildInfo.env.USER": "jfrog",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			out, err := tc.config.IncludeFilter(tc.prefix)(tc.input)
+			if tc.expectError {
+				assert.NotNil(t, err)
+			}
+
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}
+
+func TestExclude(t *testing.T) {
+	tests := []struct {
+		description string
+		config      buildinfo.Configuration
+		input       map[string]string
+		prefix      string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			description: "empty input",
+			config:      buildinfo.Configuration{},
+			input:       map[string]string{},
+			prefix:      "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			description: "input with no pattern",
+			config:      buildinfo.Configuration{},
+			input: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			prefix: "",
+			expected: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			expectError: false,
+		},
+		{
+			description: "input with pattern",
+			config:      buildinfo.Configuration{EnvExclude: "*pass*"},
+			input: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			prefix: "",
+			expected: map[string]string{
+				"USER": "jfrog",
+			},
+			expectError: false,
+		},
+		{
+			description: "input with bad non-matching pattern",
+			config:      buildinfo.Configuration{EnvExclude: "pas[*"},
+			input: map[string]string{
+				"USER": "jfrog",
+			},
+			prefix: "",
+			expected: map[string]string{
+				"USER": "jfrog",
+			},
+			expectError: false,
+		},
+		{
+			description: "input with bad matching pattern",
+			config:      buildinfo.Configuration{EnvExclude: "pas[*"},
+			input: map[string]string{
+				"USER":     "jfrog",
+				"PASSWORD": "password",
+			},
+			prefix:      "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			description: "input with prefix",
+			config:      buildinfo.Configuration{EnvExclude: "*pass*"},
+			input: map[string]string{
+				"buildInfo.env.USER":     "jfrog",
+				"buildInfo.env.PASSWORD": "password",
+			},
+			prefix: "buildInfo.env.",
+			expected: map[string]string{
+				"buildInfo.env.USER": "jfrog",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			out, err := tc.config.ExcludeFilter(tc.prefix)(tc.input)
+			if tc.expectError {
+				assert.NotNil(t, err)
+			}
+
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses Issue #169 by adding the Filter implementation of the CLI in this client library, making it usable by all downstream consumers.

Test case output:
```
$ go test -cover -v github.com/jfrog/jfrog-client-go/artifactory/buildinfo
=== RUN   TestInclude
=== RUN   TestInclude/empty_input
=== RUN   TestInclude/input_with_no_pattern
=== RUN   TestInclude/input_with_pattern
=== RUN   TestInclude/input_with_bad_pattern
=== RUN   TestInclude/input_with_prefix
--- PASS: TestInclude (0.00s)
    --- PASS: TestInclude/empty_input (0.00s)
    --- PASS: TestInclude/input_with_no_pattern (0.00s)
    --- PASS: TestInclude/input_with_pattern (0.00s)
    --- PASS: TestInclude/input_with_bad_pattern (0.00s)
    --- PASS: TestInclude/input_with_prefix (0.00s)
=== RUN   TestExclude
=== RUN   TestExclude/empty_input
=== RUN   TestExclude/input_with_no_pattern
=== RUN   TestExclude/input_with_pattern
=== RUN   TestExclude/input_with_bad_non-matching_pattern
=== RUN   TestExclude/input_with_bad_matching_pattern
=== RUN   TestExclude/input_with_prefix
--- PASS: TestExclude (0.00s)
    --- PASS: TestExclude/empty_input (0.00s)
    --- PASS: TestExclude/input_with_no_pattern (0.00s)
    --- PASS: TestExclude/input_with_pattern (0.00s)
    --- PASS: TestExclude/input_with_bad_non-matching_pattern (0.00s)
    --- PASS: TestExclude/input_with_bad_matching_pattern (0.00s)
    --- PASS: TestExclude/input_with_prefix (0.00s)
PASS
coverage: 41.5% of statements
ok      github.com/jfrog/jfrog-client-go/artifactory/buildinfo  0.030s  coverage: 41.5% of statements
```