### PR TITLE
Use API v2 in delete permission target

### DIFF
--- a/artifactory/services/permissiontarget.go
+++ b/artifactory/services/permissiontarget.go
@@ -29,7 +29,7 @@ func (pts *PermissionTargetService) GetJfrogHttpClient() *jfroghttpclient.JfrogH
 func (pts *PermissionTargetService) Delete(permissionTargetName string) error {
 	httpClientsDetails := pts.ArtDetails.CreateHttpClientDetails()
 	log.Info("Deleting permission target...")
-	resp, body, err := pts.client.SendDelete(pts.ArtDetails.GetUrl()+"api/security/permissions/"+permissionTargetName, nil, &httpClientsDetails)
+	resp, body, err := pts.client.SendDelete(pts.ArtDetails.GetUrl()+"api/v2/security/permissions/"+permissionTargetName, nil, &httpClientsDetails)
 	if err != nil {
 		return err
 	}

--- a/tests/artifactorypermissiontarget_test.go
+++ b/tests/artifactorypermissiontarget_test.go
@@ -82,4 +82,6 @@ func TestPermissionTargetEmptyFields(t *testing.T) {
 	assert.Nil(t, params.ReleaseBundle)
 	assert.NoError(t, testsPermissionTargetService.Create(params))
 	validatePermissionTarget(t, params)
+	err := testsPermissionTargetService.Delete(params.Name)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Use `DELETE api/v2/security/permissions/<permissionTargetName>` 
instead of `DELETE api/security/permissions/<permissionTargetName>`

In some cases, the permission target is not deleted. To reproduce, run TestPermissionTarget.
Verified on:
* Artifactory 7.17.5 on artifactory-pro Docker image
* Artifactory 7.17.4 on Artifactory SaaS