### PR TITLE
add context to managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ serviceConfig, err := config.NewConfigBuilder().
     Build()
 ```
 
+#### Creating Artifactory Service Config with [Context](https://golang.org/pkg/context/)
+```go
+ctx := context.Background()
+serviceConfig, err := config.NewConfigBuilder().
+    SetServiceDetails(rtDetails).
+    SetCertificatesPath(certPath).
+    SetThreads(threads).
+    SetDryRun(false).
+    SetContext(ctx).
+    Build()
+```
+
 #### Creating New Artifactory Service Manager
 ```go
 rtManager, err := artifactory.New(&rtDetails, serviceConfig)

--- a/artifactory/httpclient/rtClientBuilder.go
+++ b/artifactory/httpclient/rtClientBuilder.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"context"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/httpclient"
 )
@@ -12,6 +13,7 @@ func ArtifactoryClientBuilder() *artifactoryHttpClientBuilder {
 type artifactoryHttpClientBuilder struct {
 	certificatesDirPath string
 	insecureTls         bool
+	ctx                 context.Context
 	ServiceDetails      *auth.ServiceDetails
 }
 
@@ -30,6 +32,11 @@ func (builder *artifactoryHttpClientBuilder) SetServiceDetails(rtDetails *auth.S
 	return builder
 }
 
+func (builder *artifactoryHttpClientBuilder) SetContext(ctx context.Context) *artifactoryHttpClientBuilder {
+	builder.ctx = ctx
+	return builder
+}
+
 func (builder *artifactoryHttpClientBuilder) Build() (rtHttpClient *ArtifactoryHttpClient, err error) {
 	rtHttpClient = &ArtifactoryHttpClient{ArtDetails: builder.ServiceDetails}
 	rtHttpClient.httpClient, err = httpclient.ClientBuilder().
@@ -37,6 +44,7 @@ func (builder *artifactoryHttpClientBuilder) Build() (rtHttpClient *ArtifactoryH
 		SetInsecureTls(builder.insecureTls).
 		SetClientCertPath((*rtHttpClient.ArtDetails).GetClientCertPath()).
 		SetClientCertKeyPath((*rtHttpClient.ArtDetails).GetClientCertKeyPath()).
+		SetContext(builder.ctx).
 		Build()
 	return
 }

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -34,6 +34,7 @@ func NewWithProgress(artDetails *auth.ServiceDetails, config config.Config, prog
 		SetCertificatesPath(config.GetCertificatesPath()).
 		SetInsecureTls(config.IsInsecureTls()).
 		SetServiceDetails(artDetails).
+		SetContext(config.GetContext()).
 		Build()
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -12,6 +13,7 @@ type Config interface {
 	GetServiceDetails() auth.ServiceDetails
 	GetLogger() log.Log
 	IsInsecureTls() bool
+	GetContext() context.Context
 }
 
 type servicesConfig struct {
@@ -21,6 +23,7 @@ type servicesConfig struct {
 	threads          int
 	logger           log.Log
 	insecureTls      bool
+	ctx              context.Context
 }
 
 func (config *servicesConfig) IsDryRun() bool {
@@ -45,4 +48,8 @@ func (config *servicesConfig) GetLogger() log.Log {
 
 func (config *servicesConfig) IsInsecureTls() bool {
 	return config.insecureTls
+}
+
+func (config *servicesConfig) GetContext() context.Context {
+	return config.ctx
 }

--- a/config/configbuilder.go
+++ b/config/configbuilder.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"github.com/jfrog/jfrog-client-go/auth"
 )
 
@@ -16,6 +17,7 @@ type servicesConfigBuilder struct {
 	threads          int
 	isDryRun         bool
 	insecureTls      bool
+	ctx              context.Context
 }
 
 func (builder *servicesConfigBuilder) SetServiceDetails(artDetails auth.ServiceDetails) *servicesConfigBuilder {
@@ -43,6 +45,11 @@ func (builder *servicesConfigBuilder) SetInsecureTls(insecureTls bool) *services
 	return builder
 }
 
+func (builder *servicesConfigBuilder) SetContext(ctx context.Context) *servicesConfigBuilder {
+	builder.ctx = ctx
+	return builder
+}
+
 func (builder *servicesConfigBuilder) Build() (Config, error) {
 	c := &servicesConfig{}
 	c.ServiceDetails = builder.ServiceDetails
@@ -50,5 +57,6 @@ func (builder *servicesConfigBuilder) Build() (Config, error) {
 	c.certificatesPath = builder.certificatesPath
 	c.dryRun = builder.isDryRun
 	c.insecureTls = builder.insecureTls
+	c.ctx = builder.ctx
 	return c, nil
 }

--- a/distribution/manager.go
+++ b/distribution/manager.go
@@ -22,6 +22,7 @@ func New(details *auth.ServiceDetails, config config.Config) (*DistributionServi
 		SetCertificatesPath(config.GetCertificatesPath()).
 		SetInsecureTls(config.IsInsecureTls()).
 		SetServiceDetails(details).
+		SetContext(config.GetContext()).
 		Build()
 	if err != nil {
 		return nil, err

--- a/httpclient/clientBuilder.go
+++ b/httpclient/clientBuilder.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -20,6 +21,7 @@ type httpClientBuilder struct {
 	clientCertPath      string
 	clientCertKeyPath   string
 	insecureTls         bool
+	ctx                 context.Context
 }
 
 func (builder *httpClientBuilder) SetCertificatesPath(certificatesPath string) *httpClientBuilder {
@@ -39,6 +41,11 @@ func (builder *httpClientBuilder) SetClientCertKeyPath(certificatePath string) *
 
 func (builder *httpClientBuilder) SetInsecureTls(insecureTls bool) *httpClientBuilder {
 	builder.insecureTls = insecureTls
+	return builder
+}
+
+func (builder *httpClientBuilder) SetContext(ctx context.Context) *httpClientBuilder {
+	builder.ctx = ctx
 	return builder
 }
 
@@ -62,7 +69,7 @@ func (builder *httpClientBuilder) Build() (*HttpClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &HttpClient{Client: &http.Client{Transport: transport}}, nil
+		return &HttpClient{Client: &http.Client{Transport: transport}, ctx: builder.ctx}, nil
 	}
 
 	transport, err := cert.GetTransportWithLoadedCert(builder.certificatesDirPath, builder.insecureTls, createDefaultHttpTransport())

--- a/tests/artifactoryctx_test.go
+++ b/tests/artifactoryctx_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestCtx(t *testing.T) {
+	t.Run("ctx", testCtx)
+	t.Run("ctxWithTimeout", testCtxTimeout)
+}
+
+func ctxMgr(t *testing.T, artDetails auth.ServiceDetails, ctx context.Context) (artifactory.ArtifactoryServicesManager, error) {
+	cfg, err := config.NewConfigBuilder().SetServiceDetails(artDetails).SetContext(ctx).Build()
+	assert.NoError(t, err)
+	return artifactory.New(&artDetails, cfg)
+}
+
+func testCtx(t *testing.T) {
+	artDetails := GetRtDetails()
+	sm, err := ctxMgr(t, artDetails, context.Background())
+	_, err = sm.GetVersion()
+	assert.NoError(t, err)
+}
+
+func testCtxTimeout(t *testing.T) {
+	artDetails := GetRtDetails()
+	timeoutCtx, _ := context.WithTimeout(context.Background(), time.Millisecond*250)
+	sm, err := ctxMgr(t, artDetails, timeoutCtx)
+	time.Sleep(time.Millisecond * 300)
+	_, err = sm.GetVersion()
+	assert.Error(t, err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This add a context to the managers so they can execute http requests using a provided context. It probably fixes #192 