### PR TITLE
Bugfix- explode fail after overriding the archive filename

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -405,7 +405,7 @@ func (ds *DownloadService) downloadFileIfNeeded(downloadPath, localPath, localFi
 	if isEqual {
 		log.Debug(logMsgPrefix, "File already exists locally.")
 		if downloadParams.IsExplode() {
-			e = clientutils.HandleArchive(localPath, localFileName, downloadData.Dependency.Name, logMsgPrefix)
+			e = clientutils.ExtractArchive(localPath, localFileName, downloadData.Dependency.Name, logMsgPrefix)
 		}
 		return e
 	}

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -405,30 +405,12 @@ func (ds *DownloadService) downloadFileIfNeeded(downloadPath, localPath, localFi
 	if isEqual {
 		log.Debug(logMsgPrefix, "File already exists locally.")
 		if downloadParams.IsExplode() {
-			e = explodeLocalFile(localPath, localFileName)
+			e = clientutils.HandleArchive(localPath, localFileName, downloadData.Dependency.Name, logMsgPrefix)
 		}
 		return e
 	}
 	downloadFileDetails := createDownloadFileDetails(downloadPath, localPath, localFileName, downloadData)
 	return ds.downloadFile(downloadFileDetails, logMsgPrefix, downloadParams)
-}
-
-func explodeLocalFile(localPath, localFileName string) (err error) {
-	log.Info("Extracting archive:", localFileName, "to", localPath)
-	absolutePath := filepath.Join(localPath, localFileName)
-	err = nil
-
-	// The file is indeed an archive
-	if fileutils.IsSupportedArchive(localFileName) {
-		err := fileutils.Unarchive(absolutePath, localPath)
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
-		// If the file was extracted successfully, remove it from the file system
-		err = os.Remove(absolutePath)
-	}
-
-	return errorutils.CheckError(err)
 }
 
 func createDir(localPath, localFileName, logMsgPrefix string) error {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -323,7 +323,7 @@ func (jc *HttpClient) doDownloadFile(downloadFileDetails *DownloadFileDetails, l
 
 	// Extract archive.
 	if isExplode {
-		err = utils.HandleArchive(downloadFileDetails.LocalPath, downloadFileDetails.LocalFileName, downloadFileDetails.FileName, logMsgPrefix)
+		err = utils.ExtractArchive(downloadFileDetails.LocalPath, downloadFileDetails.LocalFileName, downloadFileDetails.FileName, logMsgPrefix)
 	}
 	return
 }
@@ -425,7 +425,7 @@ func (jc *HttpClient) DownloadFileConcurrently(flags ConcurrentDownloadFlags, lo
 	}
 
 	if flags.Explode {
-		if err := utils.HandleArchive(flags.LocalPath, flags.LocalFileName, flags.FileName, logMsgPrefix); err != nil {
+		if err := utils.ExtractArchive(flags.LocalPath, flags.LocalFileName, flags.FileName, logMsgPrefix); err != nil {
 			return nil, err
 		}
 	}

--- a/utils/archiveutils.go
+++ b/utils/archiveutils.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// localPath - The path of the downloaded archive file.
+// localFileName - name of the archive file.
+// originFileName - name of the archive file in Artifactory.
+// logMsgPrefix - prefix log message.
+// Extract an archive file to the 'localPath'.
+func HandleArchive(localPath, localFileName, originFileName, logMsgPrefix string) error {
+	if !fileutils.IsSupportedArchive(originFileName) {
+		return nil
+	}
+	extractionPath, err := getExtractionPath(localPath)
+	if err != nil {
+		return err
+	}
+	// In order to extract an archive file, the file extension is required, therefore,
+	// we replace the local downloaded file name, with its origin in Artifactory.
+	archivePath := filepath.Join(localPath, originFileName)
+	if !strings.HasSuffix(localFileName, originFileName) {
+		relativeLocalFilePath := localFileName
+		if !strings.HasPrefix(relativeLocalFilePath, localPath) {
+			relativeLocalFilePath = filepath.Join(localPath, relativeLocalFilePath)
+		}
+		err = os.Rename(relativeLocalFilePath, archivePath)
+		if err != nil {
+			return err
+		}
+	}
+	archivePath, err = filepath.Abs(archivePath)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(extractionPath, 0777)
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	log.Info(logMsgPrefix+"Extracting archive:", archivePath, "to", extractionPath)
+	return extractArchive(archivePath, extractionPath)
+}
+
+func extractArchive(localFilePath, extractionPath string) error {
+	err := fileutils.Unarchive(localFilePath, extractionPath)
+	if err != nil {
+		return err
+	}
+	// If the file was extracted successfully, remove it from the file system
+	return errorutils.CheckError(os.Remove(localFilePath))
+}
+
+func getExtractionPath(localPath string) (string, error) {
+	// The local path to which the file is going to be extracted,
+	// needs to be absolute.
+	absolutePath, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	// Add a trailing slash to the local path, since it has to be a directory.
+	return absolutePath + string(os.PathSeparator), nil
+}

--- a/utils/archiveutils.go
+++ b/utils/archiveutils.go
@@ -15,7 +15,7 @@ import (
 // originFileName - name of the archive file in Artifactory.
 // logMsgPrefix - prefix log message.
 // Extract an archive file to the 'localPath'.
-func HandleArchive(localPath, localFileName, originFileName, logMsgPrefix string) error {
+func ExtractArchive(localPath, localFileName, originFileName, logMsgPrefix string) error {
 	if !fileutils.IsSupportedArchive(originFileName) {
 		return nil
 	}
@@ -45,10 +45,10 @@ func HandleArchive(localPath, localFileName, originFileName, logMsgPrefix string
 		return err
 	}
 	log.Info(logMsgPrefix+"Extracting archive:", archivePath, "to", extractionPath)
-	return extractArchive(archivePath, extractionPath)
+	return extract(archivePath, extractionPath)
 }
 
-func extractArchive(localFilePath, extractionPath string) error {
+func extract(localFilePath, extractionPath string) error {
 	err := fileutils.Unarchive(localFilePath, extractionPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Download & explode fails to unzip the archive file if it missing the extension on the filename. A simple solution is to override the name with its origin in Artifactory as it gets deleted anyway after we finish to extract successfully.

Related PR:
 * https://github.com/jfrog/jfrog-cli/pull/932