### PR TITLE
Add Regenerate API to manger

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -70,6 +70,7 @@ type ArtifactoryServicesManager interface {
 	CreateUser(params services.UserParams) error
 	UpdateUser(params services.UserParams) error
 	DeleteUser(name string) error
+	RegenerateAPIKey() (string, error)
 }
 
 // By using this struct, you have the option of overriding only some of the ArtifactoryServicesManager

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -416,3 +416,9 @@ func (sm *ArtifactoryServicesManagerImp) PromoteDocker(params services.DockerPro
 func (sm *ArtifactoryServicesManagerImp) Client() *jfroghttpclient.JfrogHttpClient {
 	return sm.client
 }
+
+func (sm *ArtifactoryServicesManagerImp) RegenerateAPIKey() (string, error) {
+	securityService := services.NewSecurityService(sm.client)
+	securityService.ArtDetails = sm.config.GetServiceDetails()
+	return securityService.RegenerateAPIKey()
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

README.md mentions that the `RegenerateAPIKey` function can be invoked using an instance of `manager`. 

```
apiKey, err := rtManager.RegenerateAPIKey()
```

This isn't true. This PR corrects this by implementing RegenerateAPIKey function in manager.go
