### PR TITLE
Encode build name and number when outputs build url

### DIFF
--- a/artifactory/services/buildinfo.go
+++ b/artifactory/services/buildinfo.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -77,6 +78,6 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo, projec
 	summary.SetSha256(resp.Header.Get("X-Checksum-Sha256"))
 
 	log.Debug("Artifactory response:", resp.Status)
-	log.Info("Build info successfully deployed. Browse it in Artifactory under " + bis.GetArtifactoryDetails().GetUrl() + "webapp/builds/" + build.Name + "/" + build.Number)
+	log.Info("Build info successfully deployed. Browse it in Artifactory under " + bis.GetArtifactoryDetails().GetUrl() + "webapp/builds/" + url.QueryEscape(build.Name) + "/" + url.QueryEscape(build.Number))
 	return summary, nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixes https://github.com/jfrog/jfrog-cli/issues/158