### PR TITLE
feat: use Build info to create release bundle

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -23,12 +23,16 @@ func CreateAqlBodyForSpecWithPattern(params *ArtifactoryCommonParams) (string, e
 	itemTypeQuery := buildItemTypeQueryPart(params)
 	nePath := buildNePathPart(triplesSize == 0 || includeRoot)
 	excludeQuery := buildExcludeQueryPart(params, triplesSize == 0 || params.Recursive, params.Recursive)
+	buildQueryPart, err := buildBuildInfoQuery(params)
+	if err != nil {
+		return "", err
+	}
 	releaseBundle, err := buildReleaseBundleQuery(params)
 	if err != nil {
 		return "", err
 	}
 
-	json := fmt.Sprintf(`{%s"$or":[`, propsQueryPart+itemTypeQuery+nePath+excludeQuery+releaseBundle)
+	json := fmt.Sprintf(`{%s"$or":[`, propsQueryPart+itemTypeQuery+nePath+excludeQuery+buildQueryPart+releaseBundle)
 
 	// Get archive search parameters
 	archivePathFilePairs := createArchiveSearchParams(params)
@@ -253,6 +257,19 @@ func buildExcludeQueryPart(params *ArtifactoryCommonParams, useLocalPath, recurs
 		excludeQuery += fmt.Sprintf(`"$or":[{%s"path":{"$nmatch":"%s"},"name":{"$nmatch":"%s"}}],`, excludeRepoStr, excludePath, excludeTriple.file)
 	}
 	return excludeQuery
+}
+
+func buildBuildInfoQuery(params *ArtifactoryCommonParams) (string, error) {
+	buildName, buildVersion, err := parseNameAndVersion(params.Build, false)
+	if buildName == "" || err != nil {
+		return "", err
+	}
+	itemsPart := `"$and":` +
+		`[{` +
+		`"artifact.module.build.name":%s,` +
+		`"artifact.module.build.number":%s` +
+		`}],`
+	return fmt.Sprintf(itemsPart, getAqlValue(buildName), getAqlValue(buildVersion)), nil
 }
 
 func buildReleaseBundleQuery(params *ArtifactoryCommonParams) (string, error) {


### PR DESCRIPTION
I noticed that ArtifactoryCommonParams.Build is never use during the creation of a release bundle.
I use the "same" code as Bundle parameter. Works fine :)
