### PR TITLE
Fix download latest build number for v1

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -422,11 +422,11 @@ func getArtifactPropertyByKey(properties []utils.Property, key string) string {
 }
 
 func getArtifactSymlinkPath(properties []utils.Property) string {
-	return getArtifactPropertyByKey(properties, utils.ARTIFACTORY_SYMLINK)
+	return getArtifactPropertyByKey(properties, utils.ArtifactorySymlink)
 }
 
 func getArtifactSymlinkChecksum(properties []utils.Property) string {
-	return getArtifactPropertyByKey(properties, utils.SYMLINK_SHA1)
+	return getArtifactPropertyByKey(properties, utils.SymlinkSha1)
 }
 
 type fileHandlerFunc func(DownloadData) parallel.TaskFunc

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -170,9 +170,9 @@ func createProperties(artifact clientutils.Artifact, uploadParams UploadParams) 
 				return nil, err
 			}
 			sha1 := checksumInfo[checksum.SHA1]
-			artifactProps.AddProperty(utils.SYMLINK_SHA1, sha1)
+			artifactProps.AddProperty(utils.SymlinkSha1, sha1)
 		}
-		artifactProps.AddProperty(utils.ARTIFACTORY_SYMLINK, artifactSymlink)
+		artifactProps.AddProperty(utils.ArtifactorySymlink, artifactSymlink)
 	}
 	return utils.MergeProperties([]*utils.Properties{uploadParams.GetTargetProps(), artifactProps}), nil
 }

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -135,6 +135,17 @@ func CreateAqlQueryForPypi(repo, file string) string {
 	return fmt.Sprintf(itemsPart, repo, file, buildIncludeQueryPart([]string{"name", "repo", "path", "actual_md5", "actual_sha1"}))
 }
 
+func CreateAqlQueryForLatestCreated(repo, path string) string {
+	itemsPart :=
+		`items.find({` +
+			`"repo": "%s",` +
+			`"path": {"$match": "%s"}` +
+			`})` +
+			`.sort({%s})` +
+			`.limit(1)`
+	return fmt.Sprintf(itemsPart, repo, path, buildSortQueryPart([]string{"created"}, "desc"))
+}
+
 func prepareSearchPattern(pattern string, repositoryExists bool) string {
 	addWildcardIfNeeded(&pattern, repositoryExists)
 	// Remove parenthesis

--- a/artifactory/services/utils/aqlquerybuilder_test.go
+++ b/artifactory/services/utils/aqlquerybuilder_test.go
@@ -119,6 +119,19 @@ func assertSortBody(actual, expected string, t *testing.T) {
 	}
 }
 
+func TestCreateAqlQueryForLatestCreated(t *testing.T) {
+	actual := CreateAqlQueryForLatestCreated("repo", "name")
+	expected := `items.find({` +
+		`"repo": "repo",` +
+		`"path": {"$match": "name"}` +
+		`})` +
+		`.sort({"$desc":["created"]})` +
+		`.limit(1)`
+	if actual != expected {
+		t.Error("The function CreateAqlQueryForLatestCreated expected to return the string:\n'" + expected + "'.\nbut returned:\n'" + actual + "'.")
+	}
+}
+
 func TestPrepareSourceSearchPattern(t *testing.T) {
 	newPattern := prepareSourceSearchPattern("/testdata/b/b1/b.in", "/testdata", true)
 	assert.Equal(t, "/testdata/b/b1/b.in", newPattern)

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/auth"
-	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	ARTIFACTORY_SYMLINK = "symlink.dest"
-	SYMLINK_SHA1        = "symlink.destsha1"
-	Latest              = "LATEST"
-	LastRelease         = "LAST_RELEASE"
+	ArtifactorySymlink            = "symlink.dest"
+	SymlinkSha1                   = "symlink.destsha1"
+	latest                        = "LATEST"
+	lastRelease                   = "LAST_RELEASE"
+	defaultBuildRepositoriesValue = "artifactory-build-info"
 )
 
 func UploadFile(localPath, url, logMsgPrefix string, artifactoryDetails *auth.ServiceDetails, details *fileutils.FileDetails,
@@ -150,7 +151,7 @@ func getBuildNameAndNumberFromBuildIdentifier(buildIdentifier string, flags Comm
 }
 
 func GetBuildNameAndNumberFromArtifactory(buildName, buildNumber string, flags CommonConf) (string, string, error) {
-	if buildNumber == Latest || buildNumber == LastRelease {
+	if buildNumber == latest || buildNumber == lastRelease {
 		return getLatestBuildNumberFromArtifactory(buildName, buildNumber, flags)
 	}
 	return buildName, buildNumber, nil
@@ -182,8 +183,8 @@ func parseNameAndVersion(identifier string, useLatestPolicy bool) (string, strin
 	}
 	if !strings.Contains(identifier, Delimiter) {
 		if useLatestPolicy {
-			log.Debug("No '" + Delimiter + "' is found in the build, build number is set to " + Latest)
-			return identifier, Latest, nil
+			log.Debug("No '" + Delimiter + "' is found in the build, build number is set to " + latest)
+			return identifier, latest, nil
 		} else {
 			return "", "", errorutils.CheckError(errors.New("No '" + Delimiter + "' is found in '" + identifier + "'"))
 		}
@@ -206,9 +207,9 @@ func parseNameAndVersion(identifier string, useLatestPolicy bool) (string, strin
 	}
 	if name == "" {
 		if useLatestPolicy {
-			log.Debug("No delimiter char (" + Delimiter + ") without escaping char was found in the build, build number is set to " + Latest)
+			log.Debug("No delimiter char (" + Delimiter + ") without escaping char was found in the build, build number is set to " + latest)
 			name = identifier
-			version = Latest
+			version = latest
 		} else {
 			return "", "", errorutils.CheckError(errors.New("No delimiter char (" + Delimiter + ") without escaping char was found in '" + identifier + "'"))
 		}
@@ -225,39 +226,21 @@ type Build struct {
 }
 
 func getLatestBuildNumberFromArtifactory(buildName, buildNumber string, flags CommonConf) (string, string, error) {
-	restUrl := flags.GetArtifactoryDetails().GetUrl() + "api/build/patternArtifacts"
-	body, err := createBodyForLatestBuildRequest(buildName, buildNumber)
+	aqlBody := CreateAqlQueryForLatestCreated(defaultBuildRepositoriesValue, buildName)
+	reader, err := aqlSearch(aqlBody, flags)
 	if err != nil {
 		return "", "", err
 	}
-	log.Debug("Getting build name and number from Artifactory: " + buildName + ", " + buildNumber)
-	httpClientsDetails := flags.GetArtifactoryDetails().CreateHttpClientDetails()
-	SetContentType("application/json", &httpClientsDetails.Headers)
-	log.Debug("Sending post request to: " + restUrl + ", with the following body: " + string(body))
-	client, err := httpclient.ClientBuilder().Build()
-	if err != nil {
-		return "", "", err
+	defer reader.Close()
+	for resultItem := new(ResultItem); reader.NextRecord(resultItem) == nil; resultItem = new(ResultItem) {
+		if i := strings.LastIndex(resultItem.Name, "-"); i != -1 {
+			// Remove the timestamp and .json to get the build number
+			buildNumber = resultItem.Name[:i]
+			return buildName, buildNumber, nil
+		}
 	}
-	resp, body, err := client.SendPost(restUrl, body, httpClientsDetails, "")
-	if err != nil {
-		return "", "", err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", "", errorutils.CheckError(errors.New("Artifactory response: " + resp.Status + "\n" + utils.IndentJson(body)))
-	}
-	log.Debug("Artifactory response: ", resp.Status)
-	var responseBuild []Build
-	err = json.Unmarshal(body, &responseBuild)
-	if errorutils.CheckError(err) != nil {
-		return "", "", err
-	}
-	if responseBuild[0].BuildNumber != "" {
-		log.Debug("Found build number: " + responseBuild[0].BuildNumber)
-	} else {
-		log.Debug("The build could not be found in Artifactory")
-	}
-
-	return buildName, responseBuild[0].BuildNumber, nil
+	log.Debug(fmt.Sprintf("The %s/%s build run could not be found in Artifactory.", buildName, buildNumber))
+	return "", "", err
 }
 
 func createBodyForLatestBuildRequest(buildName, buildNumber string) (body []byte, err error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix Downloading latest version using --build flag for v1

jfrog/jfrog-cli#1110
(When trying to download the artifacts from Arifactory using Jfrog CLI and specifying the --build option and it is expected to fetch the latest version but it is not fetching the latest #version.)