### PR TITLE
Support Xray policy and build indexing APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Optional flags:
 | `-rt.url`           | [Default: http://localhost:8081/artifactory] Artifactory URL.                                          |
 | `-rt.user`          | [Default: admin] Artifactory username.                                                                 |
 | `-rt.password`      | [Default: password] Artifactory password.                                                              |
-| `-rt.distUrl`       | [Optional] JFrog Distribution URL.                                                                     |
-| `-rt.xrayUrl`       | [Optional] JFrog Xray URL.                                                                     |
+| `-ds.url`           | [Optional] JFrog Distribution URL.                                                                     |
+| `-xr.url`           | [Optional] JFrog Xray URL.                                                                             |
 | `-rt.apikey`        | [Optional] Artifactory API key.                                                                        |
 | `-rt.sshKeyPath`    | [Optional] Ssh key file path. Should be used only if the Artifactory URL format is ssh://[domain]:port |
 | `-rt.sshPassphrase` | [Optional] Ssh key passphrase.                                                                         |
@@ -1344,7 +1344,7 @@ params.Rules = []utils.PolicyRule{
 		},
 	},
 }
-resp, err := xrayManager.CreatePolicy(params)
+err := xrayManager.CreatePolicy(params)
 ```
 
 #### Creating a License Xray Policy
@@ -1365,29 +1365,29 @@ params.Rules = []utils.PolicyRule{
 		Priority: 2,
 	},
 }
-resp, err := xrayManager.CreatePolicy(params)
+err := xrayManager.CreatePolicy(params)
 ```
 
 #### Get an Xray Policy
 ```go
-policy, resp, err := xrayManager.GetPolicy("example-policy")
+policy, err := xrayManager.GetPolicy("example-policy")
 ```
 
 #### Update an Xray Policy
 ```go
-policy, resp, err := xrayManager.GetPolicy("example-policy")
+policy, err := xrayManager.GetPolicy("example-policy")
 policy.Description = "Updated description"
 
-resp, err := xrayManager.UpdatePolicy(*policy)
+err := xrayManager.UpdatePolicy(*policy)
 ```
 
 #### Delete an Xray Policy
 ```go
-resp, err := xrayManager.DeletePolicy("example-policy")
+err := xrayManager.DeletePolicy("example-policy")
 ```
 
 #### Add builds to indexing configuration
 ```go
 buildsToIndex := []string{"buildName1", "buildName2"}
-resp, err := xrayManager.AddBuildsToIndexing(buildsToIndex)
+err := xrayManager.AddBuildsToIndexing(buildsToIndex)
 ```

--- a/README.md
+++ b/README.md
@@ -1293,25 +1293,25 @@ params.Policies = []utils.AssignedPolicy{
   },
 }
 
-resp, err := xrayManager.CreateWatch(*params)
+err := xrayManager.CreateWatch(*params)
 ```
 
 #### Get an Xray Watch
 ```go
-watch, resp, err := xrayManager.GetWatch("example-watch-all")
+watch, err := xrayManager.GetWatch("example-watch-all")
 ```
 
 #### Update an Xray Watch
 ```go
-watch, resp, err := xrayManager.GetWatch("example-watch-all")
+watch, err := xrayManager.GetWatch("example-watch-all")
 watch.Description = "Updated description"
 
-resp, err := xrayManager.UpdateWatch(*watch)
+err := xrayManager.UpdateWatch(*watch)
 ```
 
 #### Delete an Xray Watch
 ```go
-resp, err := xrayManager.DeleteWatch("example-watch-all")
+err := xrayManager.DeleteWatch("example-watch-all")
 ```
 
 #### Creating a Security Xray Policy

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
       - [Creating a License Xray Policy](#creating-a-license-xray-policy)
       - [Update an Xray Policy](#update-an-xray-policy)
       - [Delete an Xray Policy](#delete-an-xray-policy)
+      - [Add builds to indexing configuration](#add-builds-to-indexing-configuration)
 
 ## General
 _jfrog-client-go_ is a library which provides Go APIs to performs actions on JFrog Artifactory or Bintray from your Go application.
@@ -1383,4 +1384,10 @@ resp, err := xrayManager.UpdatePolicy(*policy)
 #### Delete an Xray Policy
 ```go
 resp, err := xrayManager.DeletePolicy("example-policy")
+```
+
+#### Add builds to indexing configuration
+```go
+buildsToIndex := []string{"buildName1", "buildName2"}
+resp, err := xrayManager.AddBuildsToIndexing(buildsToIndex)
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
       go vet -v ./...
   - CLIENT_TESTS:
     TEST_SUIT:
-      go test -v github.com\jfrog\jfrog-client-go\tests --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%" --rt.distUrl="%JFROG_CLI_DIST_URL%" --rt.xrayUrl=%JFROG_CLI_XRAY_URL%
+      go test -v github.com\jfrog\jfrog-client-go\tests --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%" --ds.url="%JFROG_CLI_DIST_URL%" --xr.url=%JFROG_CLI_XRAY_URL%
 
 test_script:
   - "%TEST_SUIT%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,8 @@ environment:
     secure: Um8o75MQIieSavIemF4ySA==
   JFROG_CLI_DIST_URL:
     secure: RIh0gGFDn2JAnLUEEqLsQrfLmtDrzDd5Qphea4gOE0Lu1Uz2Xa/y+D0Mld917gwy
+  JFROG_CLI_XRAY_URL:
+    secure: RIh0gGFDn2JAnLUEEqLsQnYytsZwN5ZAIw+0CHigBR3DTUVTl3QVus6IjkdAiFd1
 
   matrix:
   - VET:
@@ -24,7 +26,7 @@ environment:
       go vet -v ./...
   - CLIENT_TESTS:
     TEST_SUIT:
-      go test -v github.com\jfrog\jfrog-client-go\tests --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%" --rt.distUrl="%JFROG_CLI_DIST_URL%"
+      go test -v github.com\jfrog\jfrog-client-go\tests --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%" --rt.distUrl="%JFROG_CLI_DIST_URL%" --rt.xrayUrl=%JFROG_CLI_XRAY_URL%
 
 test_script:
   - "%TEST_SUIT%"

--- a/tests/jfrogclient_test.go
+++ b/tests/jfrogclient_test.go
@@ -45,6 +45,7 @@ func InitServiceManagers() {
 	createArtifactoryPermissionTargetManager()
 	createArtifactoryUserManager()
 	createArtifactoryGroupManager()
+	createArtifactoryBuildInfoManager()
 
 	if *DistUrl != "" {
 		createDistributionManager()
@@ -53,6 +54,7 @@ func InitServiceManagers() {
 		createXrayVersionManager()
 		createXrayWatchManager()
 		createXrayPolicyManager()
+		createXrayBinMgrManager()
 	}
 	createReposIfNeeded()
 }

--- a/tests/jfrogclient_test.go
+++ b/tests/jfrogclient_test.go
@@ -52,6 +52,7 @@ func InitServiceManagers() {
 	if *XrayUrl != "" {
 		createXrayVersionManager()
 		createXrayWatchManager()
+		createXrayPolicyManager()
 	}
 	createReposIfNeeded()
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -78,6 +78,7 @@ var testsBundleDeleteRemoteService *distributionServices.DeleteReleaseBundleServ
 // Xray Services
 var testsXrayVersionService *xrayServices.VersionService
 var testsXrayWatchService *xrayServices.WatchService
+var testsXrayPolicyService *xrayServices.PolicyService
 
 var timestamp = time.Now().Unix()
 var trueValue = true
@@ -297,11 +298,19 @@ func createArtifactoryPermissionTargetManager() {
 }
 
 func createXrayWatchManager() {
-	XrayDetails := GetXrayDetails()
-	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&XrayDetails).Build()
+	xrayDetails := GetXrayDetails()
+	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&xrayDetails).Build()
 	failOnHttpClientCreation(err)
 	testsXrayWatchService = xrayServices.NewWatchService(client)
-	testsXrayWatchService.XrayDetails = XrayDetails
+	testsXrayWatchService.XrayDetails = xrayDetails
+}
+
+func createXrayPolicyManager() {
+	xrayDetails := GetXrayDetails()
+	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&xrayDetails).Build()
+	failOnHttpClientCreation(err)
+	testsXrayPolicyService = xrayServices.NewPolicyService(client)
+	testsXrayPolicyService.XrayDetails = xrayDetails
 }
 
 func failOnHttpClientCreation(err error) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -97,8 +97,8 @@ const (
 
 func init() {
 	RtUrl = flag.String("rt.url", "http://localhost:8081/artifactory/", "Artifactory url")
-	DistUrl = flag.String("rt.distUrl", "", "Distribution url")
-	XrayUrl = flag.String("rt.xrayUrl", "", "Xray url")
+	DistUrl = flag.String("ds.url", "", "Distribution url")
+	XrayUrl = flag.String("xr.url", "", "Xray url")
 	RtUser = flag.String("rt.user", "admin", "Artifactory username")
 	RtPassword = flag.String("rt.password", "password", "Artifactory password")
 	RtApiKey = flag.String("rt.apikey", "", "Artifactory user API key")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils/tests"
 
 	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
@@ -64,6 +65,7 @@ var testsReplicationDeleteService *services.DeleteReplicationService
 var testsPermissionTargetService *services.PermissionTargetService
 var testUserService *services.UserService
 var testGroupService *services.GroupService
+var testBuildInfoService *services.BuildInfoService
 
 // Distribution services
 var testsBundleSetSigningKeyService *distributionServices.SetSigningKeyService
@@ -79,6 +81,7 @@ var testsBundleDeleteRemoteService *distributionServices.DeleteReleaseBundleServ
 var testsXrayVersionService *xrayServices.VersionService
 var testsXrayWatchService *xrayServices.WatchService
 var testsXrayPolicyService *xrayServices.PolicyService
+var testXrayBinMgrService *xrayServices.BinMgrService
 
 var timestamp = time.Now().Unix()
 var trueValue = true
@@ -154,6 +157,15 @@ func createArtifactoryGroupManager() {
 	testGroupService = services.NewGroupService(client)
 	testGroupService.ArtDetails = artDetails
 }
+
+func createArtifactoryBuildInfoManager() {
+	artDetails := GetRtDetails()
+	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&artDetails).Build()
+	failOnHttpClientCreation(err)
+	testBuildInfoService = services.NewBuildInfoService(client)
+	testBuildInfoService.ArtDetails = artDetails
+}
+
 func createArtifactoryDownloadManager() {
 	artDetails := GetRtDetails()
 	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&artDetails).Build()
@@ -311,6 +323,14 @@ func createXrayPolicyManager() {
 	failOnHttpClientCreation(err)
 	testsXrayPolicyService = xrayServices.NewPolicyService(client)
 	testsXrayPolicyService.XrayDetails = xrayDetails
+}
+
+func createXrayBinMgrManager() {
+	XrayDetails := GetXrayDetails()
+	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&XrayDetails).Build()
+	failOnHttpClientCreation(err)
+	testXrayBinMgrService = xrayServices.NewBinMgrService(client)
+	testXrayBinMgrService.XrayDetails = XrayDetails
 }
 
 func failOnHttpClientCreation(err error) {
@@ -579,4 +599,128 @@ func getAllRepos(t *testing.T) *[]services.RepositoryDetails {
 	data, err := testsGetRepositoryService.GetAll()
 	assert.NoError(t, err, "Failed to get all repositories details")
 	return data
+}
+
+func createDummyBuild(buildName string) error {
+	dataArtifactoryBuild := &buildinfo.BuildInfo{
+		Name:    buildName,
+		Number:  "1.0.0",
+		Started: "2014-09-30T12:00:19.893+0300",
+		Modules: []buildinfo.Module{{
+			Id: "example-module",
+			Artifacts: []buildinfo.Artifact{
+				{
+					Type: "gz",
+					Name: "c.tar.gz",
+					Checksum: &buildinfo.Checksum{
+						Sha1: "9d4336ff7bc2d2348aee4e27ad55e42110df4a80",
+						Md5:  "b4918187cc9b3bf1b0772546d9398d7d",
+					},
+				},
+			},
+		}},
+	}
+	return testBuildInfoService.PublishBuildInfo(dataArtifactoryBuild)
+}
+
+func deleteBuild(buildName string) error {
+	err := deleteBuildIndex(buildName)
+	if err != nil {
+		return err
+	}
+
+	artDetails := GetRtDetails()
+	artHTTPDetails := artDetails.CreateHttpClientDetails()
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.SendDelete(artDetails.GetUrl()+"api/build/"+buildName+"?deleteAll=1", nil, artHTTPDetails)
+
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("failed to delete build " + resp.Status)
+	}
+
+	return nil
+}
+
+func getIndexedBuilds() ([]string, error) {
+	xrayDetails := GetXrayDetails()
+	artHTTPDetails := xrayDetails.CreateHttpClientDetails()
+	utils.SetContentType("application/json", &artHTTPDetails.Headers)
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return []string{}, err
+	}
+
+	resp, body, _, err := client.SendGet(xrayDetails.GetUrl()+"api/v1/binMgr/default/builds", true, artHTTPDetails)
+	if err != nil {
+		return []string{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return []string{}, errors.New("failed to get build index " + resp.Status)
+	}
+
+	response := &indexedBuildsPayload{}
+	err = json.Unmarshal(body, response)
+	if err != nil {
+		return []string{}, err
+	}
+
+	return response.IndexedBuilds, nil
+}
+
+func deleteBuildIndex(buildName string) error {
+	// Prepare new indexed builds list
+	indexedBuilds, err := getIndexedBuilds()
+	if err != nil {
+		return err
+	}
+	buildIndex := indexOf(buildName, indexedBuilds)
+	if buildIndex == -1 {
+		// Build indexing does not exist
+		return nil
+	}
+	indexedBuilds = append(indexedBuilds[:buildIndex], indexedBuilds[buildIndex+1:]...)
+
+	// Delete build index
+	xrayDetails := GetXrayDetails()
+	artHTTPDetails := xrayDetails.CreateHttpClientDetails()
+	utils.SetContentType("application/json", &artHTTPDetails.Headers)
+	client, err := httpclient.ClientBuilder().Build()
+	if err != nil {
+		return err
+	}
+
+	dataIndexBuild := indexedBuildsPayload{IndexedBuilds: indexedBuilds}
+	requestContentIndexBuild, err := json.Marshal(dataIndexBuild)
+
+	resp, _, err := client.SendPut(xrayDetails.GetUrl()+"api/v1/binMgr/default/builds", requestContentIndexBuild, artHTTPDetails)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("failed to delete build index " + resp.Status)
+	}
+
+	return nil
+}
+
+func indexOf(element string, data []string) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1
+}
+
+type indexedBuildsPayload struct {
+	BinMgrId         string   `json:"bin_mgr_id,omitempty"`
+	IndexedBuilds    []string `json:"indexed_builds"`
+	NonIndexedBuilds []string `json:"non_indexed_builds,omitempty"`
 }

--- a/tests/xraybinmgr_test.go
+++ b/tests/xraybinmgr_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXrayBinMgr(t *testing.T) {
+	if *XrayUrl == "" {
+		t.Skip("Xray is not being tested, skipping...")
+	}
+
+	t.Run("addBuildsToIndexing", addBuildsToIndexing)
+}
+
+func addBuildsToIndexing(t *testing.T) {
+	buildName := fmt.Sprintf("%s-%d", "jfrog-build1", time.Now().Unix())
+	defer deleteBuild(buildName)
+
+	// Create a build
+	err := createDummyBuild(buildName)
+	assert.NoError(t, err)
+
+	// Index build
+	_, err = testXrayBinMgrService.AddBuildsToIndexing([]string{buildName})
+	assert.NoError(t, err)
+
+	// Assert build contained in the indexed build list
+	indexedBuilds, err := getIndexedBuilds()
+	assert.NoError(t, err)
+	assert.Contains(t, indexedBuilds, buildName)
+}

--- a/tests/xraybinmgr_test.go
+++ b/tests/xraybinmgr_test.go
@@ -25,7 +25,7 @@ func addBuildsToIndexing(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Index build
-	_, err = testXrayBinMgrService.AddBuildsToIndexing([]string{buildName})
+	err = testXrayBinMgrService.AddBuildsToIndexing([]string{buildName})
 	assert.NoError(t, err)
 
 	// Assert build contained in the indexed build list

--- a/tests/xraypolicy_test.go
+++ b/tests/xraypolicy_test.go
@@ -1,0 +1,195 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/xray/services/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXrayPolicy(t *testing.T) {
+	if *XrayUrl == "" {
+		t.Skip("Xray is not being tested, skipping...")
+	}
+
+	t.Run("createMinSeverity", createMinSeverity)
+	t.Run("createRangeSeverity", createRangeSeverity)
+	t.Run("createLicenseAllowed", createLicenseAllowed)
+	t.Run("createLicenseBanned", createLicenseBanned)
+	t.Run("create2Priorities", create2Priorities)
+	t.Run("createPolicyActions", createPolicyActions)
+	t.Run("createUpdatePolicy", createUpdatePolicy)
+}
+
+func initXrayPolicyTest(t *testing.T, policyName string) string {
+	testsXrayPolicyService.Delete(policyName)
+	return policyName
+}
+
+func deletePolicy(t *testing.T, policyName string) {
+	_, err := testsXrayPolicyService.Delete(policyName)
+	assert.NoError(t, err)
+}
+
+func createMinSeverity(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-min-severity")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "min-severity",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.Low),
+		Priority: 1,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.Security, policyRule)
+}
+
+func createRangeSeverity(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-range-severity")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "range-severity",
+		Criteria: *utils.CreateCvssRangePolicyCriteria(3.4, 5.6),
+		Priority: 1,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.Security, policyRule)
+}
+
+func createLicenseAllowed(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-allowed-licenses")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "allowed-licenses",
+		Criteria: *utils.CreateLicensePolicyCriteria(true, true, true, "MIT", "Apache-2.0"),
+		Priority: 1,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.License, policyRule)
+}
+
+func createLicenseBanned(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-banned-licenses")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "banned-licenses",
+		Criteria: *utils.CreateLicensePolicyCriteria(false, true, true, "MIT", "Apache-2.0"),
+		Priority: 1,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.License, policyRule)
+}
+
+func create2Priorities(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-2-priorties")
+	defer deletePolicy(t, policyName)
+
+	policyRule1 := utils.PolicyRule{
+		Name:     "priority-1",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.Low),
+		Priority: 1,
+	}
+	policyRule2 := utils.PolicyRule{
+		Name:     "priority-2",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.Medium),
+		Priority: 2,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.Security, policyRule1, policyRule2)
+}
+
+func createPolicyActions(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "create-policy-actions")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "policy-actions",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.High),
+		Priority: 1,
+		Actions: &utils.PolicyAction{
+			BlockDownload: utils.PolicyBlockDownload{
+				Active:    true,
+				Unscanned: true,
+			},
+			BlockReleaseBundleDistribution: true,
+			FailBuild:                      true,
+			NotifyDeployer:                 true,
+			NotifyWatchRecipients:          true,
+			CustomSeverity:                 utils.Information,
+		},
+	}
+	createAndCheckPolicy(t, policyName, true, utils.Security, policyRule)
+}
+
+func createUpdatePolicy(t *testing.T) {
+	policyName := initXrayPolicyTest(t, "update-policy")
+	defer deletePolicy(t, policyName)
+
+	policyRule := utils.PolicyRule{
+		Name:     "low-severity",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.Low),
+		Priority: 1,
+	}
+	createAndCheckPolicy(t, policyName, true, utils.Security, policyRule)
+
+	policyRule = utils.PolicyRule{
+		Name:     "medium-severity",
+		Criteria: *utils.CreateSeverityPolicyCriteria(utils.Medium),
+		Priority: 1,
+	}
+
+	createAndCheckPolicy(t, policyName, false, utils.Security, policyRule)
+}
+
+func createPolicy(t *testing.T, policyName string, policyType utils.PolicyType, policyRules ...utils.PolicyRule) *utils.PolicyParams {
+	policyParams := utils.PolicyParams{
+		Name:        policyName,
+		Type:        policyType,
+		Description: "crate-policy-description",
+		Rules:       policyRules,
+	}
+	_, err := testsXrayPolicyService.Create(policyParams)
+	assert.NoError(t, err)
+	return &policyParams
+}
+
+func updatePolicy(t *testing.T, policyName string, policyType utils.PolicyType, policyRules ...utils.PolicyRule) *utils.PolicyParams {
+	policyParams := utils.PolicyParams{
+		Name:        policyName,
+		Type:        policyType,
+		Description: "update-policy-description",
+		Rules:       policyRules,
+	}
+	_, err := testsXrayPolicyService.Update(policyParams)
+	assert.NoError(t, err)
+	return &policyParams
+}
+
+func createAndCheckPolicy(t *testing.T, policyName string, create bool, policyType utils.PolicyType, policyRules ...utils.PolicyRule) {
+	var expected *utils.PolicyParams
+	if create {
+		expected = createPolicy(t, policyName, policyType, policyRules...)
+	} else {
+		expected = updatePolicy(t, policyName, policyType, policyRules...)
+	}
+
+	// Get policy
+	actual, _, err := testsXrayPolicyService.Get(policyName)
+	assert.NoError(t, err)
+
+	// Compare general policy details
+	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, expected.Type, actual.Type)
+	assert.Equal(t, expected.Description, actual.Description)
+
+	// Compare rules
+	assert.Len(t, actual.Rules, len(expected.Rules))
+	for i, expectedRule := range expected.Rules {
+		actualRule := actual.Rules[i]
+		assert.Equal(t, expectedRule.Name, actualRule.Name)
+		assert.Equal(t, expectedRule.Priority, actualRule.Priority)
+		assert.Equal(t, expectedRule.Criteria, actualRule.Criteria)
+		if expectedRule.Actions != nil {
+			assert.Equal(t, expectedRule.Actions, actualRule.Actions)
+		}
+	}
+
+}

--- a/tests/xraypolicy_test.go
+++ b/tests/xraypolicy_test.go
@@ -27,7 +27,7 @@ func initXrayPolicyTest(t *testing.T, policyName string) string {
 }
 
 func deletePolicy(t *testing.T, policyName string) {
-	_, err := testsXrayPolicyService.Delete(policyName)
+	err := testsXrayPolicyService.Delete(policyName)
 	assert.NoError(t, err)
 }
 
@@ -146,7 +146,7 @@ func createPolicy(t *testing.T, policyName string, policyType utils.PolicyType, 
 		Description: "crate-policy-description",
 		Rules:       policyRules,
 	}
-	_, err := testsXrayPolicyService.Create(policyParams)
+	err := testsXrayPolicyService.Create(policyParams)
 	assert.NoError(t, err)
 	return &policyParams
 }
@@ -158,7 +158,7 @@ func updatePolicy(t *testing.T, policyName string, policyType utils.PolicyType, 
 		Description: "update-policy-description",
 		Rules:       policyRules,
 	}
-	_, err := testsXrayPolicyService.Update(policyParams)
+	err := testsXrayPolicyService.Update(policyParams)
 	assert.NoError(t, err)
 	return &policyParams
 }
@@ -172,7 +172,7 @@ func createAndCheckPolicy(t *testing.T, policyName string, create bool, policyTy
 	}
 
 	// Get policy
-	actual, _, err := testsXrayPolicyService.Get(policyName)
+	actual, err := testsXrayPolicyService.Get(policyName)
 	assert.NoError(t, err)
 
 	// Compare general policy details

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -67,12 +66,12 @@ func testXrayWatchAll(t *testing.T) {
 		},
 	}
 
-	_, err = testsXrayWatchService.Create(paramsAllRepos)
+	err = testsXrayWatchService.Create(paramsAllRepos)
 	assert.NoError(t, err)
 	defer testsXrayWatchService.Delete(paramsAllRepos.Name)
 
 	validateWatchGeneralSettings(t, paramsAllRepos)
-	targetConfig, _, err := testsXrayWatchService.Get(paramsAllRepos.Name)
+	targetConfig, err := testsXrayWatchService.Get(paramsAllRepos.Name)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"excludePath1", "excludePath2"}, targetConfig.Repositories.ExcludePatterns)
@@ -105,11 +104,11 @@ func testXrayWatchAll(t *testing.T) {
 			Type: "security",
 		},
 	}
-	_, err = testsXrayWatchService.Update(*targetConfig)
+	err = testsXrayWatchService.Update(*targetConfig)
 	assert.NoError(t, err)
 
 	validateWatchGeneralSettings(t, *targetConfig)
-	updatedTargetConfig, _, err := testsXrayWatchService.Get(paramsAllRepos.Name)
+	updatedTargetConfig, err := testsXrayWatchService.Get(paramsAllRepos.Name)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"excludePath3", "excludePath4"}, updatedTargetConfig.Repositories.ExcludePatterns)
@@ -185,12 +184,12 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 		Name:     build1Name,
 		BinMgrID: "default",
 	}
-	_, err = testsXrayWatchService.Create(paramsSelectedRepos)
+	err = testsXrayWatchService.Create(paramsSelectedRepos)
 	assert.NoError(t, err)
 	defer testsXrayWatchService.Delete(paramsSelectedRepos.Name)
 	validateWatchGeneralSettings(t, paramsSelectedRepos)
 
-	targetConfig, _, err := testsXrayWatchService.Get(paramsSelectedRepos.Name)
+	targetConfig, err := testsXrayWatchService.Get(paramsSelectedRepos.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"selectedExcludePath1", "selectedExcludePath2"}, targetConfig.Repositories.ExcludePatterns)
 	assert.Equal(t, []string{"selectedIncludePath1", "selectedIncludePath2"}, targetConfig.Repositories.IncludePatterns)
@@ -240,11 +239,11 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 
 	targetConfig.Repositories.Repositories[repo1Name] = updatedRepo1
 
-	_, err = testsXrayWatchService.Update(*targetConfig)
+	err = testsXrayWatchService.Update(*targetConfig)
 	assert.NoError(t, err)
 
 	validateWatchGeneralSettings(t, *targetConfig)
-	updatedTargetConfig, _, err := testsXrayWatchService.Get(paramsSelectedRepos.Name)
+	updatedTargetConfig, err := testsXrayWatchService.Get(paramsSelectedRepos.Name)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"excludePath-2"}, updatedTargetConfig.Repositories.ExcludePatterns)
@@ -280,12 +279,12 @@ func testXrayWatchBuildsByPattern(t *testing.T) {
 		},
 	}
 
-	_, err = testsXrayWatchService.Create(paramsBuildsByPattern)
+	err = testsXrayWatchService.Create(paramsBuildsByPattern)
 	assert.NoError(t, err)
 	defer testsXrayWatchService.Delete(paramsBuildsByPattern.Name)
 	validateWatchGeneralSettings(t, paramsBuildsByPattern)
 
-	targetConfig, _, err := testsXrayWatchService.Get(paramsBuildsByPattern.Name)
+	targetConfig, err := testsXrayWatchService.Get(paramsBuildsByPattern.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, utils.WatchBuildAll, targetConfig.Builds.Type)
 	assert.Equal(t, []string{"excludePath"}, targetConfig.Builds.All.ExcludePatterns)
@@ -294,11 +293,11 @@ func testXrayWatchBuildsByPattern(t *testing.T) {
 	targetConfig.Builds.All.ExcludePatterns = []string{"excludePath-2"}
 	targetConfig.Builds.All.IncludePatterns = []string{"includePath-2", "fake-2"}
 
-	_, err = testsXrayWatchService.Update(*targetConfig)
+	err = testsXrayWatchService.Update(*targetConfig)
 	assert.NoError(t, err)
 
 	validateWatchGeneralSettings(t, *targetConfig)
-	updatedTargetConfig, _, err := testsXrayWatchService.Get(paramsBuildsByPattern.Name)
+	updatedTargetConfig, err := testsXrayWatchService.Get(paramsBuildsByPattern.Name)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"excludePath-2"}, updatedTargetConfig.Builds.All.ExcludePatterns)
@@ -312,24 +311,22 @@ func testXrayWatchUpdateMissingWatch(t *testing.T) {
 	paramsMissingWatch.Builds.Type = utils.WatchBuildAll
 	paramsMissingWatch.Policies = []utils.AssignedPolicy{}
 
-	_, err := testsXrayWatchService.Update(paramsMissingWatch)
-	assert.Error(t, err)
+	err := testsXrayWatchService.Update(paramsMissingWatch)
+	assert.EqualError(t, err, "Xray response: 404 Not Found\n{\n  \"error\": \"Failed to update Watch: Watch was not found\"\n}")
 }
 
 func testXrayWatchDeleteMissingWatch(t *testing.T) {
-	resp, err := testsXrayWatchService.Delete("jfrog-client-go-tests-watch-builds-missing")
-	assert.Equal(t, resp.StatusCode, http.StatusNotFound)
-	assert.Error(t, err)
+	err := testsXrayWatchService.Delete("jfrog-client-go-tests-watch-builds-missing")
+	assert.EqualError(t, err, "Xray response: 404 Not Found\n{\n  \"error\": \"Failed to delete Watch: Watch was not found\"\n}")
 }
 
 func testXrayWatchGetMissingWatch(t *testing.T) {
-	_, resp, err := testsXrayWatchService.Get("jfrog-client-go-tests-watch-builds-missing")
-	assert.Equal(t, resp.StatusCode, http.StatusNotFound)
-	assert.Error(t, err)
+	_, err := testsXrayWatchService.Get("jfrog-client-go-tests-watch-builds-missing")
+	assert.EqualError(t, err, "Xray response: 404 Not Found\n{\n  \"error\": \"Watch was not found\"\n}")
 }
 
 func validateWatchGeneralSettings(t *testing.T, params utils.WatchParams) {
-	targetConfig, _, err := testsXrayWatchService.Get(params.Name)
+	targetConfig, err := testsXrayWatchService.Get(params.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, params.Name, targetConfig.Name)
 	assert.Equal(t, params.Description, targetConfig.Description)

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -379,13 +379,13 @@ func createDummyPolicy(policyName string) error {
 			Priority: 1,
 		}},
 	}
-	_, err := testsXrayPolicyService.Create(params)
+	err := testsXrayPolicyService.Create(params)
 	return err
 }
 
 func createAndIndexBuild(t *testing.T, buildName string) error {
 	err := createDummyBuild(buildName)
 	assert.NoError(t, err)
-	_, err = testXrayBinMgrService.AddBuildsToIndexing([]string{buildName})
+	err = testXrayBinMgrService.AddBuildsToIndexing([]string{buildName})
 	return err
 }

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
+	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	artifactoryServices "github.com/jfrog/jfrog-client-go/artifactory/services"
 	artUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -34,14 +34,14 @@ func TestXrayWatch(t *testing.T) {
 
 func testXrayWatchAll(t *testing.T) {
 	policy1Name := fmt.Sprintf("%s-%d", "jfrog-policy1", time.Now().Unix())
-	err := createPolicy(policy1Name)
+	err := createExamplePolicy(policy1Name)
 	assert.NoError(t, err)
-	defer deletePolicy(policy1Name)
+	defer testsXrayPolicyService.Delete(policy1Name)
 
 	policy2Name := fmt.Sprintf("%s-%d", "jfrog-policy2", time.Now().Unix())
-	err = createPolicy(policy2Name)
+	err = createExamplePolicy(policy2Name)
 	assert.NoError(t, err)
-	defer deletePolicy(policy2Name)
+	defer testsXrayPolicyService.Delete(policy2Name)
 
 	AllWatchName := fmt.Sprintf("%s-%d", "jfrog-client-go-tests-watch-all-repos", time.Now().Unix())
 	paramsAllRepos := utils.NewWatchParams()
@@ -128,9 +128,9 @@ func testXrayWatchAll(t *testing.T) {
 
 func testXrayWatchSelectedRepos(t *testing.T) {
 	policy1Name := fmt.Sprintf("%s-%d", "jfrog-policy1-pattern", time.Now().Unix())
-	err := createPolicy(policy1Name)
+	err := createExamplePolicy(policy1Name)
 	assert.NoError(t, err)
-	defer deletePolicy(policy1Name)
+	defer testsXrayPolicyService.Delete(policy1Name)
 
 	repo1Name := fmt.Sprintf("%s-%d", "jfrog-repo1", time.Now().Unix())
 	createRepoLocal(t, repo1Name)
@@ -267,9 +267,9 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 
 func testXrayWatchBuildsByPattern(t *testing.T) {
 	policy1Name := fmt.Sprintf("%s-%d", "jfrog-policy1-pattern", time.Now().Unix())
-	err := createPolicy(policy1Name)
+	err := createExamplePolicy(policy1Name)
 	assert.NoError(t, err)
-	defer deletePolicy(policy1Name)
+	defer testsXrayPolicyService.Delete(policy1Name)
 
 	paramsBuildsByPattern := utils.NewWatchParams()
 	paramsBuildsByPattern.Name = fmt.Sprintf("%s-%d", "jfrog-client-go-tests-watch-builds-by-pattern", time.Now().Unix())
@@ -339,7 +339,7 @@ func validateWatchGeneralSettings(t *testing.T, params utils.WatchParams) {
 	assert.Equal(t, params.Name, targetConfig.Name)
 	assert.Equal(t, params.Description, targetConfig.Description)
 	assert.Equal(t, params.Active, targetConfig.Active)
-	assert.Equal(t, params.Policies, targetConfig.Policies)
+	assert.ElementsMatch(t, params.Policies, targetConfig.Policies)
 }
 
 func createRepoLocal(t *testing.T, repoKey string) {
@@ -381,25 +381,23 @@ func createBuild(buildName string) error {
 		return err
 	}
 
-	dataArtifactoryBuild := ArtifactoryBuild{
-		Name:       buildName,
-		Version:    "1.0.0",
-		Number:     "2",
-		Started:    "2014-09-30T12:00:19.893+0300",
-		Properties: map[string]interface{}{},
-		Modules: []ArtifactoryModule{
-			{
-				ID: "example-mdule",
-				Artifacts: []ArtifactoryArtifact{
-					{
-						Type: "gz",
+	dataArtifactoryBuild := buildinfo.BuildInfo{
+		Name:    buildName,
+		Number:  "1.0.0",
+		Started: "2014-09-30T12:00:19.893+0300",
+		Modules: []buildinfo.Module{{
+			Id: "example-mdule",
+			Artifacts: []buildinfo.Artifact{
+				{
+					Type: "gz",
+					Name: "c.tar.gz",
+					Checksum: &buildinfo.Checksum{
 						Sha1: "9d4336ff7bc2d2348aee4e27ad55e42110df4a80",
 						Md5:  "b4918187cc9b3bf1b0772546d9398d7d",
-						Name: "c.tar.gz",
 					},
 				},
 			},
-		},
+		}},
 	}
 	requestContentArtifactoryBuild, err := json.Marshal(dataArtifactoryBuild)
 	if err != nil {
@@ -488,49 +486,17 @@ func deleteBuild(buildName string) error {
 	return nil
 }
 
-type ArtifactoryBuild struct {
-	Version    string              `json:"version"`
-	Name       string              `json:"name"`
-	Number     string              `json:"number"`
-	Started    string              `json:"started"`
-	Properties interface{}         `json:"properties"`
-	Modules    []ArtifactoryModule `json:"modules"`
-}
-
-type ArtifactoryModule struct {
-	ID        string                `json:"id"`
-	Artifacts []ArtifactoryArtifact `json:"artifacts"`
-}
-
-type ArtifactoryArtifact struct {
-	Type string `json:"type"`
-	Sha1 string `json:"sha1"`
-	Md5  string `json:"md5"`
-	Name string `json:"name"`
-}
-
-func createPolicy(policyName string) error {
-	xrayDetails := GetXrayDetails()
-	xrayHTTPDetails := xrayDetails.CreateHttpClientDetails()
-
-	artUtils.SetContentType("application/json", &xrayHTTPDetails.Headers)
-	client, err := httpclient.ClientBuilder().Build()
-	if err != nil {
-		return err
-	}
-	data := ArtifactoryPolicy{
+func createExamplePolicy(policyName string) error {
+	params := utils.PolicyParams{
 		Name:        policyName,
 		Description: "example policy",
-		Type:        "security",
-		Rules: []ArtifactoryPolicyRules{{
+		Type:        utils.Security,
+		Rules: []utils.PolicyRule{{
 			Name:     "sec_rule",
-			Priority: 1,
-			Criteria: map[string]string{
-				"min_severity": "medium",
-			},
-			Actions: ArtifactoryPolicyActions{
+			Criteria: *utils.CreateSeverityPolicyCriteria(utils.Medium),
+			Actions: &utils.PolicyAction{
 				Webhooks: []string{},
-				BlockDownload: ArtifactoryPolicyActionsBlockDownload{
+				BlockDownload: utils.PolicyBlockDownload{
 					Active:    true,
 					Unscanned: false,
 				},
@@ -539,69 +505,9 @@ func createPolicy(policyName string) error {
 				NotifyDeployer:                 true,
 				NotifyWatchRecipients:          true,
 			},
+			Priority: 1,
 		}},
 	}
-
-	requestContent, err := json.Marshal(data)
-	if err != nil {
-		return errors.New("failed marshalling policy " + policyName)
-	}
-
-	resp, _, err := client.SendPost(xrayDetails.GetUrl()+"api/v2/policies", requestContent, xrayHTTPDetails)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return errors.New("Status is not Created - " + strconv.Itoa(resp.StatusCode))
-	}
-
+	testsXrayPolicyService.Create(params)
 	return nil
-}
-
-func deletePolicy(policyName string) error {
-	xrayDetails := GetXrayDetails()
-	xrayHTTPDetails := xrayDetails.CreateHttpClientDetails()
-	artUtils.SetContentType("application/json", &xrayHTTPDetails.Headers)
-	client, err := httpclient.ClientBuilder().Build()
-	if err != nil {
-		return err
-	}
-
-	resp, _, err := client.SendDelete(xrayDetails.GetUrl()+"api/v2/policies/"+policyName, nil, xrayHTTPDetails)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("failed to delete policy " + resp.Status)
-	}
-	return nil
-}
-
-type ArtifactoryPolicy struct {
-	Name        string                   `json:"name"`
-	Description string                   `json:"description"`
-	Type        string                   `json:"type"`
-	Rules       []ArtifactoryPolicyRules `json:"rules"`
-}
-
-type ArtifactoryPolicyRules struct {
-	Name     string                   `json:"name"`
-	Priority int                      `json:"priority"`
-	Criteria map[string]string        `json:"criteria"`
-	Actions  ArtifactoryPolicyActions `json:"actions"`
-}
-
-type ArtifactoryPolicyActions struct {
-	Webhooks                       []string                              `json:"webhooks"`
-	BlockDownload                  ArtifactoryPolicyActionsBlockDownload `json:"block_download"`
-	BlockReleaseBundleDistribution bool                                  `json:"block_release_bundle_distribution"`
-	FailBuild                      bool                                  `json:"fail_build"`
-	NotifyDeployer                 bool                                  `json:"notify_deployer"`
-	NotifyWatchRecipients          bool                                  `json:"notify_watch_recipients"`
-}
-
-type ArtifactoryPolicyActionsBlockDownload struct {
-	Active    bool `json:"active"`
-	Unscanned bool `json:"unscanned"`
 }

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -39,40 +39,71 @@ func (sm *XrayServicesManager) Client() *jfroghttpclient.JfrogHttpClient {
 	return sm.client
 }
 
-// GetVersion will return the xray version
+// GetVersion will return the Xray version
 func (sm *XrayServicesManager) GetVersion() (string, error) {
 	versionService := services.NewVersionService(sm.client)
 	versionService.XrayDetails = sm.config.GetServiceDetails()
 	return versionService.GetVersion()
 }
 
-// CreateWatch will create a new xray watch
+// CreateWatch will create a new Xray watch
 func (sm *XrayServicesManager) CreateWatch(params utils.WatchParams) (*http.Response, error) {
-	WatchService := services.NewWatchService(sm.client)
-	WatchService.XrayDetails = sm.config.GetServiceDetails()
-	return WatchService.Create(params)
+	watchService := services.NewWatchService(sm.client)
+	watchService.XrayDetails = sm.config.GetServiceDetails()
+	return watchService.Create(params)
 }
 
 // GetWatch retrieves the details about an Xray watch by name
 // It will error if no watch can be found by that name.
 func (sm *XrayServicesManager) GetWatch(watchName string) (*utils.WatchParams, *http.Response, error) {
-	WatchService := services.NewWatchService(sm.client)
-	WatchService.XrayDetails = sm.config.GetServiceDetails()
-	return WatchService.Get(watchName)
+	watchService := services.NewWatchService(sm.client)
+	watchService.XrayDetails = sm.config.GetServiceDetails()
+	return watchService.Get(watchName)
 }
 
 // UpdateWatch will update an existing Xray watch by name
 // It will error if no watch can be found by that name.
 func (sm *XrayServicesManager) UpdateWatch(params utils.WatchParams) (*http.Response, error) {
-	WatchService := services.NewWatchService(sm.client)
-	WatchService.XrayDetails = sm.config.GetServiceDetails()
-	return WatchService.Update(params)
+	watchService := services.NewWatchService(sm.client)
+	watchService.XrayDetails = sm.config.GetServiceDetails()
+	return watchService.Update(params)
 }
 
 // DeleteWatch will delete an existing watch by name
 // It will error if no watch can be found by that name.
 func (sm *XrayServicesManager) DeleteWatch(watchName string) (*http.Response, error) {
-	WatchService := services.NewWatchService(sm.client)
-	WatchService.XrayDetails = sm.config.GetServiceDetails()
-	return WatchService.Delete(watchName)
+	watchService := services.NewWatchService(sm.client)
+	watchService.XrayDetails = sm.config.GetServiceDetails()
+	return watchService.Delete(watchName)
+}
+
+// CreatePolicy will create a new Xray policy
+func (sm *XrayServicesManager) CreatePolicy(params utils.PolicyParams) (*http.Response, error) {
+	policyService := services.NewPolicyService(sm.client)
+	policyService.XrayDetails = sm.config.GetServiceDetails()
+	return policyService.Create(params)
+}
+
+// GetPolicy retrieves the details about an Xray policy by name
+// It will error if no policy can be found by that name.
+func (sm *XrayServicesManager) GetPolicy(policyName string) (*utils.PolicyParams, *http.Response, error) {
+	policyService := services.NewPolicyService(sm.client)
+	policyService.XrayDetails = sm.config.GetServiceDetails()
+	return policyService.Get(policyName)
+}
+
+// UpdatePolicy will update an existing Xray policy by name
+// It will error if no policy can be found by that name.
+func (sm *XrayServicesManager) UpdatePolicy(params utils.PolicyParams) (*http.Response, error) {
+	policyService := services.NewPolicyService(sm.client)
+	policyService.XrayDetails = sm.config.GetServiceDetails()
+	return policyService.Update(params)
+}
+
+// DeletePolicy will delete an existing policy by name
+// It will error if no policy can be found by that name.
+func (sm *XrayServicesManager) DeletePolicy(policyName string) (*http.Response, error) {
+	policyService := services.NewPolicyService(sm.client)
+	policyService.XrayDetails = sm.config.GetServiceDetails()
+	return policyService.Delete(policyName)
 }

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -107,3 +107,10 @@ func (sm *XrayServicesManager) DeletePolicy(policyName string) (*http.Response, 
 	policyService.XrayDetails = sm.config.GetServiceDetails()
 	return policyService.Delete(policyName)
 }
+
+// AddBuildsToIndexing will add builds to Xray indexing configuration
+func (sm *XrayServicesManager) AddBuildsToIndexing(buildNames []string) (*http.Response, error) {
+	binMgrService := services.NewBinMgrService(sm.client)
+	binMgrService.XrayDetails = sm.config.GetServiceDetails()
+	return binMgrService.AddBuildsToIndexing(buildNames)
+}

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -78,7 +78,7 @@ func (sm *XrayServicesManager) DeleteWatch(watchName string) (*http.Response, er
 }
 
 // CreatePolicy will create a new Xray policy
-func (sm *XrayServicesManager) CreatePolicy(params utils.PolicyParams) (*http.Response, error) {
+func (sm *XrayServicesManager) CreatePolicy(params utils.PolicyParams) error {
 	policyService := services.NewPolicyService(sm.client)
 	policyService.XrayDetails = sm.config.GetServiceDetails()
 	return policyService.Create(params)
@@ -86,7 +86,7 @@ func (sm *XrayServicesManager) CreatePolicy(params utils.PolicyParams) (*http.Re
 
 // GetPolicy retrieves the details about an Xray policy by name
 // It will error if no policy can be found by that name.
-func (sm *XrayServicesManager) GetPolicy(policyName string) (*utils.PolicyParams, *http.Response, error) {
+func (sm *XrayServicesManager) GetPolicy(policyName string) (*utils.PolicyParams, error) {
 	policyService := services.NewPolicyService(sm.client)
 	policyService.XrayDetails = sm.config.GetServiceDetails()
 	return policyService.Get(policyName)
@@ -94,7 +94,7 @@ func (sm *XrayServicesManager) GetPolicy(policyName string) (*utils.PolicyParams
 
 // UpdatePolicy will update an existing Xray policy by name
 // It will error if no policy can be found by that name.
-func (sm *XrayServicesManager) UpdatePolicy(params utils.PolicyParams) (*http.Response, error) {
+func (sm *XrayServicesManager) UpdatePolicy(params utils.PolicyParams) error {
 	policyService := services.NewPolicyService(sm.client)
 	policyService.XrayDetails = sm.config.GetServiceDetails()
 	return policyService.Update(params)
@@ -102,14 +102,14 @@ func (sm *XrayServicesManager) UpdatePolicy(params utils.PolicyParams) (*http.Re
 
 // DeletePolicy will delete an existing policy by name
 // It will error if no policy can be found by that name.
-func (sm *XrayServicesManager) DeletePolicy(policyName string) (*http.Response, error) {
+func (sm *XrayServicesManager) DeletePolicy(policyName string) error {
 	policyService := services.NewPolicyService(sm.client)
 	policyService.XrayDetails = sm.config.GetServiceDetails()
 	return policyService.Delete(policyName)
 }
 
 // AddBuildsToIndexing will add builds to Xray indexing configuration
-func (sm *XrayServicesManager) AddBuildsToIndexing(buildNames []string) (*http.Response, error) {
+func (sm *XrayServicesManager) AddBuildsToIndexing(buildNames []string) error {
 	binMgrService := services.NewBinMgrService(sm.client)
 	binMgrService.XrayDetails = sm.config.GetServiceDetails()
 	return binMgrService.AddBuildsToIndexing(buildNames)

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -1,8 +1,6 @@
 package xray
 
 import (
-	"net/http"
-
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/config"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
@@ -47,7 +45,7 @@ func (sm *XrayServicesManager) GetVersion() (string, error) {
 }
 
 // CreateWatch will create a new Xray watch
-func (sm *XrayServicesManager) CreateWatch(params utils.WatchParams) (*http.Response, error) {
+func (sm *XrayServicesManager) CreateWatch(params utils.WatchParams) error {
 	watchService := services.NewWatchService(sm.client)
 	watchService.XrayDetails = sm.config.GetServiceDetails()
 	return watchService.Create(params)
@@ -55,7 +53,7 @@ func (sm *XrayServicesManager) CreateWatch(params utils.WatchParams) (*http.Resp
 
 // GetWatch retrieves the details about an Xray watch by name
 // It will error if no watch can be found by that name.
-func (sm *XrayServicesManager) GetWatch(watchName string) (*utils.WatchParams, *http.Response, error) {
+func (sm *XrayServicesManager) GetWatch(watchName string) (*utils.WatchParams, error) {
 	watchService := services.NewWatchService(sm.client)
 	watchService.XrayDetails = sm.config.GetServiceDetails()
 	return watchService.Get(watchName)
@@ -63,7 +61,7 @@ func (sm *XrayServicesManager) GetWatch(watchName string) (*utils.WatchParams, *
 
 // UpdateWatch will update an existing Xray watch by name
 // It will error if no watch can be found by that name.
-func (sm *XrayServicesManager) UpdateWatch(params utils.WatchParams) (*http.Response, error) {
+func (sm *XrayServicesManager) UpdateWatch(params utils.WatchParams) error {
 	watchService := services.NewWatchService(sm.client)
 	watchService.XrayDetails = sm.config.GetServiceDetails()
 	return watchService.Update(params)
@@ -71,7 +69,7 @@ func (sm *XrayServicesManager) UpdateWatch(params utils.WatchParams) (*http.Resp
 
 // DeleteWatch will delete an existing watch by name
 // It will error if no watch can be found by that name.
-func (sm *XrayServicesManager) DeleteWatch(watchName string) (*http.Response, error) {
+func (sm *XrayServicesManager) DeleteWatch(watchName string) error {
 	watchService := services.NewWatchService(sm.client)
 	watchService.XrayDetails = sm.config.GetServiceDetails()
 	return watchService.Delete(watchName)

--- a/xray/services/binMgr.go
+++ b/xray/services/binMgr.go
@@ -1,0 +1,78 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+
+	artUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	binMgrAPIURL = "api/v1/binMgr"
+)
+
+// BinMgrService defines the http client and Xray details
+type BinMgrService struct {
+	client      *jfroghttpclient.JfrogHttpClient
+	XrayDetails auth.ServiceDetails
+}
+
+// NewBinMgrService creates a new Xray Binary Manager Service
+func NewBinMgrService(client *jfroghttpclient.JfrogHttpClient) *BinMgrService {
+	return &BinMgrService{client: client}
+}
+
+// GetXrayDetails returns the Xray details
+func (xbms *BinMgrService) GetXrayDetails() auth.ServiceDetails {
+	return xbms.XrayDetails
+}
+
+// GetJfrogHttpClient returns the http client
+func (xbms *BinMgrService) GetJfrogHttpClient() *jfroghttpclient.JfrogHttpClient {
+	return xbms.client
+}
+
+// The getBinMgrURL does not end with a slash
+// So, calling functions will need to add it
+func (xbms *BinMgrService) getBinMgrURL() string {
+	return clientutils.AddTrailingSlashIfNeeded(xbms.XrayDetails.GetUrl()) + binMgrAPIURL
+}
+
+// AddBuildsToIndexing will add builds to indexing configuration
+func (xbms *BinMgrService) AddBuildsToIndexing(buildNames []string) (*http.Response, error) {
+	payloadBody := addBuildsToIndexBody{BuildNames: buildNames}
+
+	content, err := json.Marshal(payloadBody)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	httpClientsDetails := xbms.XrayDetails.CreateHttpClientDetails()
+	artUtils.SetContentType("application/json", &httpClientsDetails.Headers)
+	var url = xbms.getBinMgrURL() + "/builds"
+	var resp *http.Response
+	var respBody []byte
+
+	log.Info("Adding builds to indexing configuration...")
+	resp, respBody, err = xbms.client.SendPost(url, content, &httpClientsDetails)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+	}
+	log.Debug("Xray response:", resp.Status)
+	log.Info("Done adding builds to indexing configuration.")
+	return resp, nil
+}
+
+type addBuildsToIndexBody struct {
+	BuildNames []string `json:"names"`
+}

--- a/xray/services/binMgr.go
+++ b/xray/services/binMgr.go
@@ -46,12 +46,12 @@ func (xbms *BinMgrService) getBinMgrURL() string {
 }
 
 // AddBuildsToIndexing will add builds to indexing configuration
-func (xbms *BinMgrService) AddBuildsToIndexing(buildNames []string) (*http.Response, error) {
+func (xbms *BinMgrService) AddBuildsToIndexing(buildNames []string) error {
 	payloadBody := addBuildsToIndexBody{BuildNames: buildNames}
 
 	content, err := json.Marshal(payloadBody)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	httpClientsDetails := xbms.XrayDetails.CreateHttpClientDetails()
@@ -63,14 +63,14 @@ func (xbms *BinMgrService) AddBuildsToIndexing(buildNames []string) (*http.Respo
 	log.Info("Adding builds to indexing configuration...")
 	resp, respBody, err = xbms.client.SendPost(url, content, &httpClientsDetails)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
 	}
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done adding builds to indexing configuration.")
-	return resp, nil
+	return nil
 }
 
 type addBuildsToIndexBody struct {

--- a/xray/services/policy.go
+++ b/xray/services/policy.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+
+	artUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray/services/utils"
+)
+
+const (
+	policyAPIURL = "api/v2/policies"
+)
+
+// PolicyService defines the http client and xray details
+type PolicyService struct {
+	client      *jfroghttpclient.JfrogHttpClient
+	XrayDetails auth.ServiceDetails
+}
+
+// NewPolicyService creates a new Xray Policy Service
+func NewPolicyService(client *jfroghttpclient.JfrogHttpClient) *PolicyService {
+	return &PolicyService{client: client}
+}
+
+// GetXrayDetails returns the xray details
+func (xps *PolicyService) GetXrayDetails() auth.ServiceDetails {
+	return xps.XrayDetails
+}
+
+// GetJfrogHttpClient returns the http client
+func (xps *PolicyService) GetJfrogHttpClient() *jfroghttpclient.JfrogHttpClient {
+	return xps.client
+}
+
+// The getPolicyURL does not end with a slash
+// So, calling functions will need to add it
+func (xps *PolicyService) getPolicyURL() string {
+	return clientutils.AddTrailingSlashIfNeeded(xps.XrayDetails.GetUrl()) + policyAPIURL
+}
+
+// Delete will delete an existing policy by name
+// It will error if no policy can be found by that name.
+func (xps *PolicyService) Delete(policyName string) (*http.Response, error) {
+	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
+	artUtils.SetContentType("application/json", &httpClientsDetails.Headers)
+
+	log.Info("Deleting policy...")
+	resp, body, err := xps.client.SendDelete(xps.getPolicyURL()+"/"+policyName, nil, &httpClientsDetails)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+	}
+
+	log.Debug("Xray response:", resp.Status)
+	log.Info("Done deleting policy.")
+	return resp, nil
+}
+
+// Create will create a new xray policy
+func (xps *PolicyService) Create(params utils.PolicyParams) (*http.Response, error) {
+	body := utils.CreatePolicyBody(params)
+	content, err := json.Marshal(body)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
+	artUtils.SetContentType("application/json", &httpClientsDetails.Headers)
+	var url = xps.getPolicyURL()
+	var resp *http.Response
+	var respBody []byte
+
+	log.Info("Creating policy...")
+	resp, respBody, err = xps.client.SendPost(url, content, &httpClientsDetails)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+	}
+	log.Debug("Xray response:", resp.Status)
+	log.Info("Done creating policy.")
+	return resp, nil
+}
+
+// Update will update an existing Xray policy by name
+// It will error if no policy can be found by that name.
+func (xps *PolicyService) Update(params utils.PolicyParams) (*http.Response, error) {
+	body := utils.CreatePolicyBody(params)
+	content, err := json.Marshal(body)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
+	artUtils.SetContentType("application/json", &httpClientsDetails.Headers)
+	var url = xps.getPolicyURL() + "/" + params.Name
+	var resp *http.Response
+	var respBody []byte
+
+	log.Info("Updating policy...")
+	resp, respBody, err = xps.client.SendPut(url, content, &httpClientsDetails)
+
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+	}
+	log.Debug("Xray response:", resp.Status)
+	log.Info("Done updating policy.")
+	return resp, nil
+}
+
+// Get retrieves the details about an Xray policy by its name
+// It will error if no policy can be found by that name.
+func (xps *PolicyService) Get(policyName string) (policyResp *utils.PolicyParams, resp *http.Response, err error) {
+	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
+	log.Info("Getting policy...")
+	resp, body, _, err := xps.client.SendGet(xps.getPolicyURL()+"/"+policyName, true, &httpClientsDetails)
+	policy := &utils.PolicyBody{}
+
+	if err != nil {
+		return &utils.PolicyParams{}, resp, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &utils.PolicyParams{}, resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+	}
+
+	err = json.Unmarshal(body, policy)
+
+	if err != nil {
+		return &utils.PolicyParams{}, resp, errors.New("failed unmarshalling policy " + policyName)
+	}
+
+	log.Debug("Xray response:", resp.Status)
+	log.Info("Done getting policy.")
+
+	return &utils.PolicyParams{
+		Name:        policy.Name,
+		Type:        policy.Type,
+		Description: policy.Description,
+		Rules:       policy.Rules,
+	}, resp, nil
+}

--- a/xray/services/policy.go
+++ b/xray/services/policy.go
@@ -48,30 +48,30 @@ func (xps *PolicyService) getPolicyURL() string {
 
 // Delete will delete an existing policy by name
 // It will error if no policy can be found by that name.
-func (xps *PolicyService) Delete(policyName string) (*http.Response, error) {
+func (xps *PolicyService) Delete(policyName string) error {
 	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
 	artUtils.SetContentType("application/json", &httpClientsDetails.Headers)
 
 	log.Info("Deleting policy...")
 	resp, body, err := xps.client.SendDelete(xps.getPolicyURL()+"/"+policyName, nil, &httpClientsDetails)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
 	}
 
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done deleting policy.")
-	return resp, nil
+	return nil
 }
 
 // Create will create a new xray policy
-func (xps *PolicyService) Create(params utils.PolicyParams) (*http.Response, error) {
+func (xps *PolicyService) Create(params utils.PolicyParams) error {
 	body := utils.CreatePolicyBody(params)
 	content, err := json.Marshal(body)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
@@ -83,23 +83,23 @@ func (xps *PolicyService) Create(params utils.PolicyParams) (*http.Response, err
 	log.Info("Creating policy...")
 	resp, respBody, err = xps.client.SendPost(url, content, &httpClientsDetails)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
 	}
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done creating policy.")
-	return resp, nil
+	return nil
 }
 
 // Update will update an existing Xray policy by name
 // It will error if no policy can be found by that name.
-func (xps *PolicyService) Update(params utils.PolicyParams) (*http.Response, error) {
+func (xps *PolicyService) Update(params utils.PolicyParams) error {
 	body := utils.CreatePolicyBody(params)
 	content, err := json.Marshal(body)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
@@ -112,35 +112,35 @@ func (xps *PolicyService) Update(params utils.PolicyParams) (*http.Response, err
 	resp, respBody, err = xps.client.SendPut(url, content, &httpClientsDetails)
 
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
 	}
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done updating policy.")
-	return resp, nil
+	return nil
 }
 
 // Get retrieves the details about an Xray policy by its name
 // It will error if no policy can be found by that name.
-func (xps *PolicyService) Get(policyName string) (policyResp *utils.PolicyParams, resp *http.Response, err error) {
+func (xps *PolicyService) Get(policyName string) (policyResp *utils.PolicyParams, err error) {
 	httpClientsDetails := xps.XrayDetails.CreateHttpClientDetails()
 	log.Info("Getting policy...")
 	resp, body, _, err := xps.client.SendGet(xps.getPolicyURL()+"/"+policyName, true, &httpClientsDetails)
 	policy := &utils.PolicyBody{}
 
 	if err != nil {
-		return &utils.PolicyParams{}, resp, err
+		return &utils.PolicyParams{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return &utils.PolicyParams{}, resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+		return &utils.PolicyParams{}, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
 	}
 
 	err = json.Unmarshal(body, policy)
 
 	if err != nil {
-		return &utils.PolicyParams{}, resp, errors.New("failed unmarshalling policy " + policyName)
+		return &utils.PolicyParams{}, errors.New("failed unmarshalling policy " + policyName)
 	}
 
 	log.Debug("Xray response:", resp.Status)
@@ -151,5 +151,5 @@ func (xps *PolicyService) Get(policyName string) (policyResp *utils.PolicyParams
 		Type:        policy.Type,
 		Description: policy.Description,
 		Rules:       policy.Rules,
-	}, resp, nil
+	}, nil
 }

--- a/xray/services/utils/policybody.go
+++ b/xray/services/utils/policybody.go
@@ -1,0 +1,133 @@
+package utils
+
+import (
+	"math"
+	"time"
+)
+
+type Severity string
+
+const (
+	Critical    Severity = "Critical"
+	High                 = "High"
+	Medium               = "Medium"
+	Low                  = "Low"
+	Normal               = "Normal"
+	Pending              = "Pending"
+	Information          = "Information"
+	Unknown              = "Unknown"
+)
+
+type PolicyType string
+
+const (
+	Security PolicyType = "security"
+	License             = "license"
+)
+
+func NewPolicyParams() PolicyParams {
+	return PolicyParams{}
+}
+
+type PolicyParams struct {
+	Name        string
+	Type        PolicyType
+	Description string
+	Rules       []PolicyRule
+}
+
+// PolicyBody is the top level payload to be sent to Xray
+type PolicyBody struct {
+	Name        string       `json:"name,omitempty"`
+	Type        PolicyType   `json:"type,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Author      string       `json:"author,omitempty"`
+	Rules       []PolicyRule `json:"rules,omitempty"`
+	Created     time.Time    `json:"created,omitempty"`
+	Modified    time.Time    `json:"modified,omitempty"`
+}
+
+type PolicyRule struct {
+	Name     string         `json:"name,omitempty"`
+	Criteria PolicyCriteria `json:"criteria,omitempty"`
+	Actions  *PolicyAction  `json:"actions,omitempty"`
+	Priority int            `json:"priority,omitempty"`
+}
+
+type PolicyCriteria struct {
+	// Security
+	MinSeverity Severity         `json:"min_severity,omitempty"`
+	CvssRange   *PolicyCvssRange `json:"cvss_range,omitempty"`
+
+	// License
+	AllowedLicenses        []string `json:"allowed_licenses,omitempty"`
+	BannedLicenses         []string `json:"banned_licenses,omitempty"`
+	AllowUnknown           bool     `json:"allow_unknown,omitempty"`
+	MultiLicensePermissive bool     `json:"multi_license_permissive,omitempty"`
+}
+
+type PolicyCvssRange struct {
+	From float64 `json:"from,omitempty"`
+	To   float64 `json:"to,omitempty"`
+}
+
+type PolicyAction struct {
+	Webhooks                       []string            `json:"webhooks,omitempty"`
+	BlockDownload                  PolicyBlockDownload `json:"block_download,omitempty"`
+	BlockReleaseBundleDistribution bool                `json:"block_release_bundle_distribution,omitempty"`
+	FailBuild                      bool                `json:"fail_build,omitempty"`
+	NotifyDeployer                 bool                `json:"notify_deployer,omitempty"`
+	NotifyWatchRecipients          bool                `json:"notify_watch_recipients,omitempty"`
+	CustomSeverity                 Severity            `json:"custom_severity,omitempty"`
+}
+
+type PolicyBlockDownload struct {
+	Active    bool `json:"active,omitempty"`
+	Unscanned bool `json:"unscanned,omitempty"`
+}
+
+// Create security policy criteria with min severity
+func CreateSeverityPolicyCriteria(minSeverity Severity) *PolicyCriteria {
+	return &PolicyCriteria{
+		MinSeverity: minSeverity,
+	}
+}
+
+// Create security policy criteria with range.
+// from - CVSS range from 0.0 to 10.0
+// to - CVSS range from 0.0 to 10.0
+func CreateCvssRangePolicyCriteria(from float64, to float64) *PolicyCriteria {
+	return &PolicyCriteria{
+		CvssRange: &PolicyCvssRange{
+			From: math.Round(from*10) / 10,
+			To:   math.Round(to*10) / 10,
+		},
+	}
+}
+
+// Create license policy criteria
+// allowedLicenses - true if the provided licenses are allowed, false if banned
+// allowUnknown - true if should allow unknown licenses, otherwise a violation will be generated for artifacts with unknown licenses
+// multiLicensePermissive - do not generate a violation if at least one license is valid in cases whereby multiple licenses were detected on the component
+// licenses - the target licenses
+func CreateLicensePolicyCriteria(allowedLicenses, allowUnknown, multiLicensePermissive bool, licenses ...string) *PolicyCriteria {
+	policyCriteria := &PolicyCriteria{
+		AllowUnknown:           allowUnknown,
+		MultiLicensePermissive: multiLicensePermissive,
+	}
+	if allowedLicenses {
+		policyCriteria.AllowedLicenses = licenses
+	} else {
+		policyCriteria.BannedLicenses = licenses
+	}
+	return policyCriteria
+}
+
+func CreatePolicyBody(policyParams PolicyParams) PolicyBody {
+	return PolicyBody{
+		Name:        policyParams.Name,
+		Type:        policyParams.Type,
+		Description: policyParams.Description,
+		Rules:       policyParams.Rules,
+	}
+}

--- a/xray/services/watch.go
+++ b/xray/services/watch.go
@@ -48,32 +48,32 @@ func (xws *WatchService) getWatchURL() string {
 
 // Delete will delete an existing watch by name
 // It will error if no watch can be found by that name.
-func (xws *WatchService) Delete(watchName string) (*http.Response, error) {
+func (xws *WatchService) Delete(watchName string) error {
 	httpClientsDetails := xws.XrayDetails.CreateHttpClientDetails()
 	log.Info("Deleting watch...")
 	resp, body, err := xws.client.SendDelete(xws.getWatchURL()+"/"+watchName, nil, &httpClientsDetails)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
 	}
 
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done deleting watch.")
-	return resp, nil
+	return nil
 }
 
 // Create will create a new xray watch
-func (xws *WatchService) Create(params utils.WatchParams) (*http.Response, error) {
+func (xws *WatchService) Create(params utils.WatchParams) error {
 	payloadBody, err := utils.CreateBody(params)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	content, err := json.Marshal(payloadBody)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	httpClientsDetails := xws.XrayDetails.CreateHttpClientDetails()
@@ -85,22 +85,22 @@ func (xws *WatchService) Create(params utils.WatchParams) (*http.Response, error
 	log.Info("Creating watch...")
 	resp, respBody, err = xws.client.SendPost(url, content, &httpClientsDetails)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
 	}
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done creating watch.")
-	return resp, nil
+	return nil
 }
 
 // Update will update an existing Xray watch by name
 // It will error if no watch can be found by that name.
-func (xws *WatchService) Update(params utils.WatchParams) (*http.Response, error) {
+func (xws *WatchService) Update(params utils.WatchParams) error {
 	payloadBody, err := utils.CreateBody(params)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	// Xray does not allow you to update a watch's name
@@ -109,12 +109,12 @@ func (xws *WatchService) Update(params utils.WatchParams) (*http.Response, error
 	payloadBody.GeneralData.Name = ""
 
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	content, err := json.Marshal(payloadBody)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return errorutils.CheckError(err)
 	}
 
 	httpClientsDetails := xws.XrayDetails.CreateHttpClientDetails()
@@ -127,35 +127,35 @@ func (xws *WatchService) Update(params utils.WatchParams) (*http.Response, error
 	resp, respBody, err = xws.client.SendPut(url, content, &httpClientsDetails)
 
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
+		return errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(respBody)))
 	}
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done updating watch.")
-	return resp, nil
+	return nil
 }
 
 // Get retrieves the details about an Xray watch by its name
 // It will error if no watch can be found by that name.
-func (xws *WatchService) Get(watchName string) (watchResp *utils.WatchParams, resp *http.Response, err error) {
+func (xws *WatchService) Get(watchName string) (watchResp *utils.WatchParams, err error) {
 	httpClientsDetails := xws.XrayDetails.CreateHttpClientDetails()
 	log.Info("Getting watch...")
 	resp, body, _, err := xws.client.SendGet(xws.getWatchURL()+"/"+watchName, true, &httpClientsDetails)
 	watch := utils.WatchBody{}
 
 	if err != nil {
-		return &utils.WatchParams{}, resp, err
+		return &utils.WatchParams{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return &utils.WatchParams{}, resp, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+		return &utils.WatchParams{}, errorutils.CheckError(errors.New("Xray response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
 	}
 
 	err = json.Unmarshal(body, &watch)
 
 	if err != nil {
-		return &utils.WatchParams{}, resp, errors.New("failed unmarshalling watch " + watchName)
+		return &utils.WatchParams{}, errors.New("failed unmarshalling watch " + watchName)
 	}
 
 	result := utils.NewWatchParams()
@@ -181,5 +181,5 @@ func (xws *WatchService) Get(watchName string) (watchResp *utils.WatchParams, re
 	log.Debug("Xray response:", resp.Status)
 	log.Info("Done getting watch.")
 
-	return &result, resp, nil
+	return &result, nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add JFrog Xray policy API support.
See usage here:
https://github.com/yahavi/jfrog-client-go/tree/xray-policy#creating-a-security-xray-policy