### PR TITLE
Use maven-2-default layout instead of gradle-default

### DIFF
--- a/tests/artifactorylocalrepository_test.go
+++ b/tests/artifactorylocalrepository_test.go
@@ -72,7 +72,7 @@ func localGradleTest(t *testing.T) {
 	repoKey := GenerateRepoKeyForRepoServiceTest()
 	glp := services.NewGradleLocalRepositoryParams()
 	glp.Key = repoKey
-	glp.RepoLayoutRef = "gradle-default"
+	glp.RepoLayoutRef = "maven-2-default"
 	glp.Description = "Gradle Repo for jfrog-client-go local-repository-test"
 	glp.SuppressPomConsistencyChecks = &trueValue
 	glp.HandleReleases = &trueValue

--- a/tests/artifactoryremoterepository_test.go
+++ b/tests/artifactoryremoterepository_test.go
@@ -78,7 +78,7 @@ func remoteGradleTest(t *testing.T) {
 	repoKey := GenerateRepoKeyForRepoServiceTest()
 	grp := services.NewGradleRemoteRepositoryParams()
 	grp.Key = repoKey
-	grp.RepoLayoutRef = "gradle-default"
+	grp.RepoLayoutRef = "maven-2-default"
 	grp.Url = "https://jcenter.bintray.com"
 	grp.Description = "Gradle Repo for jfrog-client-go remote-repository-test"
 	grp.SuppressPomConsistencyChecks = &trueValue

--- a/tests/artifactoryvirtualrepository_test.go
+++ b/tests/artifactoryvirtualrepository_test.go
@@ -84,7 +84,7 @@ func virtualGradleTest(t *testing.T) {
 
 	gvp.Description += " - Updated"
 	gvp.Notes = "Repo been updated"
-	gvp.RepoLayoutRef = "gradle-default"
+	gvp.RepoLayoutRef = "maven-2-default"
 	gvp.ForceMavenAuthentication = nil
 	gvp.ArtifactoryRequestsCanRetrieveRemoteArtifacts = &trueValue
 	gvp.ExcludesPattern = "**/****"


### PR DESCRIPTION
Replacing gradle-default repository layout with maven-2-default due to gradle-default deprecation. 