### PR TITLE
Fix fileutils MoveDir() path creation to support windows paths

### DIFF
--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -560,7 +559,7 @@ func MoveDir(fromPath, toPath string) error {
 			}
 			continue
 		}
-		err = os.Rename(v, path.Join(toPath, path.Base(v)))
+		err = os.Rename(v, filepath.Join(toPath, filepath.Base(v)))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
