### PR TITLE
Fix double slashes in download target path

### DIFF
--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -130,7 +130,8 @@ func GetFileAndDirFromPath(path string) (fileName, dir string) {
 // Get the local path and filename from original file name and path according to targetPath
 func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat bool, placeholdersUsed bool) (localTargetPath, fileName string) {
 	targetFileName, targetDirPath := GetFileAndDirFromPath(targetPath)
-	localTargetPath = FixPathForWindows(targetDirPath)
+	// Remove double slashes and double backslashes that may appear in the path
+	localTargetPath = filepath.Join(targetDirPath)
 	// When placeholders are used, the file path shouldn't be taken into account (or in other words, flat = true).
 	if !flat && !placeholdersUsed {
 		localTargetPath = filepath.Join(targetDirPath, relativePath)
@@ -142,10 +143,6 @@ func GetLocalPathAndFile(originalFileName, relativePath, targetPath string, flat
 		fileName = targetFileName
 	}
 	return
-}
-
-func FixPathForWindows(path string) string {
-	return strings.Replace(path, "\\\\", "\\", -1)
 }
 
 // Return the recursive list of files and directories in the specified path


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
