### PR TITLE
CreateFileTransferDetails - prevent double slash in target path

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -497,9 +499,12 @@ type DeployableArtifactDetails struct {
 	TargetRepository string `json:"targetRepository,omitempty"`
 }
 
-func (detailes *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl, targetRepository string) FileTransferDetails {
-	targetPath := rtUrl + targetRepository + "/" + detailes.ArtifactDest
-	return FileTransferDetails{SourcePath: detailes.SourcePath, TargetPath: targetPath, Sha256: detailes.Sha256}
+func (details *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl, targetRepository string) (FileTransferDetails, error) {
+	url, err := url.Parse(rtUrl + targetRepository)
+	url.Path = path.Join(url.Path, details.ArtifactDest)
+	targetPath := url.String()
+
+	return FileTransferDetails{SourcePath: details.SourcePath, TargetPath: targetPath, Sha256: details.Sha256}, err
 }
 
 type UploadResponseBody struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -500,11 +500,17 @@ type DeployableArtifactDetails struct {
 }
 
 func (details *DeployableArtifactDetails) CreateFileTransferDetails(rtUrl, targetRepository string) (FileTransferDetails, error) {
+	// The function path.Join expects a path, not a URL.
+	// Therefore we first parse the URL to get a path.
 	url, err := url.Parse(rtUrl + targetRepository)
+	if err != nil {
+		return FileTransferDetails{}, err
+	}
+	// The path.join will always use a single slash (forward) to separate between the two vars.
 	url.Path = path.Join(url.Path, details.ArtifactDest)
 	targetPath := url.String()
 
-	return FileTransferDetails{SourcePath: details.SourcePath, TargetPath: targetPath, Sha256: details.Sha256}, err
+	return FileTransferDetails{SourcePath: details.SourcePath, TargetPath: targetPath, Sha256: details.Sha256}, nil
 }
 
 type UploadResponseBody struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
