### PR TITLE
Add GetRemote() for more information

### DIFF
--- a/artifactory/services/getrepository.go
+++ b/artifactory/services/getrepository.go
@@ -36,6 +36,19 @@ func (grs *GetRepositoryService) Get(repoKey string) (*RepositoryDetails, error)
 	return repoDetails, nil
 }
 
+func (grs *GetRepositoryService) GetRemote(repoKey string) (*RemoteRepositoryDetails, error) {
+	log.Info("Getting repository '" + repoKey + "' details ...")
+	body, err := grs.sendGet(apiRepositories + "/" + repoKey)
+	if err != nil {
+		return nil, err
+	}
+	repoDetails := &RemoteRepositoryDetails{}
+	if err := json.Unmarshal(body, &repoDetails); err != nil {
+		return repoDetails, errorutils.CheckError(err)
+	}
+	return repoDetails, nil
+}
+
 func (grs *GetRepositoryService) GetAll() (*[]RepositoryDetails, error) {
 	log.Info("Getting all repositories ...")
 	body, err := grs.sendGet(apiRepositories)
@@ -61,6 +74,10 @@ func (grs *GetRepositoryService) sendGet(api string) ([]byte, error) {
 	log.Debug("Artifactory response:", resp.Status)
 	log.Info("Done getting repository details.")
 	return body, nil
+}
+
+type RemoteRepositoryDetails struct {
+	RemoteRepositoryBaseParams
 }
 
 type RepositoryDetails struct {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR is ultimately tied to my desire to extend https://github.com/jfrog/terraform-provider-artifactory using this library over https://github.com/atlassian/go-artifactory

I wanted to get some feedback on this type of feature. The generic `Get()` isn't super useful when needing all of the information of a remote repository. I was thinking of implementing this (i.e. `GetRemote()`) and maybe `GetLocal()` and then in the future doing something more. Thoughts? Ideas on how to do this sort of thing better in general?