### PR TITLE
Add uuid to repository name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: JFrog Client Go Tests
-on: [push, pull_request]
+on: [push, pull_request_target]
 jobs:
   JFrog-Client-Go-Tests:
     name: ${{ matrix.product }} (${{ matrix.os }})

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang-jwt/jwt/v4 v4.1.0
+	github.com/google/uuid v1.3.0
 	github.com/gookit/color v1.4.2
 	github.com/jfrog/build-info-go v0.1.0
 	github.com/jfrog/gofrog v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
 github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -131,7 +131,7 @@ const (
 )
 
 func init() {
-	RtTargetRepoKey = RtTargetRepo + "-" + uuid.New().String()[:10] + "-" + runTimestamp
+	RtTargetRepoKey = RtTargetRepo + strings.Replace(uuid.New().String(), "-", "", -1)[:5] + "-" + runTimestamp
 	RtTargetRepo = RtTargetRepoKey + "/"
 	TestArtifactory = flag.Bool("test.artifactory", false, "Test Artifactory")
 	TestDistribution = flag.Bool("test.distribution", false, "Test distribution")

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	buildinfo "github.com/jfrog/build-info-go/entities"
 
 	accessAuth "github.com/jfrog/jfrog-client-go/access/auth"
@@ -130,7 +131,7 @@ const (
 )
 
 func init() {
-	RtTargetRepoKey = RtTargetRepo + "-" + runTimestamp
+	RtTargetRepoKey = RtTargetRepo + "-" + uuid.New().String()[:10] + "-" + runTimestamp
 	RtTargetRepo = RtTargetRepoKey + "/"
 	TestArtifactory = flag.Bool("test.artifactory", false, "Test Artifactory")
 	TestDistribution = flag.Bool("test.distribution", false, "Test distribution")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
GitHub-Actions run in parallel. As a result, two different tests may get the same timestamp in the repository name.
We add an extra unique number (UUID) to the repositories creation flow.