### PR TITLE
Print repo name on creation

### DIFF
--- a/artifactory/services/repository.go
+++ b/artifactory/services/repository.go
@@ -57,7 +57,7 @@ func (rs *RepositoryService) performRequest(params interface{}, repoKey string) 
 	}
 
 	log.Debug("Artifactory response:", resp.Status)
-	log.Info("Done " + operationString + " repository '" + repoKey + "'.")
+	log.Info("Done", operationString, "repository", "'"+repoKey+"'.")
 	return nil
 }
 

--- a/artifactory/services/repository.go
+++ b/artifactory/services/repository.go
@@ -57,7 +57,7 @@ func (rs *RepositoryService) performRequest(params interface{}, repoKey string) 
 	}
 
 	log.Debug("Artifactory response:", resp.Status)
-	log.Info("Done " + operationString + " repository.")
+	log.Info("Done " + operationString + " repository '" + repoKey + "'.")
 	return nil
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Repo key might change during the template creation to include project key. Printing the final key is convenient.