### PR TITLE
Build Artifactory client with custom http.client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ rtDetails.SetApiKey("apikey")
 rtDetails.SetUser("user")
 rtDetails.SetPassword("password")
 rtDetails.SetAccessToken("accesstoken")
-rtDetails.SetHttpClient(myCustomClient)
+serviceConfig, err := config.NewConfigBuilder().
+    SetServiceDetails(rtDetails).
+    SetDryRun(false).
+    SetHttpClient(myCustomClient).
+    Build()
 ```
 
 #### Creating Artifactory Service Config

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Artifactory APIs](#artifactory-apis)
     - [Creating Artifactory Service Manager](#creating-artifactory-service-manager)
       - [Creating Artifactory Details](#creating-artifactory-details)
+      - [Create Artifactory Details with Custom HTTP Client](#creating-artifactory-details-with-custom-http-client)
       - [Creating Artifactory Service Config](#creating-artifactory-service-config)
       - [Creating New Artifactory Service Manager](#creating-new-artifactory-service-manager)
     - [Using Artifactory Services](#using-artifactory-services)
@@ -214,6 +215,21 @@ rtDetails.SetAccessToken("accesstoken")
 // if client certificates are required
 rtDetails.SetClientCertPath("path/to/.cer")
 rtDetails.SetClientCertKeyPath("path/to/.key")
+```
+
+#### Create Artifactory Details with Custom HTTP Client
+```go
+proxyUrl, err := url.Parse("http://proxyIp:proxyPort")
+myCustomClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
+
+rtDetails := auth.NewArtifactoryDetails()
+rtDetails.SetUrl("http://localhost:8081/artifactory")
+rtDetails.SetSshKeysPath("path/to/.ssh/")
+rtDetails.SetApiKey("apikey")
+rtDetails.SetUser("user")
+rtDetails.SetPassword("password")
+rtDetails.SetAccessToken("accesstoken")
+rtDetails.SetHttpClient(myCustomClient)
 ```
 
 #### Creating Artifactory Service Config

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -40,6 +40,7 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 		AppendPreRequestInterceptor(artDetails.RunPreRequestFunctions).
 		SetContext(config.GetContext()).
 		SetRetries(config.GetHttpRetries()).
+		SetHttpClient(config.GetHttpClient()).
 		Build()
 	if err != nil {
 		return nil, err

--- a/auth/servicedetails.go
+++ b/auth/servicedetails.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
-	"net/http"
 	"sync"
 	"time"
 
@@ -31,7 +30,6 @@ type ServiceDetails interface {
 	GetSshAuthHeaders() map[string]string
 	GetClient() *jfroghttpclient.JfrogHttpClient
 	GetVersion() (string, error)
-	GetHttpClient() *http.Client
 
 	SetUrl(url string)
 	SetUser(user string)
@@ -47,7 +45,6 @@ type ServiceDetails interface {
 	SetSshAuthHeaders(sshAuthHeaders map[string]string)
 	SetClient(client *jfroghttpclient.JfrogHttpClient)
 	SetHttpTimeout(httpTimeout time.Duration)
-	SetHttpClient(httpClient *http.Client)
 
 	IsSshAuthHeaderSet() bool
 	IsSshAuthentication() bool
@@ -75,7 +72,6 @@ type CommonConfigFields struct {
 	TokenMutex             sync.Mutex
 	client                 *jfroghttpclient.JfrogHttpClient
 	httpTimeout            time.Duration
-	HttpClient             *http.Client `json:"-"`
 }
 
 func (ccf *CommonConfigFields) GetUrl() string {
@@ -130,10 +126,6 @@ func (ccf *CommonConfigFields) GetClient() *jfroghttpclient.JfrogHttpClient {
 	return ccf.client
 }
 
-func (ccf *CommonConfigFields) GetHttpClient() *http.Client {
-	return ccf.HttpClient
-}
-
 func (ccf *CommonConfigFields) SetUrl(url string) {
 	ccf.Url = url
 }
@@ -180,10 +172,6 @@ func (ccf *CommonConfigFields) SetSshPassphrase(sshPassphrase string) {
 
 func (ccf *CommonConfigFields) SetSshAuthHeaders(sshAuthHeaders map[string]string) {
 	ccf.SshAuthHeaders = sshAuthHeaders
-}
-
-func (ccf *CommonConfigFields) SetHttpClient(httpClient *http.Client) {
-	ccf.HttpClient = httpClient
 }
 
 func (ccf *CommonConfigFields) SetClient(client *jfroghttpclient.JfrogHttpClient) {

--- a/auth/servicedetails.go
+++ b/auth/servicedetails.go
@@ -181,6 +181,7 @@ func (ccf *CommonConfigFields) SetSshPassphrase(sshPassphrase string) {
 func (ccf *CommonConfigFields) SetSshAuthHeaders(sshAuthHeaders map[string]string) {
 	ccf.SshAuthHeaders = sshAuthHeaders
 }
+
 func (ccf *CommonConfigFields) SetHttpClient(httpClient *http.Client) {
 	ccf.HttpClient = httpClient
 }

--- a/auth/servicedetails.go
+++ b/auth/servicedetails.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"net/http"
 	"sync"
 	"time"
 
@@ -30,6 +31,7 @@ type ServiceDetails interface {
 	GetSshAuthHeaders() map[string]string
 	GetClient() *jfroghttpclient.JfrogHttpClient
 	GetVersion() (string, error)
+	GetHttpClient() *http.Client
 
 	SetUrl(url string)
 	SetUser(user string)
@@ -45,6 +47,7 @@ type ServiceDetails interface {
 	SetSshAuthHeaders(sshAuthHeaders map[string]string)
 	SetClient(client *jfroghttpclient.JfrogHttpClient)
 	SetHttpTimeout(httpTimeout time.Duration)
+	SetHttpClient(httpClient *http.Client)
 
 	IsSshAuthHeaderSet() bool
 	IsSshAuthentication() bool
@@ -72,6 +75,7 @@ type CommonConfigFields struct {
 	TokenMutex             sync.Mutex
 	client                 *jfroghttpclient.JfrogHttpClient
 	httpTimeout            time.Duration
+	HttpClient             *http.Client `json:"-"`
 }
 
 func (ccf *CommonConfigFields) GetUrl() string {
@@ -126,6 +130,10 @@ func (ccf *CommonConfigFields) GetClient() *jfroghttpclient.JfrogHttpClient {
 	return ccf.client
 }
 
+func (ccf *CommonConfigFields) GetHttpClient() *http.Client {
+	return ccf.HttpClient
+}
+
 func (ccf *CommonConfigFields) SetUrl(url string) {
 	ccf.Url = url
 }
@@ -172,6 +180,9 @@ func (ccf *CommonConfigFields) SetSshPassphrase(sshPassphrase string) {
 
 func (ccf *CommonConfigFields) SetSshAuthHeaders(sshAuthHeaders map[string]string) {
 	ccf.SshAuthHeaders = sshAuthHeaders
+}
+func (ccf *CommonConfigFields) SetHttpClient(httpClient *http.Client) {
+	ccf.HttpClient = httpClient
 }
 
 func (ccf *CommonConfigFields) SetClient(client *jfroghttpclient.JfrogHttpClient) {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/http"
 	"time"
 )
 
@@ -17,6 +18,7 @@ type Config interface {
 	GetContext() context.Context
 	GetHttpTimeout() time.Duration
 	GetHttpRetries() int
+	GetHttpClient() *http.Client
 }
 
 type servicesConfig struct {
@@ -29,6 +31,7 @@ type servicesConfig struct {
 	ctx              context.Context
 	httpTimeout      time.Duration
 	httpRetries      int
+	httpClient       *http.Client
 }
 
 func (config *servicesConfig) IsDryRun() bool {
@@ -65,4 +68,8 @@ func (config *servicesConfig) GetHttpTimeout() time.Duration {
 
 func (config *servicesConfig) GetHttpRetries() int {
 	return config.httpRetries
+}
+
+func (config *servicesConfig) GetHttpClient() *http.Client {
+	return config.httpClient
 }

--- a/config/configbuilder.go
+++ b/config/configbuilder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"net/http"
 	"time"
 )
 
@@ -24,6 +25,7 @@ type servicesConfigBuilder struct {
 	ctx              context.Context
 	httpTimeout      time.Duration
 	httpRetries      int
+	httpClient       *http.Client
 }
 
 func (builder *servicesConfigBuilder) SetServiceDetails(artDetails auth.ServiceDetails) *servicesConfigBuilder {
@@ -66,6 +68,11 @@ func (builder *servicesConfigBuilder) SetHttpRetries(httpRetries int) *servicesC
 	return builder
 }
 
+func (builder *servicesConfigBuilder) SetHttpClient(httpClient *http.Client) *servicesConfigBuilder {
+	builder.httpClient = httpClient
+	return builder
+}
+
 func (builder *servicesConfigBuilder) Build() (Config, error) {
 	c := &servicesConfig{}
 	c.ServiceDetails = builder.ServiceDetails
@@ -76,5 +83,6 @@ func (builder *servicesConfigBuilder) Build() (Config, error) {
 	c.ctx = builder.ctx
 	c.httpTimeout = builder.httpTimeout
 	c.httpRetries = builder.httpRetries
+	c.httpClient = builder.httpClient
 	return c, nil
 }

--- a/http/httpclient/clientBuilder.go
+++ b/http/httpclient/clientBuilder.go
@@ -84,13 +84,13 @@ func (builder *httpClientBuilder) AddClientCertToTransport(transport *http.Trans
 }
 
 func (builder *httpClientBuilder) Build() (*HttpClient, error) {
-	var err error
-	var transport *http.Transport
-
 	if builder.httpClient != nil {
 		// Using a custom http.Client, pass-though.
 		return &HttpClient{client: builder.httpClient, ctx: builder.ctx, retries: builder.retries}, nil
 	}
+
+	var err error
+	var transport *http.Transport
 
 	if builder.certificatesDirPath == "" {
 		transport = builder.createDefaultHttpTransport()

--- a/http/httpclient/clientBuilder.go
+++ b/http/httpclient/clientBuilder.go
@@ -28,6 +28,7 @@ type httpClientBuilder struct {
 	ctx                 context.Context
 	timeout             time.Duration
 	retries             int
+	httpClient          *http.Client
 }
 
 func (builder *httpClientBuilder) SetCertificatesPath(certificatesPath string) *httpClientBuilder {
@@ -47,6 +48,11 @@ func (builder *httpClientBuilder) SetClientCertKeyPath(certificatePath string) *
 
 func (builder *httpClientBuilder) SetInsecureTls(insecureTls bool) *httpClientBuilder {
 	builder.insecureTls = insecureTls
+	return builder
+}
+
+func (builder *httpClientBuilder) SetHttpClient(httpClient *http.Client) *httpClientBuilder {
+	builder.httpClient = httpClient
 	return builder
 }
 
@@ -80,6 +86,12 @@ func (builder *httpClientBuilder) AddClientCertToTransport(transport *http.Trans
 func (builder *httpClientBuilder) Build() (*HttpClient, error) {
 	var err error
 	var transport *http.Transport
+
+	if builder.httpClient != nil {
+		//using a custom http.Client, pass-though.
+		return &HttpClient{client: builder.httpClient, ctx: builder.ctx, retries: builder.retries}, nil
+	}
+
 	if builder.certificatesDirPath == "" {
 		transport = builder.createDefaultHttpTransport()
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: builder.insecureTls}

--- a/http/httpclient/clientBuilder.go
+++ b/http/httpclient/clientBuilder.go
@@ -88,7 +88,7 @@ func (builder *httpClientBuilder) Build() (*HttpClient, error) {
 	var transport *http.Transport
 
 	if builder.httpClient != nil {
-		//using a custom http.Client, pass-though.
+		// Using a custom http.Client, pass-though.
 		return &HttpClient{client: builder.httpClient, ctx: builder.ctx, retries: builder.retries}, nil
 	}
 

--- a/http/jfroghttpclient/clientbuilder.go
+++ b/http/jfroghttpclient/clientbuilder.go
@@ -73,6 +73,7 @@ func (builder *jfrogHttpClientBuilder) Build() (rtHttpClient *JfrogHttpClient, e
 		SetContext(builder.ctx).
 		SetTimeout(builder.timeout).
 		SetRetries(builder.retries).
+		SetHttpClient((*rtHttpClient.JfrogServiceDetails).GetHttpClient()).
 		Build()
 	return
 }

--- a/http/jfroghttpclient/clientbuilder.go
+++ b/http/jfroghttpclient/clientbuilder.go
@@ -3,6 +3,7 @@ package jfroghttpclient
 import (
 	"context"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"net/http"
 	"time"
 )
 
@@ -21,6 +22,7 @@ type jfrogHttpClientBuilder struct {
 	clientCertPath         string
 	clientCertKeyPath      string
 	timeout                time.Duration
+	httpClient             *http.Client
 }
 
 func (builder *jfrogHttpClientBuilder) SetCertificatesPath(certificatesPath string) *jfrogHttpClientBuilder {
@@ -63,6 +65,11 @@ func (builder *jfrogHttpClientBuilder) SetTimeout(timeout time.Duration) *jfrogH
 	return builder
 }
 
+func (builder *jfrogHttpClientBuilder) SetHttpClient(httpClient *http.Client) *jfrogHttpClientBuilder {
+	builder.httpClient = httpClient
+	return builder
+}
+
 func (builder *jfrogHttpClientBuilder) Build() (rtHttpClient *JfrogHttpClient, err error) {
 	rtHttpClient = &JfrogHttpClient{preRequestInterceptors: builder.preRequestInterceptors}
 	rtHttpClient.httpClient, err = httpclient.ClientBuilder().
@@ -73,7 +80,7 @@ func (builder *jfrogHttpClientBuilder) Build() (rtHttpClient *JfrogHttpClient, e
 		SetContext(builder.ctx).
 		SetTimeout(builder.timeout).
 		SetRetries(builder.retries).
-		SetHttpClient((*rtHttpClient.JfrogServiceDetails).GetHttpClient()).
+		SetHttpClient(builder.httpClient).
 		Build()
 	return
 }

--- a/tests/artifactorycustomhttpclient_test.go
+++ b/tests/artifactorycustomhttpclient_test.go
@@ -9,6 +9,33 @@ import (
 	"testing"
 )
 
+func TestGetArtifactoryVersionWithCustomHttpClient(t *testing.T) {
+	initArtifactoryTest(t)
+	rtDetails := GetRtDetails()
+
+	client := http.DefaultClient
+
+	serviceConfig, err := config.NewConfigBuilder().
+		SetServiceDetails(rtDetails).
+		SetDryRun(false).
+		SetHttpClient(client).
+		Build()
+	if err != nil {
+		t.Error(err)
+	}
+
+	rtManager, err := artifactory.New(serviceConfig)
+	if err != nil {
+		t.Error(err)
+	}
+
+	version, err := rtManager.GetVersion()
+	assert.NoError(t, err, "Should not fail")
+	if version == "" {
+		t.Error("Expected a version, got empty string")
+	}
+}
+
 func TestGetArtifactoryVersionWithProxyShouldFail(t *testing.T) {
 	initArtifactoryTest(t)
 	rtDetails := GetRtDetails()

--- a/tests/artifactorycustomhttpclient_test.go
+++ b/tests/artifactorycustomhttpclient_test.go
@@ -1,0 +1,37 @@
+package tests
+
+import (
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestGetArtifactoryVersionWithProxyShouldFail(t *testing.T) {
+	initArtifactoryTest(t)
+	rtDetails := GetRtDetails()
+
+	proxyUrl, err := url.Parse("http://invalidproxy:12345")
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)},
+	}
+
+	serviceConfig, err := config.NewConfigBuilder().
+		SetServiceDetails(rtDetails).
+		SetDryRun(false).
+		SetHttpClient(client).
+		Build()
+	if err != nil {
+		t.Error(err)
+	}
+
+	rtManager, err := artifactory.New(serviceConfig)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = rtManager.GetVersion()
+	assert.Error(t, err, "Should fail with invalid proxy")
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

fixes #289 

This functionality can be used as follows:

```go
httpProxy := "http://localhost:54321"
rtDetails := auth.NewArtifactoryDetails()
rtDetails.SetUrl(artifactoryUrl.String())
if httpProxy != "" {
      proxyUrl, err := url.Parse(httpProxy)
      if err != nil {
	      return err
      }
      rtDetails.SetHttpClient(&http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}})
}
rtDetails.SetUser("username")
rtDetails.SetPassword("password")

serviceConfig, err := config.NewConfigBuilder().
      SetServiceDetails(rtDetails).
      SetDryRun(false).
      Build()

```