### PR TITLE
Bugfix:  Upload with target-prop's value contain special characters

### DIFF
--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -36,19 +36,19 @@ func ParseProperties(propStr string) (*Properties, error) {
 }
 
 func (props *Properties) ParseAndAddProperties(propStr string) error {
-	propList := splitAndConsiderBackslashes(propStr, propsSeparator)
+	propList := splitWhileIgnoringBackslashPrefixSeparators(propStr, propsSeparator)
 	for _, prop := range propList {
 		if prop == "" {
 			continue
 		}
 
-		parts := splitAndConsiderBackslashes(prop, keyValuesSeparator)
+		parts := splitWhileIgnoringBackslashPrefixSeparators(prop, keyValuesSeparator)
 		if len(parts) != 2 {
 			return errorutils.CheckError(errors.New(fmt.Sprintf("Invalid property format: %s - format should be key=val1,val2,...", prop)))
 		}
 
 		key := parts[0]
-		values := splitAndConsiderBackslashes(parts[1], valuesSeparator)
+		values := splitWhileIgnoringBackslashPrefixSeparators(parts[1], valuesSeparator)
 		for _, val := range values {
 			props.properties[key] = append(props.properties[key], val)
 		}
@@ -59,7 +59,7 @@ func (props *Properties) ParseAndAddProperties(propStr string) error {
 
 // Split slices s into all substrings separated by sep and returns a slice of the substrings between those separators,
 // ignoring separators with a '\' prefix, which indicates that the separator is a part of the value.
-func splitAndConsiderBackslashes(str, separator string) (splitArray []string) {
+func splitWhileIgnoringBackslashPrefixSeparators(str, separator string) (splitArray []string) {
 	values := strings.Split(str, separator)
 	for i, val := range values {
 		// Let's use separator=',' for example:

--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -42,19 +42,31 @@ func (props *Properties) ParseAndAddProperties(propStr string) error {
 			continue
 		}
 
-		parts := splitWhileIgnoringBackslashPrefixSeparators(prop, keyValuesSeparator)
-		if len(parts) != 2 {
-			return errorutils.CheckError(errors.New(fmt.Sprintf("Invalid property format: %s - format should be key=val1,val2,...", prop)))
+		key, value, err := splitPropToKeyAndValue(prop)
+		if err != nil {
+			return err
 		}
 
-		key := parts[0]
-		values := splitWhileIgnoringBackslashPrefixSeparators(parts[1], valuesSeparator)
-		for _, val := range values {
+		splitValues := splitWhileIgnoringBackslashPrefixSeparators(value, valuesSeparator)
+		for _, val := range splitValues {
 			props.properties[key] = append(props.properties[key], val)
 		}
 	}
 	props.removeDuplicateValues()
 	return nil
+}
+
+// Searches for the first "=" instance, and split str into 2 substrings.
+// Returns error for invalid property format.
+func splitPropToKeyAndValue(str string) (key, value string, err error) {
+	index := strings.Index(str, keyValuesSeparator)
+	if index == -1 || index-1 < 0 || index+1 >= len(str) {
+		return "", "", errorutils.CheckError(errors.New(fmt.Sprintf("Invalid property format: %s - format should be key=val1,val2,...", str)))
+	}
+	key = str[0:index]
+	value = str[index+1:]
+	err = nil
+	return
 }
 
 // Split slices s into all substrings separated by sep and returns a slice of the substrings between those separators,

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -41,7 +41,6 @@ func TestParseProperties(t *testing.T) {
 		{"y=a,b\\,c\\,d\\,e", Properties{properties: map[string][]string{"y": {"a", "b,c,d,e"}}}},
 		{"y=\\,a b", Properties{properties: map[string][]string{"y": {",a b"}}}},
 		{"y=a,b;x=i;y=a;x=j", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i", "j"}}}},
-
 		{"y=a=a,b;x=i;y=a=a;x=j=", Properties{properties: map[string][]string{"y": {"a=a", "b"}, "x": {"i", "j="}}}},
 		{"y=a,b;x=i\\;;y=a;x=j\\;\\;", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i;", "j;;"}}}},
 		{"y=a,b;x=\\i;y=a\\;;x=j\\;=\\,", Properties{properties: map[string][]string{"y": {"a", "b", "a;"}, "x": {"\\i", "j;=,"}}}},

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -41,6 +41,10 @@ func TestParseProperties(t *testing.T) {
 		{"y=a,b\\,c\\,d\\,e", Properties{properties: map[string][]string{"y": {"a", "b,c,d,e"}}}},
 		{"y=\\,a b", Properties{properties: map[string][]string{"y": {",a b"}}}},
 		{"y=a,b;x=i;y=a;x=j", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i", "j"}}}},
+
+		{"y=a\\=a,b;x=i;y=a\\=a;x=j\\=", Properties{properties: map[string][]string{"y": {"a=a", "b"}, "x": {"i", "j="}}}},
+		{"y=a,b;x=i\\;;y=a;x=j\\;\\;", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i;", "j;;"}}}},
+		{"y=a,b;x=\\i;y=a\\;;x=j\\;\\=\\,", Properties{properties: map[string][]string{"y": {"a", "b", "a;"}, "x": {"\\i", "j;=,"}}}},
 	}
 	for _, test := range tests {
 		t.Run(test.propsString, func(t *testing.T) {

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -42,9 +42,9 @@ func TestParseProperties(t *testing.T) {
 		{"y=\\,a b", Properties{properties: map[string][]string{"y": {",a b"}}}},
 		{"y=a,b;x=i;y=a;x=j", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i", "j"}}}},
 
-		{"y=a\\=a,b;x=i;y=a\\=a;x=j\\=", Properties{properties: map[string][]string{"y": {"a=a", "b"}, "x": {"i", "j="}}}},
+		{"y=a=a,b;x=i;y=a=a;x=j=", Properties{properties: map[string][]string{"y": {"a=a", "b"}, "x": {"i", "j="}}}},
 		{"y=a,b;x=i\\;;y=a;x=j\\;\\;", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i;", "j;;"}}}},
-		{"y=a,b;x=\\i;y=a\\;;x=j\\;\\=\\,", Properties{properties: map[string][]string{"y": {"a", "b", "a;"}, "x": {"\\i", "j;=,"}}}},
+		{"y=a,b;x=\\i;y=a\\;;x=j\\;=\\,", Properties{properties: map[string][]string{"y": {"a", "b", "a;"}, "x": {"\\i", "j;=,"}}}},
 	}
 	for _, test := range tests {
 		t.Run(test.propsString, func(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Properties value can now contain characters '=' and ';' .
In case of ';' character in the value - user should use a backslash prefix and write '\;' .