### PR TITLE
add support for log colors

### DIFF
--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -1,6 +1,9 @@
 package log
 
 import (
+	"fmt"
+	"github.com/gookit/color"
+	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"log"
 	"os"
@@ -9,6 +12,9 @@ import (
 var Logger Log
 
 type LevelType int
+
+type LogFormat string
+var Format LogFormat
 
 const (
 	ERROR LevelType = iota
@@ -50,9 +56,17 @@ func (logger *jfrogLogger) SetOutputWriter(writer io.Writer) {
 }
 
 // Set the logs writer to Stderr unless an alternative one is provided.
+// In case the writer is set for file, colors will not be in use.
 func (logger *jfrogLogger) SetLogsWriter(writer io.Writer) {
 	if writer == nil {
 		writer = os.Stderr
+		if 	isTerminal() {
+			logger.DebugLog = log.New(writer, fmt.Sprintf("[%s] ", color.Cyan.Render("Debug")), 0)
+			logger.InfoLog = log.New(writer, fmt.Sprintf("[%s] ", color.Blue.Render("Info")), 0)
+			logger.WarnLog = log.New(writer, fmt.Sprintf("[%s] ", color.Yellow.Render("Warn")), 0)
+			logger.ErrorLog = log.New(writer, fmt.Sprintf("[%s] ", color.Red.Render("Error")), 0)
+			return
+		}
 	}
 	logger.DebugLog = log.New(writer, "[Debug] ", 0)
 	logger.InfoLog = log.New(writer, "[Info] ", 0)
@@ -139,3 +153,24 @@ type Log interface {
 	Error(a ...interface{})
 	Output(a ...interface{})
 }
+
+// Check if Stderr is a terminal
+func isTerminal() bool {
+	return terminal.IsTerminal(int(os.Stderr.Fd()))
+}
+
+//predefined color formatting functions
+func (f *LogFormat) Path(message string) string {
+	if (isTerminal()){
+		return color.Green.Render(message)
+	}
+	return message
+}
+
+func (f *LogFormat) URL(message string) string {
+	if (isTerminal()){
+		return color.Green.Render(message)
+	}
+	return message
+}
+


### PR DESCRIPTION
add support for log colors in terminal

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
