### PR TITLE
Unreleased bug - build promotion fails, following the added support for Projects 

### DIFF
--- a/artifactory/services/buildinfo.go
+++ b/artifactory/services/buildinfo.go
@@ -63,8 +63,7 @@ func (bis *BuildInfoService) GetBuildInfo(params BuildInfoParams) (pbi *buildinf
 
 	// Get build-info json from Artifactory.
 	httpClientsDetails := bis.GetArtifactoryDetails().CreateHttpClientDetails()
-
-	restApi := path.Join("api/build/", name, number) + bis.getProjectQueryParam(params.ProjectKey)
+	restApi := path.Join("api/build/", name, number) + utils.GetProjectQueryParam(params.ProjectKey)
 	requestFullUrl, err := utils.BuildArtifactoryUrl(bis.GetArtifactoryDetails().GetUrl(), restApi, make(map[string]string))
 
 	log.Debug("Getting build-info from: ", requestFullUrl)
@@ -103,7 +102,7 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo, projec
 	httpClientsDetails := bis.GetArtifactoryDetails().CreateHttpClientDetails()
 	utils.SetContentType("application/vnd.org.jfrog.artifactory+json", &httpClientsDetails.Headers)
 	log.Info("Deploying build info...")
-	resp, body, err := bis.client.SendPut(bis.ArtDetails.GetUrl()+"api/build"+bis.getProjectQueryParam(projectKey), content, &httpClientsDetails)
+	resp, body, err := bis.client.SendPut(bis.ArtDetails.GetUrl()+"api/build"+utils.GetProjectQueryParam(projectKey), content, &httpClientsDetails)
 	if err != nil {
 		return err
 	}
@@ -114,11 +113,4 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo, projec
 	log.Debug("Artifactory response:", resp.Status)
 	log.Info("Build info successfully deployed. Browse it in Artifactory under " + bis.GetArtifactoryDetails().GetUrl() + "webapp/builds/" + build.Name + "/" + build.Number)
 	return nil
-}
-
-func (bis *BuildInfoService) getProjectQueryParam(projectKey string) string {
-	if projectKey == "" {
-		return ""
-	}
-	return "?buildRepo=" + utils.BuildRepoNameFromProjectKey(projectKey)
 }

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -37,7 +37,8 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 
 	promoteUrl := ps.ArtDetails.GetUrl()
 	restApi := path.Join("api/build/promote/", promotionParams.GetBuildName(), promotionParams.GetBuildNumber()) +
-		"?buildRepo=" + utils.BuildRepoNameFromProjectKey(promotionParams.ProjectKey)
+		utils.GetProjectQueryParam(promotionParams.ProjectKey)
+
 	requestFullUrl, err := utils.BuildArtifactoryUrl(promoteUrl, restApi, make(map[string]string))
 	if err != nil {
 		return err

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -105,6 +105,13 @@ func BuildRepoNameFromProjectKey(projectKey string) string {
 	return fmt.Sprintf("%s-build-info", projectKey)
 }
 
+func GetProjectQueryParam(projectKey string) string {
+	if projectKey == "" {
+		return ""
+	}
+	return "?buildRepo=" + BuildRepoNameFromProjectKey(projectKey)
+}
+
 // paths - Sorted array.
 // index - Index of the current path which we want to check if it a prefix of any of the other previous paths.
 // separator - File separator.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes the following issue that jfrog-cli's tests detected.
```
=== RUN   TestBuildPromote
[Info] Creating spec file at: /Users/eyalb/dev/jfrog-cli/tmp/upload_split_spec_a.json
[Info] [Command] jfrog rt upload --spec=/Users/eyalb/dev/jfrog-cli/tmp/upload_split_spec_a.json --build-name=cli-tests-rt-build1-1612861733 --build-number=10
[Info] [Thread 1] Uploading artifact: testdata/a/a1.in
[Info] [Thread 0] Uploading artifact: testdata/a/a2.in
[Info] [Thread 2] Uploading artifact: testdata/a/a3.in
{
  "status": "success",
  "totals": {
    "success": 3,
    "failure": 0
  }
}
[Info] [Command] jfrog rt build-publish cli-tests-rt-build1-1612861733 10
[Info] Deploying build info...
[Info] Build info successfully deployed. Browse it in Artifactory under https://ecosysjfrog.jfrog.io/artifactory/webapp/builds/cli-tests-rt-build1-1612861733/10
[Info] [Command] jfrog rt build-promote cli-tests-rt-build1-1612861733 10 cli-tests-rt1-1612861733 --props=key=v1,v2;another=property
[Info] Promoting build...
    buildinfo_test.go:62: 
        	Error Trace:	buildinfo_test.go:62
        	Error:      	Received unexpected error:
        	            	Artifactory response: 404 Not Found
        	            	{
        	            	  "errors": [
        	            	    {
        	            	      "status": 404,
        	            	      "message": "Cannot find builds by the name 'cli-tests-rt-build1-1612861733' and the number '10?buildRepo=' and buildRepo 'artifactory-build-info'."
        	            	    }
        	            	  ]
        	            	}
        	Test:       	TestBuildPromote
[Info] Creating spec file at: /Users/eyalb/dev/jfrog-cli/tmp/search_all_repo1.json
[Info] [Command] jfrog rt build-promote cli-tests-rt2-1612861733 --props=key=v1,v2;another=property
[Info] Promoting build...
    buildinfo_test.go:82: 
        	Error Trace:	buildinfo_test.go:82
        	Error:      	Received unexpected error:
        	            	Artifactory response: 404 Not Found
        	            	{
        	            	  "errors": [
        	            	    {
        	            	      "status": 404,
        	            	      "message": "Cannot find builds by the name 'cli-tests-rt-build1-1612861733' and the number '10?buildRepo=' and buildRepo 'artifactory-build-info'."
        	            	    }
        	            	  ]
        	            	}
        	Test:       	TestBuildPromote
[Info] Creating spec file at: /Users/eyalb/dev/jfrog-cli/tmp/search_repo2.json
    buildinfo_test.go:97: 
        	Error Trace:	buildinfo_test.go:97
        	Error:      	Not equal: 
        	            	expected: 3
        	            	actual  : 0
        	Test:       	TestBuildPromote
        	Messages:   	Incorrect number of artifacts were uploaded
[Info] Cleaning test data...
/Users/eyalb/dev/jfrog-cli/testdata/specs/delete_spec.json
[Info] Creating spec file at: /Users/eyalb/dev/jfrog-cli/tmp/delete_spec.json
/Users/eyalb/dev/jfrog-cli/tmp/delete_spec.json
[Info] Searching artifacts...
[Info] Found 1 artifact.
[Info] Searching artifacts...
[Info] Found 0 artifacts.
[Info] Searching artifacts...
[Info] Found 0 artifacts.
[Info] Searching artifacts...
[Info] Found 0 artifacts.
[Info] [Thread 2] Deleting cli-tests-rt1-1612861733/data
--- FAIL: TestBuildPromote (11.14s)
```
