### PR TITLE
Fix/watch remote repo

### DIFF
--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	artifactoryServices "github.com/jfrog/jfrog-client-go/artifactory/services"
 	artUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/httpclient"
@@ -132,10 +133,10 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 	defer deletePolicy(policy1Name)
 
 	repo1Name := fmt.Sprintf("%s-%d", "jfrog-repo1", time.Now().Unix())
-	createRepo(t, repo1Name)
+	createRepoLocal(t, repo1Name)
 	defer deleteRepo(t, repo1Name)
 	repo2Name := fmt.Sprintf("%s-%d", "jfrog-repo2", time.Now().Unix())
-	createRepo(t, repo2Name)
+	createRepoRemote(t, repo2Name)
 	defer deleteRepo(t, repo2Name)
 
 	build1Name := fmt.Sprintf("%s-%d", "jfrog-build1", time.Now().Unix())
@@ -339,12 +340,23 @@ func validateWatchGeneralSettings(t *testing.T, params utils.WatchParams) {
 	assert.Equal(t, params.Policies, targetConfig.Policies)
 }
 
-func createRepo(t *testing.T, repoKey string) {
+func createRepoLocal(t *testing.T, repoKey string) {
 	glp := artifactoryServices.NewGenericLocalRepositoryParams()
 	glp.Key = repoKey
 	glp.XrayIndex = &trueValue
 
 	err := testsCreateLocalRepositoryService.Generic(glp)
+	assert.NoError(t, err, "Failed to create "+repoKey)
+}
+
+func createRepoRemote(t *testing.T, repoKey string) {
+	nrp := services.NewNpmRemoteRepositoryParams()
+	nrp.Key = repoKey
+	nrp.RepoLayoutRef = "npm-default"
+	nrp.Url = "https://registry.npmjs.org"
+	nrp.XrayIndex = &trueValue
+
+	err := testsCreateRemoteRepositoryService.Npm(nrp)
 	assert.NoError(t, err, "Failed to create "+repoKey)
 }
 

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -161,7 +161,7 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 	}
 
 	var repos = map[string]utils.WatchRepository{}
-	repo := utils.NewWatchRepository(repo1Name, "default")
+	repo := utils.NewWatchRepository(repo1Name, "default", utils.WatchRepositoryLocal)
 	repo.Filters.PackageTypes = []string{"npm", "maven"}
 	repo.Filters.Names = []string{"example-name"}
 	repo.Filters.Paths = []string{"example-path"}
@@ -170,7 +170,7 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 
 	repos[repo1Name] = repo
 
-	anotherRepo := utils.NewWatchRepository(repo2Name, "default")
+	anotherRepo := utils.NewWatchRepository(repo2Name, "default", utils.WatchRepositoryRemote)
 	anotherRepo.Filters.PackageTypes = []string{"nuget"}
 	anotherRepo.Filters.Names = []string{"another-example-name"}
 	anotherRepo.Filters.Paths = []string{"another-example-path"}
@@ -203,6 +203,7 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 
 	assert.Equal(t, repo1Name, targetConfig.Repositories.Repositories[repo1Name].Name)
 	assert.Equal(t, "default", targetConfig.Repositories.Repositories[repo1Name].BinMgrID)
+	assert.Equal(t, utils.WatchRepositoryLocal, targetConfig.Repositories.Repositories[repo1Name].RepoType)
 	assert.Equal(t, []string{"Maven", "Npm"}, targetConfig.Repositories.Repositories[repo1Name].Filters.PackageTypes)
 	assert.Equal(t, []string{"example-name"}, targetConfig.Repositories.Repositories[repo1Name].Filters.Names)
 	assert.Equal(t, []string{"example-path"}, targetConfig.Repositories.Repositories[repo1Name].Filters.Paths)
@@ -211,6 +212,7 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 
 	assert.Equal(t, repo2Name, targetConfig.Repositories.Repositories[repo2Name].Name)
 	assert.Equal(t, "default", targetConfig.Repositories.Repositories[repo2Name].BinMgrID)
+	assert.Equal(t, utils.WatchRepositoryRemote, targetConfig.Repositories.Repositories[repo2Name].RepoType)
 	assert.Equal(t, []string{"NuGet"}, targetConfig.Repositories.Repositories[repo2Name].Filters.PackageTypes)
 	assert.Equal(t, []string{"another-example-name"}, targetConfig.Repositories.Repositories[repo2Name].Filters.Names)
 	assert.Equal(t, []string{"another-example-path"}, targetConfig.Repositories.Repositories[repo2Name].Filters.Paths)

--- a/xray/services/utils/watchbody.go
+++ b/xray/services/utils/watchbody.go
@@ -13,6 +13,11 @@ const (
 	// WatchBuildByName is the option where builds are selected by name to be watched
 	WatchBuildByName WatchBuildType = "byname"
 
+	// WatchRepositoryLocal is a local repository
+	WatchRepositoryLocal WatchRepositoryType = "local"
+	// WatchRepositoryRemote is a remote repository
+	WatchRepositoryRemote WatchRepositoryType = "remote"
+
 	// WatchRepositoriesAll is the option where all repositories are watched
 	WatchRepositoriesAll WatchRepositoriesType = "all"
 	// WatchRepositoriesByName is the option where repositories are selected by name to be watched
@@ -24,6 +29,9 @@ type WatchBuildType string
 
 // WatchRepositoriesType defines the type of filter for a repositories on a watch
 type WatchRepositoriesType string
+
+// WatchRepositoryType defines the type of Repository for a watch
+type WatchRepositoryType string
 
 // NewWatchParams creates a new struct to configure an Xray watch
 func NewWatchParams() WatchParams {
@@ -72,6 +80,7 @@ type WatchRepositoryAll struct {
 type WatchRepository struct {
 	Name     string
 	BinMgrID string
+	RepoType WatchRepositoryType
 	Filters  watchFilters
 }
 
@@ -127,10 +136,11 @@ type watchProjectResources struct {
 }
 
 type watchProjectResourcesElement struct {
-	Name     string        `json:"name,omitempty"`
-	BinMgrID string        `json:"bin_mgr_id,oitempty"`
-	Type     string        `json:"type"`
-	Filters  []watchFilter `json:"filters,omitempty"`
+	Name     string              `json:"name,omitempty"`
+	BinMgrID string              `json:"bin_mgr_id,omitempty"`
+	Type     string              `json:"type"`
+	RepoType WatchRepositoryType `json:"repo_type,omitempty"`
+	Filters  []watchFilter       `json:"filters,omitempty"`
 }
 
 type watchFilters struct {
@@ -201,6 +211,7 @@ func configureRepositories(payloadBody *WatchBody, params WatchParams) error {
 				Type:     "repository",
 				Name:     repository.Name,
 				BinMgrID: repository.BinMgrID,
+				RepoType: repository.RepoType,
 				Filters:  make([]watchFilter, 0),
 			}
 
@@ -334,6 +345,7 @@ func UnpackWatchBody(watch *WatchParams, body *WatchBody) {
 			repository := WatchRepository{
 				Name:     resource.Name,
 				BinMgrID: resource.BinMgrID,
+				RepoType: resource.RepoType,
 			}
 			unpackFilters(resource.Filters, &repository.Filters, &watch.Repositories)
 			watch.Repositories.Repositories[repository.Name] = repository
@@ -431,9 +443,10 @@ func unpackFilters(filters []watchFilter, output *watchFilters, repos *WatchRepo
 }
 
 // NewWatchRepository creates a new repository struct to configure an Xray Watch
-func NewWatchRepository(name string, binMgrID string) WatchRepository {
+func NewWatchRepository(name string, binMgrID string, repoType WatchRepositoryType) WatchRepository {
 	return WatchRepository{
 		Name:     name,
 		BinMgrID: binMgrID,
+		RepoType: repoType,
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

A watch payload defaults to watching local repositories.

This PR adds the `repo_type` parameter to a the payload so that a `remote` repo can be watched.

