### PR TITLE
Fix time format used in build info

### DIFF
--- a/artifactory/buildinfo/buildinfo.go
+++ b/artifactory/buildinfo/buildinfo.go
@@ -7,7 +7,7 @@ import (
 type ModuleType string
 
 const (
-	TimeFormat = "2006-01-02T15:04:05.999Z0700"
+	TimeFormat = "2006-01-02T15:04:05.000-0700"
 
 	// Build type
 	Build ModuleType = "build"


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
