### PR TITLE
Fix MoveFile

### DIFF
--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -571,20 +571,29 @@ func MoveDir(fromPath, toPath string) error {
 // MoveFile(source, destination) will work moving file between folders
 // Therefore, we are using our own implementation (MoveFile) in order to rename files.
 func MoveFile(sourcePath, destPath string) error {
+	inputFileOpen := true
 	inputFile, err := os.Open(sourcePath)
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	defer inputFile.Close()
+	defer func() {
+		if inputFileOpen {
+			inputFile.Close()
+		}
+	}()
+
 	outputFile, err := os.Create(destPath)
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
 	defer outputFile.Close()
+
 	_, err = io.Copy(outputFile, inputFile)
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
 	// The copy was successful, so now delete the original file
+	inputFile.Close()
+	inputFileOpen = false
 	return errorutils.CheckError(os.Remove(sourcePath))
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes an issue with the ```MoveFile``` function, which the ```jfrog-cli``` tests revieled.
```
Error] [Thread 2]  Received an error: remove C:\Users\appveyor\AppData\Local\Temp\1\jfrog.cli.temp.-1608298394-408535009\randFile: The process cannot access the file because it is being used by another process.
[Error] remove C:\Users\appveyor\AppData\Local\Temp\1\jfrog.cli.temp.-1608298394-408535009\randFile: The process cannot access the file because it is being used by another process.
{
  "status": "failure",
  "totals": {
    "success": 0,
    "failure": 1
  }
}
    artifactory_test.go:739: 
        	Error Trace:	artifactory_test.go:739
        	Error:      	Received unexpected error:
        	            	Download finished with errors, please review the logs.
        	Test:       	TestArtifactoryDownloadAndExplode
```
Notice above that the file cannot be removed because it is used by another process. Without this fix, the file is closed only after it is being removed, which probably causes this failure. This probably happens on Windows only, because Windows is more sensitive to files being locked.