### PR TITLE
Support commands on aggregated builds

### DIFF
--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -471,7 +471,7 @@ func filterBuildAqlSearchResults(reader *content.ContentReader, buildArtifactsSh
 			buildArtifactsSha[resultItem.Actual_Sha1] = 0
 			continue
 		}
-		if isBuildContained(resultBuildName, "", builds) && buildArtifactsSha[resultItem.Actual_Sha1] != 0 {
+		if isBuildNameContained(resultBuildName, builds) && buildArtifactsSha[resultItem.Actual_Sha1] != 0 {
 			priorityArray[1].Write(*resultItem)
 			buildArtifactsSha[resultItem.Actual_Sha1] = 1
 			continue
@@ -510,11 +510,20 @@ func filterBuildAqlSearchResults(reader *content.ContentReader, buildArtifactsSh
 	return content.NewContentReader(resultCw.GetFilePath(), content.DefaultKey), nil
 }
 
-// Return true if the input buildName and buildNumber are contained in the builds array.
-// If the buildNumber is empty, compare only the build names.
+// Return true if the input buildName and buildNumber contained in the builds array.
 func isBuildContained(buildName, buildNumber string, builds []Build) bool {
 	for _, build := range builds {
-		if build.BuildName == buildName && (buildNumber == "" || build.BuildNumber == buildNumber) {
+		if build.BuildName == buildName && build.BuildNumber == buildNumber {
+			return true
+		}
+	}
+	return false
+}
+
+// Return true if the input buildName contained in the builds array.
+func isBuildNameContained(buildName string, builds []Build) bool {
+	for _, build := range builds {
+		if build.BuildName == buildName {
 			return true
 		}
 	}

--- a/artifactory/services/utils/artifactoryutils_test.go
+++ b/artifactory/services/utils/artifactoryutils_test.go
@@ -44,7 +44,7 @@ func TestFilterBuildAqlSearchResults(t *testing.T) {
 	assert.NoError(t, err)
 	resultsToFilter := content.NewContentReader(filepath.Join(testDataPath, "filter_build_aql_search.json"), content.DefaultKey)
 	buildArtifactsSha := map[string]int{"a": 2, "b": 2, "c": 2}
-	resultReader, err := filterBuildAqlSearchResults(resultsToFilter, buildArtifactsSha, "myBuild", "1")
+	resultReader, err := filterBuildAqlSearchResults(resultsToFilter, buildArtifactsSha, []Build{{"myBuild", "1"}})
 	defer resultReader.Close()
 	assert.NoError(t, err)
 	isMatch, err := fileutils.FilesIdentical(resultReader.GetFilePath(), filepath.Join(testDataPath, "filter_build_aql_search_expected.json"))

--- a/artifactory/services/utils/parsebuildnamenumber_test.go
+++ b/artifactory/services/utils/parsebuildnamenumber_test.go
@@ -74,8 +74,7 @@ func TestBuildParsingBuildNumberWithOnlyEscapeChars(t *testing.T) {
 func TestBundleParsingNoBundleVersion(t *testing.T) {
 	log.SetLogger(log.NewLogger(log.DEBUG, nil))
 	_, _, err := parseNameAndVersion("CLI-Bundle-Name", false)
-	assert.EqualError(t, err, "No '/' is found in the bundle")
-
+	assert.EqualError(t, err, "No '/' is found in 'CLI-Bundle-Name'")
 }
 
 func TestBundleParsingBundleVersionProvided(t *testing.T) {
@@ -116,5 +115,5 @@ func TestBundleParsingBundleVersionWithEscapeCharsInTheBundleVersion(t *testing.
 
 func TestBundleParsingBundleVersionWithOnlyEscapeChars(t *testing.T) {
 	_, _, err := parseNameAndVersion("CLI-Bundle-Name\\/1\\/2\\/3\\/4", false)
-	assert.EqualError(t, err, "No delimiter char (/) without escaping char was found in the bundle")
+	assert.EqualError(t, err, "No delimiter char (/) without escaping char was found in 'CLI-Bundle-Name\\/1\\/2\\/3\\/4'")
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Integration tests on CLI: https://github.com/jfrog/jfrog-cli/pull/990

Support operations in transitive builds in all AQL-based commands: Search, Download, Delete, Move, Copy, and GitLfsClean.
Build A is considered transitive of build B if A is a module of B or another transitive build of B:
```json
{
    "name": "B",
    "modules": [{
        "id": "A",
        "type": "Build"
    }]
}
```
