### PR TITLE
Fix exclusions in transitive search (v1)

### DIFF
--- a/artifactory/services/utils/repopathfile_test.go
+++ b/artifactory/services/utils/repopathfile_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )
@@ -90,7 +91,9 @@ func TestCreatePathFilePairs(t *testing.T) {
 func TestCreateRepoPathFileTriples(t *testing.T) {
 	for _, sample := range repoPathFilesDataProvider {
 		t.Run(sample.pattern+"_recursive_"+strconv.FormatBool(sample.recursive), func(t *testing.T) {
-			validateRepoPathFile(createRepoPathFileTriples(sample.pattern, sample.recursive), sample.expected, sample.pattern, t)
+			repoPathFileTriples, err := createRepoPathFileTriples(sample.pattern, sample.recursive)
+			assert.NoError(t, err)
+			validateRepoPathFile(repoPathFileTriples, sample.expected, sample.pattern, t)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gookit/color v1.4.2
 	github.com/jfrog/gofrog v1.0.6
 	github.com/mholt/archiver/v3 v3.5.1-0.20210618180617-81fac4ba96e4
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xanzy/ssh-agent v0.3.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Exclusion patterns must start with a repository name or an asterisk.
Fixed a bug when an exclusion started with an asterisk in transitive search, which caused an error to be returned from Artifactory.