### PR TITLE
Add KeyPairRef fields on local, federated and virtual repositories

### DIFF
--- a/artifactory/services/federatedrepository.go
+++ b/artifactory/services/federatedrepository.go
@@ -148,6 +148,7 @@ type FederatedRepositoryMember struct {
 type FederatedRepositoryBaseParams struct {
 	RepositoryBaseParams
 	AdditionalRepositoryBaseParams
+	KeyPairRefsRepositoryParams
 	ArchiveBrowsingEnabled *bool                       `json:"archiveBrowsingEnabled,omitempty"`
 	Members                []FederatedRepositoryMember `json:"members,omitempty"`
 }

--- a/artifactory/services/localrepository.go
+++ b/artifactory/services/localrepository.go
@@ -143,6 +143,7 @@ func (lrs *LocalRepositoryService) Yum(params YumLocalRepositoryParams) error {
 type LocalRepositoryBaseParams struct {
 	RepositoryBaseParams
 	AdditionalRepositoryBaseParams
+	KeyPairRefsRepositoryParams
 	ArchiveBrowsingEnabled *bool `json:"archiveBrowsingEnabled,omitempty"`
 }
 

--- a/artifactory/services/repository.go
+++ b/artifactory/services/repository.go
@@ -107,6 +107,11 @@ type JavaPackageManagersRepositoryParams struct {
 	ChecksumPolicyType           string `json:"checksumPolicyType,omitempty"`
 }
 
+type KeyPairRefsRepositoryParams struct {
+	PrimaryKeyPairRef   string `json:"primaryKeyPairRef,omitempty"`
+	SecondaryKeyPairRef string `json:"secondaryKeyPairRef,omitempty"`
+}
+
 type NugetRepositoryParams struct {
 	MaxUniqueSnapshots       int   `json:"maxUniqueSnapshots,omitempty"`
 	ForceNugetAuthentication *bool `json:"forceNugetAuthentication,omitempty"`

--- a/artifactory/services/virtualrepository.go
+++ b/artifactory/services/virtualrepository.go
@@ -126,6 +126,7 @@ func (vrs *VirtualRepositoryService) Yum(params YumVirtualRepositoryParams) erro
 
 type VirtualRepositoryBaseParams struct {
 	RepositoryBaseParams
+	KeyPairRefsRepositoryParams
 	Repositories                                  []string `json:"repositories,omitempty"`
 	ArtifactoryRequestsCanRetrieveRemoteArtifacts *bool    `json:"artifactoryRequestsCanRetrieveRemoteArtifacts,omitempty"`
 	DefaultDeploymentRepo                         string   `json:"defaultDeploymentRepo,omitempty"`


### PR DESCRIPTION
I suggest to add those fields according to https://www.jfrog.com/confluence/display/JFROG/Repository+Configuration+JSON

Signed-off-by: francois  samin <francois.samin@corp.ovh.com>

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
