### PR TITLE
Remove initDownloadService from ArtifactoryServicesManager

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -32,7 +32,6 @@ type ArtifactoryServicesManager interface {
 	GetPathsToDelete(params services.DeleteParams) (*content.ContentReader, error)
 	DeleteFiles(reader *content.ContentReader) (int, error)
 	ReadRemoteFile(readPath string) (io.ReadCloser, error)
-	initDownloadService() *services.DownloadService
 	DownloadFiles(params ...services.DownloadParams) (totalDownloaded, totalExpected int, err error)
 	DownloadFilesWithResultReader(params ...services.DownloadParams) (resultReader *content.ContentReader, totalDownloaded, totalExpected int, err error)
 	GetUnreferencedGitLfsFiles(params services.GitLfsCleanParams) (*content.ContentReader, error)


### PR DESCRIPTION
The interface ArtifactoryServicesManager contains the private method
initDownloadService.  This means that gomock for example cannot be used
to generate a set of mocks for this interface which can then be used in
unit-testing.  In this change we simply remove initDownloadService from
ArtifactoryServicesManager, which means that it is now only defined and
used by ArtifactoryServicesManagerImp.