### PR TITLE
Download fails with panic, if filtered build does not exist

### DIFF
--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -43,6 +43,11 @@ func SearchBySpecWithBuild(specFile *ArtifactoryCommonParams, flags CommonConf) 
 		return nil, err
 	}
 
+	// The specified build does not exist, so an empty reader is returned.
+	if len(aggregatedBuilds) == 0 {
+		return content.NewEmptyContentReader(content.DefaultKey), nil
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -74,10 +79,10 @@ func SearchBySpecWithBuild(specFile *ArtifactoryCommonParams, flags CommonConf) 
 		defer dependenciesReader.Close()
 	}
 	if artErr != nil {
-		return nil, err
+		return nil, artErr
 	}
 	if depErr != nil {
-		return nil, err
+		return nil, depErr
 	}
 
 	return filterBuildArtifactsAndDependencies(artifactsReader, dependenciesReader, specFile, flags, aggregatedBuilds)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes one of the issues reported at https://github.com/jfrog/artifactory-azure-devops-extension/issues/235.
The following command fails with a panic, if the filtered build does not exist - 
```
jfrog rt dl "*" "/home/vsts/work/r1/a/x/" --build="gradle-cli/1" --flat --fail-no-op

```