### PR TITLE
Fix IsEncrypted for new Openssl format

### DIFF
--- a/auth/sshlogin.go
+++ b/auth/sshlogin.go
@@ -135,7 +135,7 @@ func IsEncrypted(buffer []byte) (bool, error) {
 		}
 	}
 	// Key is not encrypted or an error occurred
-	return false, nil
+	return false, err
 }
 
 func parseUrl(url string) (protocol, host string, port int, err error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

In the new OpenSSH format of the private SSH keys, the private keys do not contain the `Proc-Type: ENCRYPTED` header 
(See https://security.stackexchange.com/a/129729). Therefore, we have to find out whether the key is encrypted using another method.

To resolve this issue, I used [ParsePrivateKey](https://pkg.go.dev/golang.org/x/crypto/ssh#ParsePrivateKey) of Go builtin ssh package.
