### PR TITLE
Fix npm install dependency version with "v" prefix

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -117,7 +117,11 @@ func CreateAqlQueryForNpm(npmName, npmVersion string) string {
 	itemsPart :=
 		`items.find({` +
 			`"@npm.name":"%s",` +
-			`"@npm.version":"%s"` +
+			`"$or": [` +
+				// sometimes the npm.version in the repository is written with "v" suffix, so we search both syntaxes
+				`{"@npm.version":"%[2]s"},` +
+				`{"@npm.version":"v%[2]s"}` +
+			`]` +
 			`})%s`
 	return fmt.Sprintf(itemsPart, npmName, npmVersion, buildIncludeQueryPart([]string{"name", "repo", "path", "actual_sha1", "actual_md5"}))
 }

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -118,7 +118,7 @@ func CreateAqlQueryForNpm(npmName, npmVersion string) string {
 		`items.find({` +
 			`"@npm.name":"%s",` +
 			`"$or": [` +
-				// sometimes the npm.version in the repository is written with "v" suffix, so we search both syntaxes
+				// sometimes the npm.version in the repository is written with "v" prefix, so we search both syntaxes
 				`{"@npm.version":"%[2]s"},` +
 				`{"@npm.version":"v%[2]s"}` +
 			`]` +


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
When using npm install the command is searching for dependencies data in the repository.
Sometimes the dependency "npm.version" is prefixed with "v" and the AQL command fails to provide the dependency data.
With this fix, we will always check for both syntaxes(with/without "v" prefix)


Following [Issue 1138](https://github.com/jfrog/jfrog-cli/issues/1138)