### PR TITLE
Add BuildInfoEnvPrefix const

### DIFF
--- a/artifactory/buildinfo/config.go
+++ b/artifactory/buildinfo/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 )
 
+const BuildInfoEnvPrefix = "buildInfo.env."
+
 type Configuration struct {
 	ArtDetails auth.ServiceDetails
 	BuildUrl   string
@@ -31,13 +33,13 @@ func (config *Configuration) IsDryRun() bool {
 type Filter func(map[string]string) (map[string]string, error)
 
 // IncludeFilter returns a function used to filter entries of a map based on key
-func (config Configuration) IncludeFilter(prefix string) Filter {
+func (config Configuration) IncludeFilter() Filter {
 	pats := strings.Split(config.EnvInclude, ";")
 	return func(tempMap map[string]string) (map[string]string, error) {
 		result := make(map[string]string)
 		for k, v := range tempMap {
 			for _, filterPattern := range pats {
-				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, prefix)))
+				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, BuildInfoEnvPrefix)))
 				if errorutils.CheckError(err) != nil {
 					return nil, err
 				}
@@ -52,14 +54,14 @@ func (config Configuration) IncludeFilter(prefix string) Filter {
 }
 
 // ExcludeFilter returns a function used to filter entries of a map based on key
-func (config Configuration) ExcludeFilter(prefix string) Filter {
+func (config Configuration) ExcludeFilter() Filter {
 	pats := strings.Split(config.EnvExclude, ";")
 	return func(tempMap map[string]string) (map[string]string, error) {
 		result := make(map[string]string)
 		for k, v := range tempMap {
 			include := true
 			for _, filterPattern := range pats {
-				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, prefix)))
+				matched, err := filepath.Match(strings.ToLower(filterPattern), strings.ToLower(strings.TrimPrefix(k, BuildInfoEnvPrefix)))
 				if errorutils.CheckError(err) != nil {
 					return nil, err
 				}

--- a/artifactory/buildinfo/config_test.go
+++ b/artifactory/buildinfo/config_test.go
@@ -11,7 +11,6 @@ func TestInclude(t *testing.T) {
 		description string
 		config      Configuration
 		input       map[string]string
-		prefix      string
 		expected    map[string]string
 		expectError bool
 	}{
@@ -19,7 +18,6 @@ func TestInclude(t *testing.T) {
 			description: "empty input",
 			config:      Configuration{},
 			input:       map[string]string{},
-			prefix:      "",
 			expected:    map[string]string{},
 			expectError: false,
 		},
@@ -30,7 +28,6 @@ func TestInclude(t *testing.T) {
 				"USER":     "jfrog",
 				"PASSWORD": "password",
 			},
-			prefix:      "",
 			expected:    map[string]string{},
 			expectError: false,
 		},
@@ -41,7 +38,6 @@ func TestInclude(t *testing.T) {
 				"USER":     "jfrog",
 				"PASSWORD": "password",
 			},
-			prefix: "",
 			expected: map[string]string{
 				"USER": "jfrog",
 			},
@@ -53,28 +49,14 @@ func TestInclude(t *testing.T) {
 			input: map[string]string{
 				"USER": "jfrog",
 			},
-			prefix:      "",
 			expected:    nil,
 			expectError: true,
-		},
-		{
-			description: "input with prefix",
-			config:      Configuration{EnvInclude: "*user*"},
-			input: map[string]string{
-				"buildInfo.env.USER":     "jfrog",
-				"buildInfo.env.PASSWORD": "password",
-			},
-			prefix: "buildInfo.env.",
-			expected: map[string]string{
-				"buildInfo.env.USER": "jfrog",
-			},
-			expectError: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			out, err := tc.config.IncludeFilter(tc.prefix)(tc.input)
+			out, err := tc.config.IncludeFilter()(tc.input)
 			if tc.expectError {
 				assert.NotNil(t, err)
 			}
@@ -89,7 +71,6 @@ func TestExclude(t *testing.T) {
 		description string
 		config      Configuration
 		input       map[string]string
-		prefix      string
 		expected    map[string]string
 		expectError bool
 	}{
@@ -97,7 +78,6 @@ func TestExclude(t *testing.T) {
 			description: "empty input",
 			config:      Configuration{},
 			input:       map[string]string{},
-			prefix:      "",
 			expected:    map[string]string{},
 			expectError: false,
 		},
@@ -108,7 +88,6 @@ func TestExclude(t *testing.T) {
 				"USER":     "jfrog",
 				"PASSWORD": "password",
 			},
-			prefix: "",
 			expected: map[string]string{
 				"USER":     "jfrog",
 				"PASSWORD": "password",
@@ -122,7 +101,6 @@ func TestExclude(t *testing.T) {
 				"USER":     "jfrog",
 				"PASSWORD": "password",
 			},
-			prefix: "",
 			expected: map[string]string{
 				"USER": "jfrog",
 			},
@@ -134,7 +112,6 @@ func TestExclude(t *testing.T) {
 			input: map[string]string{
 				"USER": "jfrog",
 			},
-			prefix: "",
 			expected: map[string]string{
 				"USER": "jfrog",
 			},
@@ -147,28 +124,14 @@ func TestExclude(t *testing.T) {
 				"USER":     "jfrog",
 				"PASSWORD": "password",
 			},
-			prefix:      "",
 			expected:    nil,
 			expectError: true,
-		},
-		{
-			description: "input with prefix",
-			config:      Configuration{EnvExclude: "*pass*"},
-			input: map[string]string{
-				"buildInfo.env.USER":     "jfrog",
-				"buildInfo.env.PASSWORD": "password",
-			},
-			prefix: "buildInfo.env.",
-			expected: map[string]string{
-				"buildInfo.env.USER": "jfrog",
-			},
-			expectError: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			out, err := tc.config.ExcludeFilter(tc.prefix)(tc.input)
+			out, err := tc.config.ExcludeFilter()(tc.input)
 			if tc.expectError {
 				assert.NotNil(t, err)
 			}


### PR DESCRIPTION
Following the merge of https://github.com/jfrog/jfrog-client-go/pull/170 which moved the env include and env exclude from jfrog-cli to jfrog-client-go, the code which was moved should also be deleted from jfrog-cli.

This pull request improves the API added by https://github.com/jfrog/jfrog-client-go/pull/170, to make it easier for jfrog-cli to use it, It removed the prefix argument, and replaces it with a const.