### PR TITLE
remove omitempty since default is true

### DIFF
--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -85,15 +85,16 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 }
 
 type BuildPromotionBody struct {
-	Comment             string              `json:"comment,omitempty"`
-	SourceRepo          string              `json:"sourceRepo,omitempty"`
-	TargetRepo          string              `json:"targetRepo,omitempty"`
-	Status              string              `json:"status,omitempty"`
-	IncludeDependencies bool                `json:"dependencies,omitempty"`
-	Copy                bool                `json:"copy,omitempty"`
-	FailFast            bool                `json:"failFast"`
-	DryRun              bool                `json:"dryRun,omitempty"`
-	Properties          map[string][]string `json:"properties,omitempty"`
+	Comment             string `json:"comment,omitempty"`
+	SourceRepo          string `json:"sourceRepo,omitempty"`
+	TargetRepo          string `json:"targetRepo,omitempty"`
+	Status              string `json:"status,omitempty"`
+	IncludeDependencies bool   `json:"dependencies,omitempty"`
+	Copy                bool   `json:"copy,omitempty"`
+	// FailFast options default is true. We need to avoid omitempty, otherwise, it would be forced to false if omitted.
+	FailFast   bool                `json:"failFast"`
+	DryRun     bool                `json:"dryRun,omitempty"`
+	Properties map[string][]string `json:"properties,omitempty"`
 }
 
 type PromotionParams struct {

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -91,7 +91,7 @@ type BuildPromotionBody struct {
 	Status              string              `json:"status,omitempty"`
 	IncludeDependencies bool                `json:"dependencies,omitempty"`
 	Copy                bool                `json:"copy,omitempty"`
-	FailFast            bool                `json:"failFast,omitempty"`
+	FailFast            bool                `json:"failFast"`
 	DryRun              bool                `json:"dryRun,omitempty"`
 	Properties          map[string][]string `json:"properties,omitempty"`
 }


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----

FailFast needs to be always printed in the response since it defaults to true
