### PR TITLE
Allow adding properties to release bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ err := distManager.SetSigningKey(params)
 
 ```go
 params := services.NewCreateReleaseBundleParams("bundle-name", "1")
-params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
+params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip", Props: "key1=val1;key2=val2"}}
 params.Description = "Description"
 params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
@@ -640,7 +640,7 @@ err := distManager.CreateReleaseBundle(params)
 
 ```go
 params := services.NewUpdateReleaseBundleParams("bundle-name", "1")
-params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
+params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip", Props: "key1=val1;key2=val2"}}
 params.Description = "New Description"
 params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -54,7 +54,7 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 		SourceRepo:          promotionParams.GetSourceRepo(),
 		TargetRepo:          promotionParams.GetTargetRepo(),
 		DryRun:              ps.isDryRun(),
-		Properties:          props.ToBuildPromoteMap()}
+		Properties:          props.ToMap()}
 	requestContent, err := json.Marshal(data)
 	if err != nil {
 		return errorutils.CheckError(err)

--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -73,13 +73,13 @@ func (props *Properties) ToHeadersMap() map[string]string {
 	return headers
 }
 
-// Convert properties from Slice to map that build promotion REST API requires
-func (props *Properties) ToBuildPromoteMap() map[string][]string {
-	buildPromote := map[string][]string{}
+// Convert properties from Slice to map
+func (props *Properties) ToMap() map[string][]string {
+	propertiesMap := map[string][]string{}
 	for _, prop := range props.Properties {
-		buildPromote[prop.Key] = []string{prop.Value}
+		propertiesMap[prop.Key] = append(propertiesMap[prop.Key], prop.Value)
 	}
-	return buildPromote
+	return propertiesMap
 }
 
 // Split properties string of format key=value to key value strings

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -1,6 +1,30 @@
 package utils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToMap(t *testing.T) {
+	properties := Properties{[]Property{
+		{Key: "a", Value: "b"},
+		{Key: "c", Value: "d"},
+		{Key: "c", Value: "e"}},
+	}
+	propertiesMap := properties.ToMap()
+	assert.Len(t, propertiesMap, 2)
+	for key, values := range propertiesMap {
+		switch key {
+		case "a":
+			assert.Equal(t, []string{"b"}, values)
+		case "c":
+			assert.ElementsMatch(t, []string{"d", "e"}, values)
+		default:
+			assert.Fail(t, "Unexpected key "+key)
+		}
+	}
+}
 
 func TestToEncodedString(t *testing.T) {
 	tests := []struct {

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateBundleBody(t *testing.T) {
+	releaseBundleParam := ReleaseBundleParams{
+		SignImmediately:    true,
+		StoringRepository:  "storing-repo",
+		Description:        "Release bundle description",
+		ReleaseNotes:       "Release notes",
+		ReleaseNotesSyntax: Asciidoc,
+	}
+
+	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, releaseBundleBody)
+	assert.Equal(t, true, releaseBundleBody.DryRun)
+	assert.Equal(t, true, releaseBundleBody.SignImmediately)
+	assert.Equal(t, "storing-repo", releaseBundleBody.StoringRepository)
+	assert.Equal(t, "Release bundle description", releaseBundleBody.Description)
+	assert.Equal(t, "Release notes", releaseBundleBody.ReleaseNotes.Content)
+	assert.Equal(t, ReleaseNotesSyntax(Asciidoc), releaseBundleBody.ReleaseNotes.Syntax)
+	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 0)
+}
+
+func TestCreateBundleBodyQuery(t *testing.T) {
+	releaseBundleParam := ReleaseBundleParams{
+		SpecFiles: []*utils.ArtifactoryCommonParams{{
+			Pattern: "dist-repo/*",
+			Props:   "a=b;c=d;c=e",
+		}},
+	}
+
+	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, releaseBundleBody)
+	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 1)
+	query := releaseBundleBody.BundleSpec.Queries[0]
+	assert.Contains(t, query.Aql, "dist-repo")
+	props := query.AddedProps
+	assert.Len(t, props, 2)
+	for _, prop := range props {
+		switch prop.Key {
+		case "a":
+			assert.Equal(t, []string{"b"}, prop.Values)
+		case "c":
+			assert.ElementsMatch(t, []string{"d", "e"}, prop.Values)
+		default:
+			assert.Fail(t, "Unexpected key "+prop.Key)
+		}
+	}
+}

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -20,6 +20,11 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName string `json:"query_name,omitempty"`
-	Aql       string `json:"aql"`
+	QueryName  string        `json:"query_name,omitempty"`
+	Aql        string        `json:"aql"`
+	AddedProps []BundleProps `json:"added_props,omitempty"`
+}
+type BundleProps struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
 }


### PR DESCRIPTION
Allow adding properties to release bundles. 
The properties will be added to the release bundle's artifacts after distribution of the release bundle.

```go
params := services.NewCreateReleaseBundleParams("bundle-name", "1")
params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip", Props: "key1=val1;key2=val2"}}
err := distManager.CreateReleaseBundle(params)
```

