### PR TITLE
V1 Fix: Upload with archive and include-dirs leaves out empty directories

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -772,6 +772,12 @@ func (us *UploadService) addFileToZip(artifact *clientutils.Artifact, progressPr
 		_, e = writer.Write([]byte(filepath.ToSlash(artifact.SymlinkTargetPath)))
 		return
 	}
+	// Check if directory
+	// Write directory to writer - path needs to end with a separator.
+	if info.IsDir() {
+		_, e = writer.Write([]byte(filepath.ToSlash(localPath + fileutils.GetFileSeparator())))
+		return
+	}
 	file, e := os.Open(localPath)
 	if e != nil {
 		return

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -772,8 +772,7 @@ func (us *UploadService) addFileToZip(artifact *clientutils.Artifact, progressPr
 		_, e = writer.Write([]byte(filepath.ToSlash(artifact.SymlinkTargetPath)))
 		return
 	}
-	// Check if directory
-	// Write directory to writer - path needs to end with a separator.
+	// If this is a directory, add it to the writer with a trailing slash.
 	if info.IsDir() {
 		_, e = writer.Write([]byte(filepath.ToSlash(localPath + fileutils.GetFileSeparator())))
 		return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Uploading a folder as a zip file with --include-dirs will exclude any empty directories in the folder.
Reviewed in PR: https://github.com/jfrog/jfrog-client-go/pull/415