### PR TITLE
Fix: Archiving broken symlink for upload command

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -753,14 +753,7 @@ func (us *UploadService) addFileToZip(artifact *clientutils.Artifact, progressPr
 	if artifact.SymlinkTargetPath != "" && !symlink {
 		localPath = artifact.SymlinkTargetPath
 	}
-	file, e := os.Open(localPath)
-	defer func() {
-		err := file.Close()
-		if e == nil {
-			e = err
-		}
-	}()
-	info, e := os.Lstat(file.Name())
+	info, e := os.Lstat(localPath)
 	if errorutils.CheckError(e) != nil {
 		return
 	}
@@ -776,12 +769,23 @@ func (us *UploadService) addFileToZip(artifact *clientutils.Artifact, progressPr
 	if errorutils.CheckError(e) != nil {
 		return
 	}
+	// Symlink will be written to zip as a symlink and not the symlink target file.
 	if artifact.SymlinkTargetPath != "" && symlink {
 		// Write symlink's target to writer - file's body for symlinks is the symlink target.
 		_, e = writer.Write([]byte(filepath.ToSlash(artifact.SymlinkTargetPath)))
 		return
 	}
 
+	file, e := os.Open(localPath)
+	if e != nil {
+		return e
+	}
+	defer func() {
+		err := file.Close()
+		if e == nil {
+			e = err
+		}
+	}()
 	if us.Progress != nil {
 		progressReader := us.Progress.NewProgressReader(info.Size(), progressPrefix, localPath)
 		reader = progressReader.ActionWithProgress(file)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fails archiving symlinks with non-exists target.