### PR TITLE
Bugfix - AQL is not supported in rbc/rbu

### DIFF
--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -41,9 +41,9 @@ func CreateBundleBody(createBundleParams ReleaseBundleParams, dryRun bool) (*Rel
 				return nil, err
 			}
 			specFile.Aql = utils.Aql{ItemsFind: query}
-			aql := utils.BuildQueryFromSpecFile(specFile, utils.NONE)
-			bundleQueries = append(bundleQueries, BundleQuery{Aql: aql})
 		}
+		aql := utils.BuildQueryFromSpecFile(specFile, utils.NONE)
+		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql})
 	}
 
 	// Create release bundle struct


### PR DESCRIPTION
Release bundle create/update - When spec type is AQL, we ignore the AQL.

Precondition for: https://github.com/jfrog/jfrog-cli/pull/812
Resolves: https://github.com/jfrog/jfrog-cli/issues/809