### PR TITLE
Support path mapping in distibution commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,13 @@ params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
 params.TargetProps = "key1=val1;key2=val2,val3"
 
+// Artifact path mapping:
+// After distribution, the artifact "source-repo/a/123.zip" destination in the edge node will be "target-repo/a-123.zip".
+// The spec's pattern is a wildcard with capturing groups surrounded by parenthesis. 
+// Respectfully, the spec target's replacement groups surrounded by curly brackets.
+pathMappingSpec := &utils.ArtifactoryCommonParams{Pattern: "source-repo/(a)/(*.zip)", Target: "target-repo/{1}-{2}"}
+params.SpecFiles = append(params.SpecFiles, pathMappingSpec)
+
 err := distManager.CreateReleaseBundle(params)
 ```
 
@@ -816,6 +823,13 @@ params.Description = "New Description"
 params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"
 params.TargetProps = "key1=val1;key2=val2,val3"
+
+// Artifact path mapping:
+// After distribution, the artifact "source-repo/a/123.zip" destination in the edge node will be "target-repo/a-123.zip".
+// The spec's pattern is a wildcard with capturing groups surrounded by parenthesis. 
+// Respectfully, the spec target's replacement groups surrounded by curly brackets.
+pathMappingSpec := &utils.ArtifactoryCommonParams{Pattern: "source-repo/(a)/(*.zip)", Target: "target-repo/{1}-{2}"}
+params.SpecFiles = append(params.SpecFiles, pathMappingSpec)
 
 err := distManager.CreateReleaseBundle(params)
 ```

--- a/README.md
+++ b/README.md
@@ -805,10 +805,15 @@ params.ReleaseNotes = "Release notes"
 params.ReleaseNotesSyntax = "plain_text"
 params.TargetProps = "key1=val1;key2=val2,val3"
 
-// Artifact path mapping:
-// After distribution, the artifact "source-repo/a/123.zip" destination in the edge node will be "target-repo/a-123.zip".
-// The spec's pattern is a wildcard with capturing groups surrounded by parenthesis. 
-// Respectfully, the spec target's replacement groups surrounded by curly brackets.
+// Be default, artifacts that are distributed as part of a release bundle, have the same path in their destination server
+// (the edge node) as the path they had on the distributing Artifactory server.
+// You have however the option for modifying the target path on edge node. You do this by defining the Target property as shown below.
+// The Pattern property is a wildcard based pattern. Any wildcards enclosed in parenthesis in the pattern (source)
+// path can be matched with a corresponding placeholder in the target path, to determine the path and name
+// of the artifact, once distributed to the edge node.
+// In the following example, the path in the edge node is similar to the path in the source Artifactory server, except for the additional "dir" level at the root of the repository.
+// Pattern: my-repo/(*)/a.zip
+// Target: my-repo/dir/{1}/a.zip
 pathMappingSpec := &utils.ArtifactoryCommonParams{Pattern: "source-repo/(a)/(*.zip)", Target: "target-repo/{1}-{2}"}
 params.SpecFiles = append(params.SpecFiles, pathMappingSpec)
 
@@ -824,10 +829,8 @@ params.ReleaseNotes = "New Release notes"
 params.ReleaseNotesSyntax = "plain_text"
 params.TargetProps = "key1=val1;key2=val2,val3"
 
-// Artifact path mapping:
-// After distribution, the artifact "source-repo/a/123.zip" destination in the edge node will be "target-repo/a-123.zip".
-// The spec's pattern is a wildcard with capturing groups surrounded by parenthesis. 
-// Respectfully, the spec target's replacement groups surrounded by curly brackets.
+// The Target property defines the target path in the edge node, and can include replaceable in the form of {1}, {2}, ...
+// Read more about it in the above "Creating a Release Bundle" section.
 pathMappingSpec := &utils.ArtifactoryCommonParams{Pattern: "source-repo/(a)/(*.zip)", Target: "target-repo/{1}-{2}"}
 params.SpecFiles = append(params.SpecFiles, pathMappingSpec)
 

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -100,10 +100,10 @@ func createPathMappings(specFile *rtUtils.ArtifactoryCommonParams) []PathMapping
 
 	// Convert the file spec pattern and target to match the path mapping input and output specifications, respectfully.
 	return []PathMapping{{
-		// The file spec pattern is wildcard. Convert it to Regex:
+		// The file spec pattern is wildcard based. Convert it to Regex:
 		Input: utils.PathToRegExp(specFile.Pattern),
 		// The file spec target contain placeholders-style matching groups, like {1}.
-		// Convert it to Regex-style matching groups, like $1.
+		// Convert it to REST API's matching groups style, like $1.
 		Output: fileSpecCaptureGroup.ReplaceAllStringFunc(specFile.Target, func(s string) string {
 			// Remove curly parenthesis and prepend $
 			return "$" + s[1:2]

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"regexp"
+
+	rtUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils"
 )
 
 type ReleaseNotesSyntax string
@@ -12,8 +15,10 @@ const (
 	PlainText                    = "plain_text"
 )
 
+var fileSpecCaptureGroup = regexp.MustCompile("({\\d})")
+
 type ReleaseBundleParams struct {
-	SpecFiles          []*utils.ArtifactoryCommonParams
+	SpecFiles          []*rtUtils.ArtifactoryCommonParams
 	Name               string
 	Version            string
 	SignImmediately    bool
@@ -41,6 +46,9 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 			return nil, err
 		}
 
+		// Create path mapping
+		pathMappings := createPathMappings(specFile)
+
 		// Create added properties
 		addedProps, err := createAddedProps(specFile)
 		if err != nil {
@@ -48,7 +56,7 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 		}
 
 		// Append bundle query
-		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, AddedProps: addedProps})
+		bundleQueries = append(bundleQueries, BundleQuery{Aql: aql, PathMappings: pathMappings, AddedProps: addedProps})
 	}
 
 	// Create release bundle struct
@@ -73,20 +81,39 @@ func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*Re
 }
 
 // Create the AQL query from the input spec
-func createAql(specFile *utils.ArtifactoryCommonParams) (string, error) {
-	if specFile.GetSpecType() != utils.AQL {
-		query, err := utils.CreateAqlBodyForSpecWithPattern(specFile)
+func createAql(specFile *rtUtils.ArtifactoryCommonParams) (string, error) {
+	if specFile.GetSpecType() != rtUtils.AQL {
+		query, err := rtUtils.CreateAqlBodyForSpecWithPattern(specFile)
 		if err != nil {
 			return "", err
 		}
-		specFile.Aql = utils.Aql{ItemsFind: query}
+		specFile.Aql = rtUtils.Aql{ItemsFind: query}
 	}
-	return utils.BuildQueryFromSpecFile(specFile, utils.NONE), nil
+	return rtUtils.BuildQueryFromSpecFile(specFile, rtUtils.NONE), nil
+}
+
+// Creat the path mapping from the input spec
+func createPathMappings(specFile *rtUtils.ArtifactoryCommonParams) []PathMapping {
+	if len(specFile.Target) == 0 {
+		return []PathMapping{}
+	}
+
+	// Convert the file spec pattern and target to match the path mapping input and output specifications, respectfully.
+	return []PathMapping{{
+		// The file spec pattern is wildcard. Convert it to Regex:
+		Input: utils.PathToRegExp(specFile.Pattern),
+		// The file spec target contain placeholders-style matching groups, like {1}.
+		// Convert it to Regex-style matching groups, like $1.
+		Output: fileSpecCaptureGroup.ReplaceAllStringFunc(specFile.Target, func(s string) string {
+			// Remove curly parenthesis and prepend $
+			return "$" + s[1:2]
+		}),
+	}}
 }
 
 // Create the AddedProps array from the input TargetProps string
-func createAddedProps(specFile *utils.ArtifactoryCommonParams) ([]AddedProps, error) {
-	props, err := utils.ParseProperties(specFile.TargetProps, utils.SplitCommas)
+func createAddedProps(specFile *rtUtils.ArtifactoryCommonParams) ([]AddedProps, error) {
+	props, err := rtUtils.ParseProperties(specFile.TargetProps, rtUtils.SplitCommas)
 	if err != nil {
 		return nil, err
 	}
@@ -100,6 +127,6 @@ func createAddedProps(specFile *utils.ArtifactoryCommonParams) ([]AddedProps, er
 
 func AddGpgPassphraseHeader(gpgPassphrase string, headers *map[string]string) {
 	if gpgPassphrase != "" {
-		utils.AddHeader("X-GPG-PASSPHRASE", gpgPassphrase, headers)
+		rtUtils.AddHeader("X-GPG-PASSPHRASE", gpgPassphrase, headers)
 	}
 }

--- a/distribution/services/utils/distributionutils_test.go
+++ b/distribution/services/utils/distributionutils_test.go
@@ -52,3 +52,37 @@ func TestCreateBundleBodyQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestCreatePathMappings(t *testing.T) {
+	tests := []struct {
+		specPattern           string
+		specTarget            string
+		expectedMappingInput  string
+		expectedMappingOutput string
+	}{
+		{"", "", "", ""},
+		{"repo/path/file.in", "", "", ""},
+		{"a/b/c", "a/b/x", "^a/b/c$", "a/b/x"},
+		{"a/(b)/c", "a/d/c", "^a/b/c$", "a/d/c"},
+		{"a/(*)/c", "a/d/c", "^a/b/c$", "a/d/c"},
+		{"a/(b)/c", "a/(d)/c", "^a/(b)/c$", "a/(d)/c"},
+		{"a/(b)/c", "a/b/c/{1}", "^a/(b)/c$", "a/b/c/$1"},
+		{"a/(b)/(c)", "a/b/c/{1}/{2}", "^a/(b)/(c)$", "a/b/c/$1/$2"},
+		{"a/(b)/(c)", "a/b/c/{2}/{1}", "^a/(b)/(c)$", "a/b/c/$2/$1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.specPattern, func(t *testing.T) {
+			specFile := &utils.ArtifactoryCommonParams{Pattern: test.specPattern, Target: test.specTarget}
+			pathMappings := createPathMappings(specFile)
+			if test.expectedMappingInput == "" {
+				assert.Empty(t, pathMappings)
+				return
+			}
+			assert.Len(t, pathMappings, 1)
+			actualPathMapping := pathMappings[0]
+			assert.Equal(t, test.expectedMappingInput, actualPathMapping.Input)
+			assert.Equal(t, test.expectedMappingOutput, actualPathMapping.Output)
+		})
+	}
+}

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -20,10 +20,17 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName  string       `json:"query_name,omitempty"`
-	Aql        string       `json:"aql"`
-	AddedProps []AddedProps `json:"added_props,omitempty"`
+	QueryName    string        `json:"query_name,omitempty"`
+	Aql          string        `json:"aql"`
+	PathMappings []PathMapping `json:"mappings,omitempty"`
+	AddedProps   []AddedProps  `json:"added_props,omitempty"`
 }
+
+type PathMapping struct {
+	Input  string `json:"input"`
+	Output string `json:"output"`
+}
+
 type AddedProps struct {
 	Key    string   `json:"key"`
 	Values []string `json:"values"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -169,7 +169,7 @@ func PrepareLocalPathForUpload(localPath string, useRegExp bool) string {
 		localPath = localPath[3:]
 	}
 	if !useRegExp {
-		localPath = pathToRegExp(cleanPath(localPath))
+		localPath = PathToRegExp(cleanPath(localPath))
 	}
 	return localPath
 }
@@ -186,7 +186,7 @@ func cleanPath(path string) string {
 	return path
 }
 
-func pathToRegExp(localPath string) string {
+func PathToRegExp(localPath string) string {
 	var SPECIAL_CHARS = []string{".", "^", "$", "+"}
 	for _, char := range SPECIAL_CHARS {
 		localPath = strings.Replace(localPath, char, "\\"+char, -1)
@@ -216,7 +216,7 @@ func BuildTargetPath(pattern, path, target string, ignoreRepo bool) (string, err
 		path = removeRepoFromPath(path)
 	}
 	pattern = addEscapingParentheses(pattern, target)
-	pattern = pathToRegExp(pattern)
+	pattern = PathToRegExp(pattern)
 	if slashIndex < 0 {
 		// If '/' doesn't exist, add an optional trailing-slash to support cases in which the provided pattern
 		// is only the repository name.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add support for Distribution path mapping.

File spec schema:
```json
{
  "files": [
    {
      "pattern": "[Mandatory] Wildcard pattern match files in the source artifactory",
      "target": "[Optinal] Path in the edge node"
    }
  ]
}

```

The support is builtin in the file spec. When Target is provided, then the path mapping is activated. Artifacts matched in the Pattern will be mapped to the Target after distribution.
To complete the picture, placeholders will be used. The pattern can include capture groups surrounded by parenthesis and the target can include target groups surrounded by curly brackets.

Comparing to the REST API of the [CreateReleaseBundle](https://www.jfrog.com/confluence/display/JFROG/Distribution+REST+API#DistributionRESTAPI-CreateReleaseBundleVersion), there are 2 differences:
1. The pattern is a wildcard and not Regex.
2. The target matching group is the same as [placeholders](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UsingPlaceholders) `{1}`, instead of as Regex `$1`.

### Examples:

---

Example 1:
```go
Pattern: "repo/dir/a.zip"
Target: "repo/dir/b.zip"
```
`repo/dir/a.zip` will be distributed to `repo/dir/b.zip` in the edge node.

---

Example 2:
```go
Pattern: "source-repo/(*)"
Target: "target-repo/{1}"
```
All artifacts at `source-repo` will be distributed to `target-repo`.

---

Example 3:
```go
Pattern: "source-repo/(a)/(*.zip)"
Target: "target-repo/{1}-{2}"
```
For example, an artifact `source-repo/a/bla.zip` will be distributed to `target-repo/a-bla.zip`