### PR TITLE
Fix: Fails to collect buildinfo vcs information for repository without commits

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -44,7 +44,9 @@ func (m *manager) ReadConfig() error {
 	m.handleSubmoduleIfNeeded()
 	m.readRevisionAndBranch()
 	m.readUrl()
-	m.readMessage()
+	if m.revision != "" {
+		m.readMessage()
+	}
 	return m.err
 }
 
@@ -276,8 +278,6 @@ func (m *manager) readRevisionFromPackedRef(ref string) {
 			return
 		}
 	}
-
-	m.err = errorutils.CheckError(errors.New("failed fetching revision from git config, from ref: " + ref))
 	return
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
For example: fails after running upload command "jfrog rt u" with buildinfo flags "--build-name=.." "--build-number=..." and when the local directory contains a repository without commits.