### PR TITLE
V1: Bugfix - Retries Send Mechanism

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -445,7 +445,7 @@ func (us *UploadService) uploadFileFromReader(getReaderFunc func() (io.Reader, e
 						return false, nil
 					}
 					// Perform retry
-					log.Warn(fmt.Sprintf("%sThe server response: %s", logMsgPrefix, resp.Status))
+					log.Warn(fmt.Sprintf("%sThe server response: %s\n %s", logMsgPrefix, resp.Status, clientutils.IndentJson(body)))
 					return true, nil
 				},
 			}


### PR DESCRIPTION
The new retries mechanism didn't worked due to reused of the http client
request struct.

In addition, a fail request message is now includes also the response body. 
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
