### PR TITLE
Placeholders logic ignores '--flat'

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -183,11 +183,11 @@ func (ds *DownloadService) produceTasks(reader *content.ContentReader, downloadP
 		if err != nil {
 			return "", err
 		}
-		target, includePlaceholder, err := clientutils.BuildTargetPath(downloadParams.GetPattern(), resultItem.GetItemRelativePath(), downloadParams.GetTarget(), true)
+		target, placeholdersUsed, err := clientutils.BuildTargetPath(downloadParams.GetPattern(), resultItem.GetItemRelativePath(), downloadParams.GetTarget(), true)
 		if err != nil {
 			return "", err
 		}
-		localPath, localFileName := fileutils.GetLocalPathAndFile(resultItem.Name, resultItem.Path, target, flat, includePlaceholder)
+		localPath, localFileName := fileutils.GetLocalPathAndFile(resultItem.Name, resultItem.Path, target, flat, placeholdersUsed)
 		return filepath.Join(localPath, localFileName), nil
 	}
 	// The sort process omits results with local path that is identical to previous results.
@@ -445,11 +445,11 @@ func (ds *DownloadService) createFileHandlerFunc(downloadParams DownloadParams, 
 				successCounters[threadId]++
 				return nil
 			}
-			target, includePlaceholder, e := clientutils.BuildTargetPath(downloadData.DownloadPath, downloadData.Dependency.GetItemRelativePath(), downloadData.Target, true)
+			target, placeholdersUsed, e := clientutils.BuildTargetPath(downloadData.DownloadPath, downloadData.Dependency.GetItemRelativePath(), downloadData.Target, true)
 			if e != nil {
 				return e
 			}
-			localPath, localFileName := fileutils.GetLocalPathAndFile(downloadData.Dependency.Name, downloadData.Dependency.Path, target, downloadData.Flat, includePlaceholder)
+			localPath, localFileName := fileutils.GetLocalPathAndFile(downloadData.Dependency.Name, downloadData.Dependency.Path, target, downloadData.Flat, placeholdersUsed)
 			if downloadData.Dependency.Type == "folder" {
 				return createDir(localPath, localFileName, logMsgPrefix)
 			}

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -2,13 +2,14 @@ package services
 
 import (
 	"errors"
-	"github.com/jfrog/jfrog-client-go/http/httpclient"
-	"github.com/jfrog/jfrog-client-go/utils/version"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"github.com/jfrog/jfrog-client-go/utils/version"
 
 	"github.com/jfrog/gofrog/parallel"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -182,11 +183,11 @@ func (ds *DownloadService) produceTasks(reader *content.ContentReader, downloadP
 		if err != nil {
 			return "", err
 		}
-		target, err := clientutils.BuildTargetPath(downloadParams.GetPattern(), resultItem.GetItemRelativePath(), downloadParams.GetTarget(), true)
+		target, includePlaceholder, err := clientutils.BuildTargetPath(downloadParams.GetPattern(), resultItem.GetItemRelativePath(), downloadParams.GetTarget(), true)
 		if err != nil {
 			return "", err
 		}
-		localPath, localFileName := fileutils.GetLocalPathAndFile(resultItem.Name, resultItem.Path, target, flat)
+		localPath, localFileName := fileutils.GetLocalPathAndFile(resultItem.Name, resultItem.Path, target, flat, includePlaceholder)
 		return filepath.Join(localPath, localFileName), nil
 	}
 	// The sort process omits results with local path that is identical to previous results.
@@ -444,11 +445,11 @@ func (ds *DownloadService) createFileHandlerFunc(downloadParams DownloadParams, 
 				successCounters[threadId]++
 				return nil
 			}
-			target, e := clientutils.BuildTargetPath(downloadData.DownloadPath, downloadData.Dependency.GetItemRelativePath(), downloadData.Target, true)
+			target, includePlaceholder, e := clientutils.BuildTargetPath(downloadData.DownloadPath, downloadData.Dependency.GetItemRelativePath(), downloadData.Target, true)
 			if e != nil {
 				return e
 			}
-			localPath, localFileName := fileutils.GetLocalPathAndFile(downloadData.Dependency.Name, downloadData.Dependency.Path, target, downloadData.Flat)
+			localPath, localFileName := fileutils.GetLocalPathAndFile(downloadData.Dependency.Name, downloadData.Dependency.Path, target, downloadData.Flat, includePlaceholder)
 			if downloadData.Dependency.Type == "folder" {
 				return createDir(localPath, localFileName, logMsgPrefix)
 			}

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -128,11 +128,11 @@ func GetFileAndDirFromPath(path string) (fileName, dir string) {
 }
 
 // Get the local path and filename from original file name and path according to targetPath
-func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat bool, includePlaceholder bool) (localTargetPath, fileName string) {
+func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat bool, placeholdersUsed bool) (localTargetPath, fileName string) {
 	targetFileName, targetDirPath := GetFileAndDirFromPath(targetPath)
 	localTargetPath = FixPathForWindows(targetDirPath)
-	// Ignore flat if placeholders are used.
-	if !flat && !includePlaceholder {
+	// When placeholders are used, the file path shouldn't be taken into account (or in other words, flat = true).
+	if !flat && !placeholdersUsed {
 		localTargetPath = filepath.Join(targetDirPath, relativePath)
 	}
 

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -128,10 +128,11 @@ func GetFileAndDirFromPath(path string) (fileName, dir string) {
 }
 
 // Get the local path and filename from original file name and path according to targetPath
-func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat bool) (localTargetPath, fileName string) {
+func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat bool, includePlaceholder bool) (localTargetPath, fileName string) {
 	targetFileName, targetDirPath := GetFileAndDirFromPath(targetPath)
 	localTargetPath = FixPathForWindows(targetDirPath)
-	if !flat {
+	// Ignore flat if placeholders are used.
+	if !flat && !includePlaceholder {
 		localTargetPath = filepath.Join(targetDirPath, relativePath)
 	}
 

--- a/utils/parenthesesutils.go
+++ b/utils/parenthesesutils.go
@@ -32,7 +32,7 @@ func (p *ParenthesesSlice) IsPresent(index int) bool {
 }
 
 // Return true if at least one of the {i} in 'target' has corresponding parentheses in 'pattern'.
-func ContainPlaceHolder(pattern, target string) bool {
+func PlaceholdersUserd(pattern, target string) bool {
 	removedParenthesesTarget := RemovePlaceholderParentheses(pattern, target)
 	return removedParenthesesTarget != target
 }

--- a/utils/parenthesesutils.go
+++ b/utils/parenthesesutils.go
@@ -31,6 +31,12 @@ func (p *ParenthesesSlice) IsPresent(index int) bool {
 	return false
 }
 
+// Return true if at least one of the {i} in 'target' has corresponding parentheses in 'pattern'.
+func ContainPlaceHolder(pattern, target string) bool {
+	removedParenthesesTarget := RemovePlaceholderParentheses(pattern, target)
+	return removedParenthesesTarget != target
+}
+
 func RemovePlaceholderParentheses(pattern, target string) string {
 	parentheses := NewParenthesesSlice(pattern, target)
 	// Remove parentheses which have a corresponding placeholder.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -290,6 +290,7 @@ func BuildTargetPath(pattern, path, target string, ignoreRepo bool) (string, boo
 
 // group - regular expression matched group to replace with placeholders
 // toReplace - target pattern to replace
+// Return - (parsed placeholders string, placeholders were  replaced)
 func ReplacePlaceHolders(groups []string, toReplace string) (string, bool) {
 	preReplaced := toReplace
 	for i := 1; i < len(groups); i++ {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -45,7 +45,7 @@ func TestBuildTargetPath(t *testing.T) {
 }
 
 func assertBuildTargetPath(regexp, source, dest, expected string, ignoreRepo bool, t *testing.T) {
-	result, err := BuildTargetPath(regexp, source, dest, ignoreRepo)
+	result, _, err := BuildTargetPath(regexp, source, dest, ignoreRepo)
 	if err != nil {
 		t.Error(err.Error())
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Placeholders define the target path of each file for upload/download/move/copy commands. As `--flat` makes sense while using wildcard patter, there is no concrete meaning for using it with placeholders, resulting in unintuitive results.
For example, `mypath/{1}/{2}/{3}/{1}' as a target path, ` --flat` has no meaning since we create the structure for each file, As a result, the question if to use ` --flat` makes no sense here.

Resolves: https://github.com/jfrog/jfrog-cli/issues/883
Related PR: https://github.com/jfrog/jfrog-cli/pull/1131