### PR TITLE
Bug fix - CleanOldDirs() does not delete dirs

### DIFF
--- a/utils/io/fileutils/temp.go
+++ b/utils/io/fileutils/temp.go
@@ -87,7 +87,7 @@ func CleanOldDirs() error {
 			}
 			// Delete old file/dirs.
 			if now.Sub(timeStamp).Hours() > maxFileAge {
-				if err := os.Remove(path.Join(tempDirBase, file.Name())); err != nil {
+				if err := os.RemoveAll(path.Join(tempDirBase, file.Name())); err != nil {
 					return errorutils.CheckError(err)
 				}
 			}


### PR DESCRIPTION
This PR fixes the following issue.
The ```CleanOldDirs()``` function an error, if ```tempDirBase``` includes directories which are not empty. This function is used by JFrog CLI after each execution. This issue can cause the following error:
```
$ jfrog -v
jfrog version 1.39.5
[Warn] remove /var/folders/cq/j4684j7n4bb_nlss5dy06mnr0000gn/T/jfrog.cli.temp.-1602145932-459087986: directory not empty
```
And here's the stack-trace:
```
$ export JFROG_CLI_ERROR_HANDLING=panic
$ jfrog -v
jfrog version 1.39.5
panic: remove /var/folders/cq/j4684j7n4bb_nlss5dy06mnr0000gn/T/jfrog.cli.temp.-1602145932-459087986: directory not empty

goroutine 1 [running]:
github.com/jfrog/jfrog-cli-core/utils/coreutils.PanicOnError(0x1b230e0, 0xc0001e06f0, 0x1b230e0, 0xc0001e06f0)
	/root/go/pkg/mod/github.com/jfrog/jfrog-cli-core@v0.1.0/utils/coreutils/utils.go:68 +0x59
github.com/jfrog/jfrog-client-go/utils/io/fileutils.CleanOldDirs(0x0, 0x0)
	/root/go/pkg/mod/github.com/jfrog/jfrog-client-go@v0.14.0/utils/io/fileutils/temp.go:91 +0x2dc
main.main()
	/var/jenkins_home/workspace/eco-system/release/jfrog-cli-release/temp/jfrog-cli/main.go:77 +0x43
``` 