### PR TITLE
Replace "buildRepo" with "project" on build APIs

### DIFF
--- a/artifactory/services/discardBuilds.go
+++ b/artifactory/services/discardBuilds.go
@@ -37,10 +37,8 @@ func (ds *DiscardBuildsService) DiscardBuilds(params DiscardBuildsParams) error 
 		return err
 	}
 	requestFullUrl += "?async=" + strconv.FormatBool(params.IsAsync())
-
-	buildRepo := utils.BuildRepoNameFromProjectKey(params.ProjectKey)
-	if buildRepo != "" {
-		requestFullUrl += "&buildRepo=" + buildRepo
+	if params.ProjectKey != "" {
+		requestFullUrl += "&project=" + params.ProjectKey
 	}
 
 	var excludeBuilds []string

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -36,10 +36,14 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 	log.Info(message)
 
 	promoteUrl := ps.ArtDetails.GetUrl()
-	restApi := path.Join("api/build/promote/", promotionParams.GetBuildName(), promotionParams.GetBuildNumber()) +
-		utils.GetProjectQueryParam(promotionParams.ProjectKey)
+	restApi := path.Join("api/build/promote/", promotionParams.GetBuildName(), promotionParams.GetBuildNumber())
 
-	requestFullUrl, err := utils.BuildArtifactoryUrl(promoteUrl, restApi, make(map[string]string))
+	queryParams := make(map[string]string)
+	if promotionParams.ProjectKey != "" {
+		queryParams["project"] = promotionParams.ProjectKey
+	}
+
+	requestFullUrl, err := utils.BuildArtifactoryUrl(promoteUrl, restApi, queryParams)
 	if err != nil {
 		return err
 	}

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -557,8 +557,14 @@ func GetBuildInfo(buildName, buildNumber, projectKey string, flags CommonConf) (
 
 	// Get build-info json from Artifactory.
 	httpClientsDetails := flags.GetArtifactoryDetails().CreateHttpClientDetails()
-	restApi := path.Join("api/build/", name, number) + GetProjectQueryParam(projectKey)
-	requestFullUrl, err := BuildArtifactoryUrl(flags.GetArtifactoryDetails().GetUrl(), restApi, make(map[string]string))
+	restApi := path.Join("api/build/", name, number)
+
+	queryParams := make(map[string]string)
+	if projectKey != "" {
+		queryParams["project"] = projectKey
+	}
+
+	requestFullUrl, err := BuildArtifactoryUrl(flags.GetArtifactoryDetails().GetUrl(), restApi, queryParams)
 
 	httpClient, err := flags.GetJfrogHttpClient()
 	if err != nil {

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -109,20 +108,11 @@ func IsWildcardPattern(pattern string) bool {
 	return strings.Contains(pattern, "*") || strings.HasSuffix(pattern, "/") || !strings.Contains(pattern, "/")
 }
 
-// Returns the name of the build-info repository, corresponding to the project key sent.
-// Returns an empty string, if the provided projectKey is empty.
-func BuildRepoNameFromProjectKey(projectKey string) string {
-	if projectKey == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s-build-info", projectKey)
-}
-
 func GetProjectQueryParam(projectKey string) string {
 	if projectKey == "" {
 		return ""
 	}
-	return "?buildRepo=" + BuildRepoNameFromProjectKey(projectKey)
+	return "?project=" + projectKey
 }
 
 // paths - Sorted array.

--- a/artifactory/services/xrayscan.go
+++ b/artifactory/services/xrayscan.go
@@ -39,7 +39,7 @@ func (ps *XrayScanService) ScanBuild(scanParams XrayScanParams) ([]byte, error) 
 	data := XrayScanBody{
 		BuildName:   scanParams.GetBuildName(),
 		BuildNumber: scanParams.GetBuildNumber(),
-		BuildRepo:   scanParams.GetBuildNumber(),
+		Project:     scanParams.GetProjectKey(),
 		Context:     clientutils.GetUserAgent(),
 	}
 
@@ -132,7 +132,7 @@ type errorsStatusResponse struct {
 type XrayScanBody struct {
 	BuildName   string `json:"buildName,omitempty"`
 	BuildNumber string `json:"buildNumber,omitempty"`
-	BuildRepo   string `json:"buildRepo,omitempty"`
+	Project     string `json:"project,omitempty"`
 	Context     string `json:"context,omitempty"`
 }
 
@@ -148,6 +148,10 @@ func (bp *XrayScanParams) GetBuildName() string {
 
 func (bp *XrayScanParams) GetBuildNumber() string {
 	return bp.BuildNumber
+}
+
+func (bp *XrayScanParams) GetProjectKey() string {
+	return bp.ProjectKey
 }
 
 func NewXrayScanParams() XrayScanParams {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR replaces the usage of the "buildRepo" query param with "project", to be compliant with Artifactory's REST APIs requirements.