### PR TITLE
Fix: Get deploy target repository while using old gradle plugins versions.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -490,17 +490,18 @@ type FileTransferDetails struct {
 
 // Represent deployed artifact's details returned from build-info project for maven and gradle.
 type DeployableArtifactDetails struct {
-	SourcePath      	string `json:"sourcePath,omitempty"`
-	ArtifactDest    	string `json:"artifactDest,omitempty"`
-	Sha256          	string `json:"sha256,omitempty"`
-	DeploySucceeded 	bool   `json:"deploySucceeded,omitempty"`
-	TargetRepository	string `json:"targetRepository,omitempty"`
+	SourcePath       string `json:"sourcePath,omitempty"`
+	ArtifactDest     string `json:"artifactDest,omitempty"`
+	Sha256           string `json:"sha256,omitempty"`
+	DeploySucceeded  bool   `json:"deploySucceeded,omitempty"`
+	TargetRepository string `json:"targetRepository,omitempty"`
 }
 
 func (detailes *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl, targetRepository string) FileTransferDetails {
 	targetPath := rtUrl + targetRepository + "/" + detailes.ArtifactDest
 	return FileTransferDetails{SourcePath: detailes.SourcePath, TargetPath: targetPath, Sha256: detailes.Sha256}
 }
+
 type UploadResponseBody struct {
 	Checksums ChecksumDetails `json:"checksums,omitempty"`
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -497,8 +497,8 @@ type DeployableArtifactDetails struct {
 	TargetRepository	string `json:"targetRepository,omitempty"`
 }
 
-func (detailes *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl string) FileTransferDetails {
-	targetPath := rtUrl + detailes.TargetRepository + detailes.ArtifactDest
+func (detailes *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl, targetRepository string) FileTransferDetails {
+	targetPath := rtUrl + targetRepository + "/" + detailes.ArtifactDest
 	return FileTransferDetails{SourcePath: detailes.SourcePath, TargetPath: targetPath, Sha256: detailes.Sha256}
 }
 type UploadResponseBody struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Relevant deployment repository will be written by the buildinfo project to the diplyableArtifacts file starting from version 2.24.12 of build-info-extractor-gradle.
In case of a gradle project with a configuration of 'usePlugin=true' it's possible that an old build-info-extractor-gradle version is being used.
In this case, deployment repository will be read from the local project configuration file.