### PR TITLE
Support for Artifactory Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,10 @@ params.Comment = "comment"
 params.Copy = true
 params.IncludeDependencies = false
 params.SourceRepo = "source-repo"
+// Optional Artifactory project key
+params.ProjectKey = "my-project-key"
 
-rtManager.DownloadFiles(params)
+rtManager.PromoteBuild(params)
 ```
 
 #### Promoting a Docker Image in Artifactory
@@ -491,6 +493,8 @@ params.MaxBuilds = "max-builds"
 params.ExcludeBuilds = "1,2"
 params.DeleteArtifacts = false
 params.Async = false
+// Optional Artifactory project key
+projectKey := "my-project-key"
 
 rtManager.DiscardBuilds(params)
 ```

--- a/README.md
+++ b/README.md
@@ -409,10 +409,10 @@ Read more about [ContentReader](#using-contentReader).
 #### Publishing Build Info to Artifactory
 ```go
 buildInfo := &buildinfo.BuildInfo{}
-// Optional Artifactory project name
-project := "my-project"
+// Optional Artifactory project key
+projectKey := "my-project-key"
 ...
-rtManager.PublishBuildInfo(buildInfo, project)
+rtManager.PublishBuildInfo(buildInfo, projectKey)
 ```
 
 #### Fetching Build Info from Artifactory
@@ -420,6 +420,8 @@ rtManager.PublishBuildInfo(buildInfo, project)
 buildInfoParams := services.NewBuildInfoParams{}
 buildInfoParams.BuildName = "buildName"
 buildInfoParams.BuildNumber = "LATEST"
+// Optional Artifactory project key
+buildInfoParams.ProjectKey = "my-project-key"
 
 rtManager.GetBuildInfo(buildInfoParams)
 ```

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -25,7 +25,7 @@ type ArtifactoryServicesManager interface {
 	CreatePermissionTarget(params services.PermissionTargetParams) error
 	UpdatePermissionTarget(params services.PermissionTargetParams) error
 	DeletePermissionTarget(permissionTargetName string) error
-	PublishBuildInfo(build *buildinfo.BuildInfo, project string) error
+	PublishBuildInfo(build *buildinfo.BuildInfo, projectKey string) error
 	DistributeBuild(params services.BuildDistributionParams) error
 	PromoteBuild(params services.PromotionParams) error
 	DiscardBuilds(params services.DiscardBuildsParams) error

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -114,12 +114,11 @@ func (sm *ArtifactoryServicesManagerImp) DeletePermissionTarget(permissionTarget
 	return permissionTargetService.Delete(permissionTargetName)
 }
 
-func (sm *ArtifactoryServicesManagerImp) PublishBuildInfo(build *buildinfo.BuildInfo, project string) error {
+func (sm *ArtifactoryServicesManagerImp) PublishBuildInfo(build *buildinfo.BuildInfo, projectKey string) error {
 	buildInfoService := services.NewBuildInfoService(sm.client)
 	buildInfoService.DryRun = sm.config.IsDryRun()
-	buildInfoService.Project = project
 	buildInfoService.ArtDetails = sm.config.GetServiceDetails()
-	return buildInfoService.PublishBuildInfo(build)
+	return buildInfoService.PublishBuildInfo(build, projectKey)
 }
 
 func (sm *ArtifactoryServicesManagerImp) DistributeBuild(params services.BuildDistributionParams) error {

--- a/artifactory/services/buildinfo.go
+++ b/artifactory/services/buildinfo.go
@@ -18,7 +18,6 @@ import (
 type BuildInfoService struct {
 	client     *jfroghttpclient.JfrogHttpClient
 	ArtDetails auth.ServiceDetails
-	Project    string
 	DryRun     bool
 }
 
@@ -38,10 +37,6 @@ func (bis *BuildInfoService) GetJfrogHttpClient() (*jfroghttpclient.JfrogHttpCli
 	return bis.client, nil
 }
 
-func (bis *BuildInfoService) GetProject() string {
-	return bis.Project
-}
-
 func (bis *BuildInfoService) IsDryRun() bool {
 	return bis.DryRun
 }
@@ -49,6 +44,7 @@ func (bis *BuildInfoService) IsDryRun() bool {
 type BuildInfoParams struct {
 	BuildName   string
 	BuildNumber string
+	ProjectKey  string
 }
 
 func NewBuildInfoParams() BuildInfoParams {
@@ -68,7 +64,7 @@ func (bis *BuildInfoService) GetBuildInfo(params BuildInfoParams) (pbi *buildinf
 	// Get build-info json from Artifactory.
 	httpClientsDetails := bis.GetArtifactoryDetails().CreateHttpClientDetails()
 
-	restApi := path.Join("api/build/", name, number)
+	restApi := path.Join("api/build/"+bis.getProjectQueryParam(params.ProjectKey), name, number)
 	requestFullUrl, err := utils.BuildArtifactoryUrl(bis.GetArtifactoryDetails().GetUrl(), restApi, make(map[string]string))
 
 	log.Debug("Getting build-info from: ", requestFullUrl)
@@ -94,7 +90,7 @@ func (bis *BuildInfoService) GetBuildInfo(params BuildInfoParams) (pbi *buildinf
 	return publishedBuildInfo, true, nil
 }
 
-func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo) error {
+func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo, projectKey string) error {
 	content, err := json.Marshal(build)
 	if errorutils.CheckError(err) != nil {
 		return err
@@ -107,7 +103,7 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo) error 
 	httpClientsDetails := bis.GetArtifactoryDetails().CreateHttpClientDetails()
 	utils.SetContentType("application/vnd.org.jfrog.artifactory+json", &httpClientsDetails.Headers)
 	log.Info("Deploying build info...")
-	resp, body, err := bis.client.SendPut(bis.ArtDetails.GetUrl()+"api/build"+bis.getProjectQueryParam(), content, &httpClientsDetails)
+	resp, body, err := bis.client.SendPut(bis.ArtDetails.GetUrl()+"api/build"+bis.getProjectQueryParam(projectKey), content, &httpClientsDetails)
 	if err != nil {
 		return err
 	}
@@ -120,9 +116,9 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo) error 
 	return nil
 }
 
-func (bis *BuildInfoService) getProjectQueryParam() string {
-	if bis.Project == "" {
+func (bis *BuildInfoService) getProjectQueryParam(projectKey string) string {
+	if projectKey == "" {
 		return ""
 	}
-	return "?project=" + bis.Project
+	return "?buildRepo=" + utils.BuildRepoNameFromPrpjectKey(projectKey)
 }

--- a/artifactory/services/buildinfo.go
+++ b/artifactory/services/buildinfo.go
@@ -64,7 +64,7 @@ func (bis *BuildInfoService) GetBuildInfo(params BuildInfoParams) (pbi *buildinf
 	// Get build-info json from Artifactory.
 	httpClientsDetails := bis.GetArtifactoryDetails().CreateHttpClientDetails()
 
-	restApi := path.Join("api/build/"+bis.getProjectQueryParam(params.ProjectKey), name, number)
+	restApi := path.Join("api/build/", name, number) + bis.getProjectQueryParam(params.ProjectKey)
 	requestFullUrl, err := utils.BuildArtifactoryUrl(bis.GetArtifactoryDetails().GetUrl(), restApi, make(map[string]string))
 
 	log.Debug("Getting build-info from: ", requestFullUrl)
@@ -120,5 +120,5 @@ func (bis *BuildInfoService) getProjectQueryParam(projectKey string) string {
 	if projectKey == "" {
 		return ""
 	}
-	return "?buildRepo=" + utils.BuildRepoNameFromPrpjectKey(projectKey)
+	return "?buildRepo=" + utils.BuildRepoNameFromProjectKey(projectKey)
 }

--- a/artifactory/services/discardBuilds.go
+++ b/artifactory/services/discardBuilds.go
@@ -38,6 +38,11 @@ func (ds *DiscardBuildsService) DiscardBuilds(params DiscardBuildsParams) error 
 	}
 	requestFullUrl += "?async=" + strconv.FormatBool(params.IsAsync())
 
+	buildRepo := utils.BuildRepoNameFromProjectKey(params.ProjectKey)
+	if buildRepo != "" {
+		requestFullUrl += "&buildRepo=" + buildRepo
+	}
+
 	var excludeBuilds []string
 	if params.GetExcludeBuilds() != "" {
 		excludeBuilds = strings.Split(params.GetExcludeBuilds(), ",")
@@ -107,6 +112,7 @@ type DiscardBuildsBody struct {
 type DiscardBuildsParams struct {
 	DeleteArtifacts bool
 	BuildName       string
+	ProjectKey      string
 	MaxDays         string
 	MaxBuilds       string
 	ExcludeBuilds   string
@@ -115,6 +121,10 @@ type DiscardBuildsParams struct {
 
 func (bd *DiscardBuildsParams) GetBuildName() string {
 	return bd.BuildName
+}
+
+func (bd *DiscardBuildsParams) GetProjectKey() string {
+	return bd.ProjectKey
 }
 
 func (bd *DiscardBuildsParams) GetMaxDays() string {

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -36,7 +36,8 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 	log.Info(message)
 
 	promoteUrl := ps.ArtDetails.GetUrl()
-	restApi := path.Join("api/build/promote/", promotionParams.GetBuildName(), promotionParams.GetBuildNumber())
+	restApi := path.Join("api/build/promote/", promotionParams.GetBuildName(), promotionParams.GetBuildNumber()) +
+		"?buildRepo=" + utils.BuildRepoNameFromProjectKey(promotionParams.ProjectKey)
 	requestFullUrl, err := utils.BuildArtifactoryUrl(promoteUrl, restApi, make(map[string]string))
 	if err != nil {
 		return err
@@ -91,6 +92,7 @@ type BuildPromotionBody struct {
 type PromotionParams struct {
 	BuildName           string
 	BuildNumber         string
+	ProjectKey          string
 	TargetRepo          string
 	Status              string
 	Comment             string
@@ -106,6 +108,10 @@ func (bp *PromotionParams) GetBuildName() string {
 
 func (bp *PromotionParams) GetBuildNumber() string {
 	return bp.BuildNumber
+}
+
+func (bp *PromotionParams) GetProjectKey() string {
+	return bp.ProjectKey
 }
 
 func (bp *PromotionParams) GetTargetRepo() string {

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -93,6 +94,15 @@ func BuildArtifactoryUrl(baseUrl, path string, params map[string]string) (string
 
 func IsWildcardPattern(pattern string) bool {
 	return strings.Contains(pattern, "*") || strings.HasSuffix(pattern, "/") || !strings.Contains(pattern, "/")
+}
+
+// Returns the name of the build-info repository, corresponding to the project key sent.
+// Returns an empty string, if the provided projectKey is empty.
+func BuildRepoNameFromPrpjectKey(projectKey string) string {
+	if projectKey == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-build-info", projectKey)
 }
 
 // paths - Sorted array.

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -98,7 +98,7 @@ func IsWildcardPattern(pattern string) bool {
 
 // Returns the name of the build-info repository, corresponding to the project key sent.
 // Returns an empty string, if the provided projectKey is empty.
-func BuildRepoNameFromPrpjectKey(projectKey string) string {
+func BuildRepoNameFromProjectKey(projectKey string) string {
 	if projectKey == "" {
 		return ""
 	}

--- a/artifactory/services/xrayscan.go
+++ b/artifactory/services/xrayscan.go
@@ -39,6 +39,7 @@ func (ps *XrayScanService) ScanBuild(scanParams XrayScanParams) ([]byte, error) 
 	data := XrayScanBody{
 		BuildName:   scanParams.GetBuildName(),
 		BuildNumber: scanParams.GetBuildNumber(),
+		BuildRepo:   scanParams.GetBuildNumber(),
 		Context:     clientutils.GetUserAgent(),
 	}
 
@@ -131,12 +132,14 @@ type errorsStatusResponse struct {
 type XrayScanBody struct {
 	BuildName   string `json:"buildName,omitempty"`
 	BuildNumber string `json:"buildNumber,omitempty"`
+	BuildRepo   string `json:"buildRepo,omitempty"`
 	Context     string `json:"context,omitempty"`
 }
 
 type XrayScanParams struct {
 	BuildName   string
 	BuildNumber string
+	ProjectKey  string
 }
 
 func (bp *XrayScanParams) GetBuildName() string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -620,7 +620,7 @@ func createDummyBuild(buildName string) error {
 			},
 		}},
 	}
-	return testBuildInfoService.PublishBuildInfo(dataArtifactoryBuild)
+	return testBuildInfoService.PublishBuildInfo(dataArtifactoryBuild, "")
 }
 
 func deleteBuild(buildName string) error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR enhances the client, so that it can support the new "projects" functionality introduced in Artifactory.

1. When publishing build-info, the project key can be optionally provided. If provided, the build-info is published to the project's build-info repository, named my-project-key-build-info. If not provided, the build-info is published (by default) to a repository named artifactory-build-info.

2. The project key is also optionally provided when fetching a published build-info. Same default as in #1.

3. Same project key option is also available when scanning a build.