### PR TITLE
Sanitize windows paths better on unarchive

### DIFF
--- a/utils/io/fileutils/archive.go
+++ b/utils/io/fileutils/archive.go
@@ -182,7 +182,7 @@ func isEntryInDestination(destinationDir, pathInArchive string) bool {
 	if os.IsPathSeparator('\\') && strings.HasPrefix(pathInArchive, "/") {
 		return false
 	}
-	// Since the entry in archive should be always represented as Unix path, the "path" module is used and not "filepath"
+
 	pathInArchive = filepath.Clean(pathInArchive)
 	if !filepath.IsAbs(pathInArchive) {
 		// If path is relative, concatenate it to the destination dir

--- a/utils/io/fileutils/archive.go
+++ b/utils/io/fileutils/archive.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -142,7 +142,9 @@ func inspectArchive(archive interface{}, localArchivePath, destinationDir string
 			return err
 		}
 		if !isEntryInDestination(destinationDir, header.EntryPath) {
-			return errorutils.CheckError(errors.New("illegal path in archive: " + header.EntryPath))
+			return errorutils.CheckError(fmt.Errorf(
+				"illegal path in archive: '%s'. For security reasons, the path should lead to an entry under '%s'",
+				header.EntryPath, destinationDir))
 		}
 
 		if (archiveEntry.Mode() & os.ModeSymlink) != 0 {
@@ -166,18 +168,25 @@ func checkSymlinkEntry(header *archiveHeader, archiveEntry archiver.File, destin
 	}
 
 	if !isEntryInDestination(destinationDir, targetLinkPath) {
-		return errorutils.CheckError(errors.New("illegal link path in archive: " + targetLinkPath))
+		return errorutils.CheckError(fmt.Errorf(
+			"illegal link path in archive: '%s'. For security reasons, the path should lead to an entry under '%s'",
+			targetLinkPath, destinationDir))
 	}
 	return nil
 }
 
 // Make sure the extraction path of the archive entry is under the destination dir
 func isEntryInDestination(destinationDir, pathInArchive string) bool {
+	// If pathInArchive starts with '/' and we are on Windows, the path is illegal
+	pathInArchive = strings.TrimSpace(pathInArchive)
+	if os.IsPathSeparator('\\') && strings.HasPrefix(pathInArchive, "/") {
+		return false
+	}
 	// Since the entry in archive should be always represented as Unix path, the "path" module is used and not "filepath"
-	pathInArchive = path.Clean(pathInArchive)
-	if !path.IsAbs(pathInArchive) {
+	pathInArchive = filepath.Clean(pathInArchive)
+	if !filepath.IsAbs(pathInArchive) {
 		// If path is relative, concatenate it to the destination dir
-		pathInArchive = path.Join(destinationDir, pathInArchive)
+		pathInArchive = filepath.Join(destinationDir, pathInArchive)
 	}
 	return strings.HasPrefix(pathInArchive, destinationDir)
 }

--- a/utils/io/fileutils/archive_test.go
+++ b/utils/io/fileutils/archive_test.go
@@ -37,10 +37,10 @@ func TestUnarchiveZipSlip(t *testing.T) {
 		archives    []string
 		errorSuffix string
 	}{
-		{"rel", []string{"zip", "tar", "tar.gz"}, "illegal path in archive: ../file"},
-		{"abs", []string{"tar", "tar.gz"}, "illegal path in archive: /tmp/bla/file"},
-		{"softlink-abs", []string{"zip", "tar", "tar.gz"}, "illegal link path in archive: /tmp/bla/file"},
-		{"softlink-rel", []string{"zip", "tar", "tar.gz"}, "illegal link path in archive: ../file"},
+		{"rel", []string{"zip", "tar", "tar.gz"}, "illegal path in archive: '../file'"},
+		{"abs", []string{"tar", "tar.gz"}, "illegal path in archive: '/tmp/bla/file'"},
+		{"softlink-abs", []string{"zip", "tar", "tar.gz"}, "illegal link path in archive: '/tmp/bla/file'"},
+		{"softlink-rel", []string{"zip", "tar", "tar.gz"}, "illegal link path in archive: '../file'"},
 	}
 	for _, test := range tests {
 		t.Run(test.testType, func(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

To prevent absolute target paths outside of an extraction directory, we should use `filepath` instead of `path`.
This issue appeared after creating `TestUploadWithArchiveAndSymlinkZipSlip` in https://github.com/jfrog/jfrog-cli/pull/1269/files#diff-90b1ac3745fa656b3bbf876ff9778354050d926be2c38f2909ac328ef9542c1bR2017 and running it on Windows.