### PR TITLE
Improve vcs url algorithm

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -85,7 +85,7 @@ func (m *manager) readUrl() {
 	if matchedResult == "" {
 		return
 	}
-	m.url = MaskCredentials(originUrl, matchedResult)
+	m.url = RemoveCredentials(originUrl, matchedResult)
 }
 
 func (m *manager) getRevisionOrBranchPath() (revision, refUrl string, err error) {

--- a/utils/regexputils.go
+++ b/utils/regexputils.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const CredentialsInUrlRegexp = `((http|https):\/\/.+:.*@)`
+const CredentialsInUrlRegexp = `(http|https|git)://.+@`
 
 func GetRegExp(regex string) (*regexp.Regexp, error) {
 	regExp, err := regexp.Compile(regex)
@@ -16,13 +16,17 @@ func GetRegExp(regex string) (*regexp.Regexp, error) {
 	return regExp, nil
 }
 
-// Mask the credentials information from the line, contained in credentialsPart.
-// The credentials are built as user:password
+// Remove credentials from the URL contained in the input line.
+// The credentials are built as 'user:password' or 'token'
 // For example:
 // line = 'This is a line http://user:password@127.0.0.1:8081/artifactory/path/to/repo'
 // credentialsPart = 'http://user:password@'
-// Returned value: 'This is a line http://***:***@127.0.0.1:8081/artifactory/path/to/repo'
-func MaskCredentials(line, credentialsPart string) string {
+// Returned value: 'This is a line http://127.0.0.1:8081/artifactory/path/to/repo'
+//
+// line = 'This is a line http://token@127.0.0.1:8081/artifactory/path/to/repo'
+// credentialsPart = 'http://token@'
+// Returned value: 'This is a line http://127.0.0.1:8081/artifactory/path/to/repo'
+func RemoveCredentials(line, credentialsPart string) string {
 	splitResult := strings.Split(credentialsPart, "//")
-	return strings.Replace(line, credentialsPart, splitResult[0]+"//***.***@", 1)
+	return strings.Replace(line, credentialsPart, splitResult[0]+"//", 1)
 }

--- a/utils/regexputils_test.go
+++ b/utils/regexputils_test.go
@@ -25,10 +25,16 @@ func TestRemoveCredentialsFromLine(t *testing.T) {
 		expectedLine string
 		matched      bool
 	}{
-		{"http", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line http://user:password@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line http://***.***@127.0.0.1:8081/artifactory/path/to/repo", true},
-		{"https", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://user:password@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://***.***@127.0.0.1:8081/artifactory/path/to/repo", true},
-		{"Special characters 1", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://u-s!<e>_r:!p-a&%%s%sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://***.***@127.0.0.1:8081/artifactory/path/to/repo", true},
-		{"Special characters 2", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://!user:[p]a(s)sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://***.***@127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"http", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line http://user:password@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line http://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"https", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://user:password@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"git", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line git://user:password@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line git://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"Special characters 1", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://u-s!<e>_r:!p-a&%%s%sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"Special characters 2", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://!user:[p]a(s)sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"http with token", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line http://123456@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line http://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"https with token", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://123456@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"git with token", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line git://123456@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line git://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"Special characters 1 with token", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://u-s!<e>_r!p-a&%%s%sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
+		{"Special characters 2 with token", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://!user[p]a(s)sword@127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", true},
 		{"No credentials", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo"}, "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", false},
 		{"No http", gofrogio.CmdOutputPattern{RegExp: regExpProtocol, Line: "This is an example line"}, "This is an example line", false},
 	}
@@ -42,7 +48,7 @@ func TestRemoveCredentialsFromLine(t *testing.T) {
 				t.Error("Expected to find a match.")
 			}
 			if test.matched {
-				actual := MaskCredentials(test.regex.Line, test.regex.MatchedResults[0])
+				actual := RemoveCredentials(test.regex.Line, test.regex.MatchedResults[0])
 				if !strings.EqualFold(actual, test.expectedLine) {
 					t.Errorf("Expected: %s, The Regex found %s and the masked line: %s", test.expectedLine, test.regex.MatchedResults[0], actual)
 				}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

When the VCS URL contains a URL with credentials, instead of masking it with '***', remove the credentials. This way, the URL will be clickable.
For example:
Before the change:
`https://***:***@github.com/jfrog/jfrog-client-go`
After the change:
`https://github.com/jfrog/jfrog-client-go`