### PR TITLE
Allow adding properties to release bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.AddProps = "key1=val1;key2=val2"
+params.TargetProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true
@@ -226,7 +226,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.AddProps = "key1=val1;key2=val2"
+params.TargetProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true
@@ -803,7 +803,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "Description"
 params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
-params.AddProps = "key1=val1;key2=val2,val3"
+params.TargetProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```
@@ -815,7 +815,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "New Description"
 params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"
-params.AddProps = "key1=val1;key2=val2,val3"
+params.TargetProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.AddedProps = "key1=val1;key2=val2"
+params.AddProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true
@@ -226,7 +226,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.AddedProps = "key1=val1;key2=val2"
+params.AddProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true
@@ -803,7 +803,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "Description"
 params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
-params.AddedProps = "key1=val1;key2=val2,val3"
+params.AddProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```
@@ -815,7 +815,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "New Description"
 params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"
-params.AddedProps = "key1=val1;key2=val2,val3"
+params.AddProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.Props = "key1=val1;key2=val2"
+params.AddedProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true
@@ -226,7 +226,7 @@ params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
 params.Target = "repo/path/"
 // Attach properties to the uploaded files.
-params.Props = "key1=val1;key2=val2"
+params.AddedProps = "key1=val1;key2=val2"
 params.AddVcsProps = false
 params.BuildProps = "build.name=buildName;build.number=17;build.timestamp=1600856623553"
 params.Recursive = true

--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "Description"
 params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
+params.AddedProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```
@@ -814,6 +815,7 @@ params.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: "repo/*/*.zip"}}
 params.Description = "New Description"
 params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"
+params.AddedProps = "key1=val1;key2=val2,val3"
 
 err := distManager.CreateReleaseBundle(params)
 ```

--- a/artifactory/services/dockerpromote.go
+++ b/artifactory/services/dockerpromote.go
@@ -73,7 +73,7 @@ func (ps *DockerPromoteService) PromoteDocker(params DockerPromoteParams) error 
 	if resp.StatusCode != http.StatusOK {
 		return errorutils.CheckError(errors.New("Artifactory response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
 	}
-	
+
 	log.Debug("Artifactory response: ", resp.Status)
 	log.Info("Promoted image", params.SourceDockerImage, "to:", params.TargetRepo, "repository.")
 	return nil

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -54,7 +54,7 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 		SourceRepo:          promotionParams.GetSourceRepo(),
 		TargetRepo:          promotionParams.GetTargetRepo(),
 		DryRun:              ps.isDryRun(),
-		Properties:          props.ToBuildPromoteMap()}
+		Properties:          props.ToMap()}
 	requestContent, err := json.Marshal(data)
 	if err != nil {
 		return errorutils.CheckError(err)

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -94,13 +94,6 @@ func (us *UploadService) performUploadTasks(consumer parallel.Runner, uploadSumm
 	return
 }
 
-func addProps(oldProps, additionalProps string) string {
-	if len(oldProps) > 0 && !strings.HasSuffix(oldProps, ";") && len(additionalProps) > 0 {
-		oldProps += ";"
-	}
-	return oldProps + additionalProps
-}
-
 func addSymlinkProps(artifact clientutils.Artifact, uploadParams UploadParams) error {
 	artifactProps := ""
 	artifactSymlink := artifact.Symlink
@@ -128,7 +121,7 @@ func addSymlinkProps(artifact clientutils.Artifact, uploadParams UploadParams) e
 		}
 		artifactProps += utils.ARTIFACTORY_SYMLINK + "=" + artifactSymlink + sha1Property
 	}
-	uploadParams.TargetProps = addProps(uploadParams.GetTargetProps(), artifactProps)
+	uploadParams.TargetProps = clientutils.AddProps(uploadParams.GetTargetProps(), artifactProps)
 	return nil
 }
 

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -73,7 +73,7 @@ func (us *UploadService) prepareUploadTasks(producer parallel.Runner, progressMg
 			if len(uploadParams.Props) > 0 {
 				uploadParams.AddedProps = addProps(uploadParams.GetAddedProps(), uploadParams.GetProps())
 			}
-			
+
 			artifactHandlerFunc := us.createArtifactHandlerFunc(&uploadSummary, uploadParams)
 			err := collectFilesForUpload(uploadParams, producer, progressMgr, artifactHandlerFunc, errorsQueue, vcsCache)
 			if err != nil {

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -71,7 +71,7 @@ func (us *UploadService) prepareUploadTasks(producer parallel.Runner, progressMg
 		for _, uploadParams := range uploadParamsSlice {
 			// Add legacy props
 			if len(uploadParams.Props) > 0 {
-				uploadParams.AddedProps = addProps(uploadParams.GetAddedProps(), uploadParams.GetProps())
+				uploadParams.AddProps = addProps(uploadParams.GetAddProps(), uploadParams.GetProps())
 			}
 
 			artifactHandlerFunc := us.createArtifactHandlerFunc(&uploadSummary, uploadParams)
@@ -133,7 +133,7 @@ func addSymlinkProps(artifact clientutils.Artifact, uploadParams UploadParams) e
 		}
 		artifactProps += utils.ARTIFACTORY_SYMLINK + "=" + artifactSymlink + sha1Property
 	}
-	uploadParams.AddedProps = addProps(uploadParams.GetAddedProps(), artifactProps)
+	uploadParams.AddProps = addProps(uploadParams.GetAddProps(), artifactProps)
 	return nil
 }
 
@@ -169,7 +169,7 @@ func collectFilesForUpload(uploadParams UploadParams, producer parallel.Runner, 
 			}
 			uploadParams.BuildProps += vcsProps
 		}
-		uploadData := UploadData{Artifact: artifact, AddedProps: uploadParams.GetAddedProps(), BuildProps: uploadParams.BuildProps}
+		uploadData := UploadData{Artifact: artifact, AddProps: uploadParams.GetAddProps(), BuildProps: uploadParams.BuildProps}
 		task := artifactHandlerFunc(uploadData)
 		if progressMgr != nil {
 			progressMgr.IncGeneralProgressTotalBy(1)
@@ -275,7 +275,7 @@ func createUploadTask(taskData *uploadTaskData, vcsCache *clientutils.VcsCache) 
 		}
 		taskData.uploadParams.BuildProps += vcsProps
 	}
-	uploadData := UploadData{Artifact: artifact, AddedProps: taskData.uploadParams.GetAddedProps(), BuildProps: taskData.uploadParams.BuildProps}
+	uploadData := UploadData{Artifact: artifact, AddProps: taskData.uploadParams.GetAddProps(), BuildProps: taskData.uploadParams.BuildProps}
 	if taskData.isDir && taskData.uploadParams.IsIncludeDirs() && !taskData.isSymlinkFlow {
 		if taskData.path != "." && (taskData.index == 0 || !utils.IsSubPath(taskData.paths, taskData.index, fileutils.GetFileSeparator())) {
 			uploadData.IsDir = true
@@ -497,7 +497,7 @@ func (up *UploadParams) GetRetries() int {
 
 type UploadData struct {
 	Artifact   clientutils.Artifact
-	AddedProps string
+	AddProps   string
 	BuildProps string
 	IsDir      bool
 }
@@ -517,7 +517,7 @@ func (us *UploadService) createArtifactHandlerFunc(uploadResult *utils.Result, u
 			if e != nil {
 				return
 			}
-			artifactFileInfo, uploaded, e := us.uploadFile(artifact.Artifact.LocalPath, target, artifact.Artifact.TargetPath, artifact.AddedProps, artifact.BuildProps, uploadParams, logMsgPrefix)
+			artifactFileInfo, uploaded, e := us.uploadFile(artifact.Artifact.LocalPath, target, artifact.Artifact.TargetPath, artifact.AddProps, artifact.BuildProps, uploadParams, logMsgPrefix)
 			if e != nil {
 				return
 			}

--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -80,13 +80,13 @@ func (props *Properties) ToHeadersMap() map[string]string {
 	return headers
 }
 
-// Convert properties from Slice to map that build promotion REST API requires
-func (props *Properties) ToBuildPromoteMap() map[string][]string {
-	buildPromote := map[string][]string{}
+// Convert properties from Slice to map
+func (props *Properties) ToMap() map[string][]string {
+	propertiesMap := map[string][]string{}
 	for _, prop := range props.Properties {
-		buildPromote[prop.Key] = []string{prop.Value}
+		propertiesMap[prop.Key] = append(propertiesMap[prop.Key], prop.Value)
 	}
-	return buildPromote
+	return propertiesMap
 }
 
 // Split properties string of format key=value to key value strings

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToEncodedString(t *testing.T) {
@@ -50,6 +52,29 @@ func TestParseProperties(t *testing.T) {
 			}
 			if !reflect.DeepEqual(test.expected.Properties, props.Properties) {
 				t.Error("Failed to parse property string.", props, "expected to be parsed to", test.expected)
+			}
+		})
+	}
+}
+
+func TestToMap(t *testing.T) {
+	tests := []struct {
+		props Properties
+	}{
+		{Properties{[]Property{}}},
+		{Properties{[]Property{{Key: "a", Value: "b"}}}},
+		{Properties{[]Property{{Key: "a", Value: "b"}, {Key: "c", Value: "d"}}}},
+		{Properties{[]Property{{Key: "a", Value: "b"}, {Key: "c", Value: "d"}, {Key: "c", Value: "e"}}}},
+	}
+	for _, test := range tests {
+		t.Run(test.props.ToEncodedString(), func(t *testing.T) {
+			expectedProps := test.props.Properties
+			propsMap := test.props.ToMap()
+			assert.LessOrEqual(t, len(propsMap), len(expectedProps))
+			for _, expectedProp := range expectedProps {
+				values := propsMap[expectedProp.Key]
+				assert.NotNil(t, values, "Key "+expectedProp.Key+" not found in map")
+				assert.Contains(t, values, expectedProp.Value)
 			}
 		})
 	}

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -24,7 +24,7 @@ type ArtifactoryCommonParams struct {
 	Exclusions       []string
 	Target           string
 	Props            string
-	AddProps         string
+	TargetProps      string
 	ExcludeProps     string
 	SortOrder        string
 	SortBy           []string
@@ -93,8 +93,8 @@ func (params *ArtifactoryCommonParams) GetProps() string {
 	return params.Props
 }
 
-func (params *ArtifactoryCommonParams) GetAddProps() string {
-	return params.AddProps
+func (params *ArtifactoryCommonParams) GetTargetProps() string {
+	return params.TargetProps
 }
 
 func (params *ArtifactoryCommonParams) GetExcludeProps() string {
@@ -133,8 +133,8 @@ func (params *ArtifactoryCommonParams) SetProps(props string) {
 	params.Props = props
 }
 
-func (params *ArtifactoryCommonParams) SetAddProps(addProps string) {
-	params.AddProps = addProps
+func (params *ArtifactoryCommonParams) SetTargetProps(targetProps string) {
+	params.TargetProps = targetProps
 }
 
 func (params *ArtifactoryCommonParams) SetExcludeProps(excludeProps string) {

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -24,6 +24,7 @@ type ArtifactoryCommonParams struct {
 	Exclusions       []string
 	Target           string
 	Props            string
+	AddedProps       string
 	ExcludeProps     string
 	SortOrder        string
 	SortBy           []string
@@ -92,6 +93,10 @@ func (params *ArtifactoryCommonParams) GetProps() string {
 	return params.Props
 }
 
+func (params *ArtifactoryCommonParams) GetAddedProps() string {
+	return params.AddedProps
+}
+
 func (params *ArtifactoryCommonParams) GetExcludeProps() string {
 	return params.ExcludeProps
 }
@@ -126,6 +131,10 @@ func (params ArtifactoryCommonParams) IsIncludeDirs() bool {
 
 func (params *ArtifactoryCommonParams) SetProps(props string) {
 	params.Props = props
+}
+
+func (params *ArtifactoryCommonParams) SetAddedProps(addedProps string) {
+	params.AddedProps = addedProps
 }
 
 func (params *ArtifactoryCommonParams) SetExcludeProps(excludeProps string) {

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -24,7 +24,7 @@ type ArtifactoryCommonParams struct {
 	Exclusions       []string
 	Target           string
 	Props            string
-	AddedProps       string
+	AddProps         string
 	ExcludeProps     string
 	SortOrder        string
 	SortBy           []string
@@ -93,8 +93,8 @@ func (params *ArtifactoryCommonParams) GetProps() string {
 	return params.Props
 }
 
-func (params *ArtifactoryCommonParams) GetAddedProps() string {
-	return params.AddedProps
+func (params *ArtifactoryCommonParams) GetAddProps() string {
+	return params.AddProps
 }
 
 func (params *ArtifactoryCommonParams) GetExcludeProps() string {
@@ -133,8 +133,8 @@ func (params *ArtifactoryCommonParams) SetProps(props string) {
 	params.Props = props
 }
 
-func (params *ArtifactoryCommonParams) SetAddedProps(addedProps string) {
-	params.AddedProps = addedProps
+func (params *ArtifactoryCommonParams) SetAddProps(addProps string) {
+	params.AddProps = addProps
 }
 
 func (params *ArtifactoryCommonParams) SetExcludeProps(excludeProps string) {

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -42,13 +42,13 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 		}
 
 		// Create added properties
-		addProps, err := createAddProps(specFile)
+		addedProps, err := createAddedProps(specFile)
 		if err != nil {
 			return nil, err
 		}
 
 		// Append bundle query
-		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddProps: addProps})
+		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddedProps: addedProps})
 	}
 
 	// Create release bundle struct
@@ -84,18 +84,18 @@ func createAql(specFile *utils.ArtifactoryCommonParams) (string, error) {
 	return utils.BuildQueryFromSpecFile(specFile, utils.NONE), nil
 }
 
-// Create the AddProps array from the input AddProps string
-func createAddProps(specFile *utils.ArtifactoryCommonParams) ([]AddProps, error) {
-	props, err := utils.ParseProperties(specFile.AddProps, utils.SplitCommas)
+// Create the AddedProps array from the input TargetProps string
+func createAddedProps(specFile *utils.ArtifactoryCommonParams) ([]AddedProps, error) {
+	props, err := utils.ParseProperties(specFile.TargetProps, utils.SplitCommas)
 	if err != nil {
 		return nil, err
 	}
 
-	var addProps []AddProps
+	var addedProps []AddedProps
 	for key, values := range props.ToMap() {
-		addProps = append(addProps, AddProps{key, values})
+		addedProps = append(addedProps, AddedProps{key, values})
 	}
-	return addProps, nil
+	return addedProps, nil
 }
 
 func AddGpgPassphraseHeader(gpgPassphrase string, headers *map[string]string) {

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -22,7 +22,6 @@ type ReleaseBundleParams struct {
 	ReleaseNotes       string
 	ReleaseNotesSyntax ReleaseNotesSyntax
 	GpgPassphrase      string
-	AddedProps         string
 }
 
 func NewReleaseBundleParams(name, version string) ReleaseBundleParams {
@@ -43,7 +42,7 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 		}
 
 		// Create added properties
-		addedProps, err := createAddedProps(&releaseBundleParams)
+		addedProps, err := createAddedProps(specFile)
 		if err != nil {
 			return nil, err
 		}
@@ -86,8 +85,8 @@ func createAql(specFile *utils.ArtifactoryCommonParams) (string, error) {
 }
 
 // Create the AddedProps array from the input AddedProps string
-func createAddedProps(releaseBundleParams *ReleaseBundleParams) ([]AddedProps, error) {
-	props, err := utils.ParseProperties(releaseBundleParams.AddedProps, utils.SplitCommas)
+func createAddedProps(specFile *utils.ArtifactoryCommonParams) ([]AddedProps, error) {
+	props, err := utils.ParseProperties(specFile.AddedProps, utils.SplitCommas)
 	if err != nil {
 		return nil, err
 	}

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -42,13 +42,13 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 		}
 
 		// Create added properties
-		addedProps, err := createAddedProps(specFile)
+		addProps, err := createAddProps(specFile)
 		if err != nil {
 			return nil, err
 		}
 
 		// Append bundle query
-		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddedProps: addedProps})
+		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddProps: addProps})
 	}
 
 	// Create release bundle struct
@@ -84,18 +84,18 @@ func createAql(specFile *utils.ArtifactoryCommonParams) (string, error) {
 	return utils.BuildQueryFromSpecFile(specFile, utils.NONE), nil
 }
 
-// Create the AddedProps array from the input AddedProps string
-func createAddedProps(specFile *utils.ArtifactoryCommonParams) ([]AddedProps, error) {
-	props, err := utils.ParseProperties(specFile.AddedProps, utils.SplitCommas)
+// Create the AddProps array from the input AddProps string
+func createAddProps(specFile *utils.ArtifactoryCommonParams) ([]AddProps, error) {
+	props, err := utils.ParseProperties(specFile.AddProps, utils.SplitCommas)
 	if err != nil {
 		return nil, err
 	}
 
-	var addedProps []AddedProps
+	var addProps []AddProps
 	for key, values := range props.ToMap() {
-		addedProps = append(addedProps, AddedProps{key, values})
+		addProps = append(addProps, AddProps{key, values})
 	}
-	return addedProps, nil
+	return addProps, nil
 }
 
 func AddGpgPassphraseHeader(gpgPassphrase string, headers *map[string]string) {

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -22,6 +22,7 @@ type ReleaseBundleParams struct {
 	ReleaseNotes       string
 	ReleaseNotesSyntax ReleaseNotesSyntax
 	GpgPassphrase      string
+	AddedProps         string
 }
 
 func NewReleaseBundleParams(name, version string) ReleaseBundleParams {
@@ -31,40 +32,71 @@ func NewReleaseBundleParams(name, version string) ReleaseBundleParams {
 	}
 }
 
-func CreateBundleBody(createBundleParams ReleaseBundleParams, dryRun bool) (*ReleaseBundleBody, error) {
+func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*ReleaseBundleBody, error) {
 	var bundleQueries []BundleQuery
 	// Create release bundle queries
-	for _, specFile := range createBundleParams.SpecFiles {
-		if specFile.GetSpecType() != utils.AQL {
-			query, err := utils.CreateAqlBodyForSpecWithPattern(specFile)
-			if err != nil {
-				return nil, err
-			}
-			specFile.Aql = utils.Aql{ItemsFind: query}
+	for _, specFile := range releaseBundleParams.SpecFiles {
+		// Create AQL
+		aql, err := createAql(specFile)
+		if err != nil {
+			return nil, err
 		}
-		aql := utils.BuildQueryFromSpecFile(specFile, utils.NONE)
-		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql})
+
+		// Create added properties
+		addedProps, err := createAddedProps(&releaseBundleParams)
+		if err != nil {
+			return nil, err
+		}
+
+		// Append bundle query
+		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddedProps: addedProps})
 	}
 
 	// Create release bundle struct
 	releaseBundleBody := &ReleaseBundleBody{
 		DryRun:            dryRun,
-		SignImmediately:   createBundleParams.SignImmediately,
-		StoringRepository: createBundleParams.StoringRepository,
-		Description:       createBundleParams.Description,
+		SignImmediately:   releaseBundleParams.SignImmediately,
+		StoringRepository: releaseBundleParams.StoringRepository,
+		Description:       releaseBundleParams.Description,
 		BundleSpec: BundleSpec{
 			Queries: bundleQueries,
 		},
 	}
 
 	// Add relese notes if needed
-	if createBundleParams.ReleaseNotes != "" {
+	if releaseBundleParams.ReleaseNotes != "" {
 		releaseBundleBody.ReleaseNotes = &ReleaseNotes{
-			Syntax:  createBundleParams.ReleaseNotesSyntax,
-			Content: createBundleParams.ReleaseNotes,
+			Syntax:  releaseBundleParams.ReleaseNotesSyntax,
+			Content: releaseBundleParams.ReleaseNotes,
 		}
 	}
 	return releaseBundleBody, nil
+}
+
+// Create the AQL query from the input spec
+func createAql(specFile *utils.ArtifactoryCommonParams) (string, error) {
+	if specFile.GetSpecType() != utils.AQL {
+		query, err := utils.CreateAqlBodyForSpecWithPattern(specFile)
+		if err != nil {
+			return "", err
+		}
+		specFile.Aql = utils.Aql{ItemsFind: query}
+	}
+	return utils.BuildQueryFromSpecFile(specFile, utils.NONE), nil
+}
+
+// Create the AddedProps array from the input AddedProps string
+func createAddedProps(releaseBundleParams *ReleaseBundleParams) ([]AddedProps, error) {
+	props, err := utils.ParseProperties(releaseBundleParams.AddedProps, utils.SplitCommas)
+	if err != nil {
+		return nil, err
+	}
+
+	var addedProps []AddedProps
+	for key, values := range props.ToMap() {
+		addedProps = append(addedProps, AddedProps{key, values})
+	}
+	return addedProps, nil
 }
 
 func AddGpgPassphraseHeader(gpgPassphrase string, headers *map[string]string) {

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -30,8 +30,7 @@ func TestCreateBundleBody(t *testing.T) {
 
 func TestCreateBundleBodyQuery(t *testing.T) {
 	releaseBundleParam := ReleaseBundleParams{
-		SpecFiles:  []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*"}},
-		AddedProps: "a=b;c=d;c=e",
+		SpecFiles: []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*", AddedProps: "a=b;c=d;c=e"}},
 	}
 
 	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -30,7 +30,7 @@ func TestCreateBundleBody(t *testing.T) {
 
 func TestCreateBundleBodyQuery(t *testing.T) {
 	releaseBundleParam := ReleaseBundleParams{
-		SpecFiles: []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*", AddedProps: "a=b;c=d;c=e"}},
+		SpecFiles: []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*", AddProps: "a=b;c=d;c=e"}},
 	}
 
 	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
@@ -39,7 +39,7 @@ func TestCreateBundleBodyQuery(t *testing.T) {
 	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 1)
 	query := releaseBundleBody.BundleSpec.Queries[0]
 	assert.Contains(t, query.Aql, "dist-repo")
-	props := query.AddedProps
+	props := query.AddProps
 	assert.Len(t, props, 2)
 	for _, prop := range props {
 		switch prop.Key {

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateBundleBody(t *testing.T) {
+	releaseBundleParam := ReleaseBundleParams{
+		SignImmediately:    true,
+		StoringRepository:  "storing-repo",
+		Description:        "Release bundle description",
+		ReleaseNotes:       "Release notes",
+		ReleaseNotesSyntax: Asciidoc,
+	}
+
+	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, releaseBundleBody)
+	assert.Equal(t, true, releaseBundleBody.DryRun)
+	assert.Equal(t, true, releaseBundleBody.SignImmediately)
+	assert.Equal(t, "storing-repo", releaseBundleBody.StoringRepository)
+	assert.Equal(t, "Release bundle description", releaseBundleBody.Description)
+	assert.Equal(t, "Release notes", releaseBundleBody.ReleaseNotes.Content)
+	assert.Equal(t, ReleaseNotesSyntax(Asciidoc), releaseBundleBody.ReleaseNotes.Syntax)
+	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 0)
+}
+
+func TestCreateBundleBodyQuery(t *testing.T) {
+	releaseBundleParam := ReleaseBundleParams{
+		SpecFiles:  []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*"}},
+		AddedProps: "a=b;c=d;c=e",
+	}
+
+	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, releaseBundleBody)
+	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 1)
+	query := releaseBundleBody.BundleSpec.Queries[0]
+	assert.Contains(t, query.Aql, "dist-repo")
+	props := query.AddedProps
+	assert.Len(t, props, 2)
+	for _, prop := range props {
+		switch prop.Key {
+		case "a":
+			assert.Equal(t, []string{"b"}, prop.Values)
+		case "c":
+			assert.ElementsMatch(t, []string{"d", "e"}, prop.Values)
+		default:
+			assert.Fail(t, "Unexpected key "+prop.Key)
+		}
+	}
+}

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -30,7 +30,7 @@ func TestCreateBundleBody(t *testing.T) {
 
 func TestCreateBundleBodyQuery(t *testing.T) {
 	releaseBundleParam := ReleaseBundleParams{
-		SpecFiles: []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*", AddProps: "a=b;c=d;c=e"}},
+		SpecFiles: []*utils.ArtifactoryCommonParams{{Pattern: "dist-repo/*", TargetProps: "a=b;c=d;c=e"}},
 	}
 
 	releaseBundleBody, err := CreateBundleBody(releaseBundleParam, true)
@@ -39,7 +39,7 @@ func TestCreateBundleBodyQuery(t *testing.T) {
 	assert.Len(t, releaseBundleBody.BundleSpec.Queries, 1)
 	query := releaseBundleBody.BundleSpec.Queries[0]
 	assert.Contains(t, query.Aql, "dist-repo")
-	props := query.AddProps
+	props := query.AddedProps
 	assert.Len(t, props, 2)
 	for _, prop := range props {
 		switch prop.Key {

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -20,6 +20,11 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName string `json:"query_name,omitempty"`
-	Aql       string `json:"aql"`
+	QueryName  string       `json:"query_name,omitempty"`
+	Aql        string       `json:"aql"`
+	AddedProps []AddedProps `json:"added_props,omitempty"`
+}
+type AddedProps struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
 }

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -20,11 +20,11 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName string     `json:"query_name,omitempty"`
-	Aql       string     `json:"aql"`
-	AddProps  []AddProps `json:"added_props,omitempty"`
+	QueryName  string       `json:"query_name,omitempty"`
+	Aql        string       `json:"aql"`
+	AddedProps []AddedProps `json:"added_props,omitempty"`
 }
-type AddProps struct {
+type AddedProps struct {
 	Key    string   `json:"key"`
 	Values []string `json:"values"`
 }

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -20,11 +20,11 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName  string       `json:"query_name,omitempty"`
-	Aql        string       `json:"aql"`
-	AddedProps []AddedProps `json:"added_props,omitempty"`
+	QueryName string     `json:"query_name,omitempty"`
+	Aql       string     `json:"aql"`
+	AddProps  []AddProps `json:"added_props,omitempty"`
 }
-type AddedProps struct {
+type AddProps struct {
 	Key    string   `json:"key"`
 	Values []string `json:"values"`
 }

--- a/tests/artifactoryupload_test.go
+++ b/tests/artifactoryupload_test.go
@@ -253,7 +253,7 @@ func propsUpload(t *testing.T) {
 
 	pattern := FixWinPath(filepath.Join(workingDir, "out", "*"))
 	up := services.NewUploadParams()
-	up.ArtifactoryCommonParams = &utils.ArtifactoryCommonParams{Pattern: pattern, Target: RtTargetRepo, AddedProps: "key1=val1"}
+	up.ArtifactoryCommonParams = &utils.ArtifactoryCommonParams{Pattern: pattern, Target: RtTargetRepo, AddProps: "key1=val1"}
 	up.Flat = true
 	uploaded, failed, err := testsUploadService.UploadFiles(up)
 	if uploaded != 1 {

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -133,30 +133,30 @@ func createWithProps(t *testing.T) {
 	// Create release bundle with properties
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.SpecFiles = []*utils.ArtifactoryCommonParams{{
-		Pattern:  RtTargetRepo + "b.in",
-		AddProps: "key1=value1;key2=value2,value3",
+		Pattern:     RtTargetRepo + "b.in",
+		TargetProps: "key1=value1;key2=value2,value3",
 	}}
 	err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
 
 	// Check results
 	distributionResponse := getLocalBundle(t, bundleName, true)
-	addProps := distributionResponse.BundleSpec.Queries[0].AddProps
-	assert.Len(t, addProps, 2)
+	addedProps := distributionResponse.BundleSpec.Queries[0].AddedProps
+	assert.Len(t, addedProps, 2)
 
 	// Populate prop1Values and prop2Values
 	var prop1Values []string
 	var prop2Values []string
-	if addProps[0].Key == "key1" {
-		assert.Equal(t, "key2", addProps[1].Key)
-		prop1Values = addProps[0].Values
-		prop2Values = addProps[1].Values
-	} else if addProps[0].Key == "key2" {
-		assert.Equal(t, "key1", addProps[1].Key)
-		prop1Values = addProps[1].Values
-		prop2Values = addProps[0].Values
+	if addedProps[0].Key == "key1" {
+		assert.Equal(t, "key2", addedProps[1].Key)
+		prop1Values = addedProps[0].Values
+		prop2Values = addedProps[1].Values
+	} else if addedProps[0].Key == "key2" {
+		assert.Equal(t, "key1", addedProps[1].Key)
+		prop1Values = addedProps[1].Values
+		prop2Values = addedProps[0].Values
 	} else {
-		assert.Fail(t, "Unexpected key", addProps[0].Key)
+		assert.Fail(t, "Unexpected key", addedProps[0].Key)
 	}
 
 	// Check prop1Values and prop2Values

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -132,8 +132,10 @@ func createWithProps(t *testing.T) {
 
 	// Create release bundle with properties
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
-	createBundleParams.SpecFiles = []*utils.ArtifactoryCommonParams{{Pattern: RtTargetRepo + "b.in"}}
-	createBundleParams.AddedProps = "key1=value1;key2=value2,value3"
+	createBundleParams.SpecFiles = []*utils.ArtifactoryCommonParams{{
+		Pattern:    RtTargetRepo + "b.in",
+		AddedProps: "key1=value1;key2=value2,value3",
+	}}
 	err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
 

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -133,30 +133,30 @@ func createWithProps(t *testing.T) {
 	// Create release bundle with properties
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.SpecFiles = []*utils.ArtifactoryCommonParams{{
-		Pattern:    RtTargetRepo + "b.in",
-		AddedProps: "key1=value1;key2=value2,value3",
+		Pattern:  RtTargetRepo + "b.in",
+		AddProps: "key1=value1;key2=value2,value3",
 	}}
 	err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
 
 	// Check results
 	distributionResponse := getLocalBundle(t, bundleName, true)
-	addedProps := distributionResponse.BundleSpec.Queries[0].AddedProps
-	assert.Len(t, addedProps, 2)
+	addProps := distributionResponse.BundleSpec.Queries[0].AddProps
+	assert.Len(t, addProps, 2)
 
 	// Populate prop1Values and prop2Values
 	var prop1Values []string
 	var prop2Values []string
-	if addedProps[0].Key == "key1" {
-		assert.Equal(t, "key2", addedProps[1].Key)
-		prop1Values = addedProps[0].Values
-		prop2Values = addedProps[1].Values
-	} else if addedProps[0].Key == "key2" {
-		assert.Equal(t, "key1", addedProps[1].Key)
-		prop1Values = addedProps[1].Values
-		prop2Values = addedProps[0].Values
+	if addProps[0].Key == "key1" {
+		assert.Equal(t, "key2", addProps[1].Key)
+		prop1Values = addProps[0].Values
+		prop2Values = addProps[1].Values
+	} else if addProps[0].Key == "key2" {
+		assert.Equal(t, "key1", addProps[1].Key)
+		prop1Values = addProps[1].Values
+		prop2Values = addProps[0].Values
 	} else {
-		assert.Fail(t, "Unexpected key", addedProps[0].Key)
+		assert.Fail(t, "Unexpected key", addProps[0].Key)
 	}
 
 	// Check prop1Values and prop2Values

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -353,6 +353,13 @@ func SplitWithEscape(str string, separator rune) []string {
 	return parts
 }
 
+func AddProps(oldProps, additionalProps string) string {
+	if len(oldProps) > 0 && !strings.HasSuffix(oldProps, ";") && len(additionalProps) > 0 {
+		oldProps += ";"
+	}
+	return oldProps + additionalProps
+}
+
 func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Precondition for: https://github.com/jfrog/jfrog-cli/pull/959, https://github.com/jfrog/jfrog-cli-core/pull/60

Allow adding properties to a created/updated release bundle.
See added_props in https://www.jfrog.com/confluence/display/JFROG/Distribution+REST+API#DistributionRESTAPI-CreateReleaseBundleVersion.