### PR TITLE
Replace timestamp with run_number for the repository name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,7 @@ jobs:
     - name: pipelines tests
       env:
         OS: ${{ matrix.os }}
-        SUITE: ${{ matrix.suite }}
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${SUITE:0:2}-${OS:0:1}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=pi-${OS:0:1}
   JFrog-Client-Go-Repository-Tests:
     name: repository ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,12 @@ on:
     branches:
       - master
       - dev
+    # Triggers the workflow on labeled PR only.
   pull_request_target:
     types: [labeled]
 jobs:
   JFrog-Client-Go-Tests:
-    name: ${{ matrix.product }} (${{ matrix.os }})
+    name: ${{ matrix.product }}(${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +26,7 @@ jobs:
     - name: Lint
       run: go vet -v ./...
     - name: ${{ matrix.product }} tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.product }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.product }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
   JFrog-Client-Go-Pipelines-Tests:
     name: pipelines (${{ matrix.os }})
     strategy:
@@ -42,7 +43,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: pipelines tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
   JFrog-Client-Go-Repository-Tests:
     name: repository (${{ matrix.os }})
     strategy:
@@ -59,4 +60,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: repository tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Lint
       run: go vet -v ./...
     - name: ${{ matrix.product }} tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.product }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.product }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
   JFrog-Client-Go-Pipelines-Tests:
     name: pipelines (${{ matrix.os }})
     strategy:
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: pipelines tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
   JFrog-Client-Go-Repository-Tests:
     name: repository (${{ matrix.os }})
     strategy:
@@ -60,4 +60,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: repository tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --test.ciRunId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,31 +4,34 @@ on:
     branches:
       - master
       - dev
-    # Triggers the workflow on labeled PR only.
+  # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [labeled]
 jobs:
   JFrog-Client-Go-Tests:
-    name: ${{ matrix.product }}(${{ matrix.os }})
+    name: ${{ matrix.suite }} ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        product: [artifactory, distribution, xray, access]
+        suite: [artifactory, distribution, xray, access]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
     - name: Install Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17.x
-    - name: Checkout code
-      uses: actions/checkout@v2
     - name: Lint
       run: go vet -v ./...
-    - name: ${{ matrix.product }} tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.product }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+    - name: ${{ matrix.suite }} tests
+      env:
+        OS: ${{ matrix.os }}
+        SUITE: ${{ matrix.suite }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.suite }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${SUITE:0:2}-${OS:0:1}
   JFrog-Client-Go-Pipelines-Tests:
-    name: pipelines (${{ matrix.os }})
+    name: pipelines ${{ matrix.os }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -43,15 +46,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: pipelines tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+      env:
+        OS: ${{ matrix.os }}
+        SUITE: ${{ matrix.suite }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${SUITE:0:2}-${OS:0:1}
   JFrog-Client-Go-Repository-Tests:
-    name: repository (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    name: repository ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -60,4 +61,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: repository tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ github.run_number }}${{ matrix.product }}${{ matrix.os }}
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.repository=true --rt.url=${{ secrets.CLI_RT_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
     types: [labeled]
 jobs:
   JFrog-Client-Go-Tests:
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: ${{ matrix.suite }} ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,6 +32,7 @@ jobs:
         SUITE: ${{ matrix.suite }}
       run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.suite }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${SUITE:0:2}-${OS:0:1}
   JFrog-Client-Go-Pipelines-Tests:
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: pipelines ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -50,6 +52,7 @@ jobs:
         OS: ${{ matrix.os }}
       run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=pi-${OS:0:1}
   JFrog-Client-Go-Repository-Tests:
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: repository ubuntu-latest
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ go test -v github.com/jfrog/jfrog-client-go/tests -timeout 0 -run TestGetArtifac
 | `-pipe.vcsRepo`      | [Optional] Vcs full repo path for Pipelines tests (ex: "domain/myrepo").                               |
 | `-pipe.vcsBranch`    | [Optional] Vcs branch for Pipelines tests (ex: "main").                                                |
 | `-access.accessToken`| [Optional] Access access token.                                                                        |
-| `-test.ciRunId`      | [Default: Timestamp] A uniq id for all the tests.                                                      |
+| `-ci.runId`          | [Default: Timestamp] A unique run ID used as a suffix to create repositories tests.                    |
 
 ## General APIs
 ### Setting the Logger

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ go test -v github.com/jfrog/jfrog-client-go/tests -timeout 0 -run TestGetArtifac
 | `-pipe.vcsRepo`      | [Optional] Vcs full repo path for Pipelines tests (ex: "domain/myrepo").                               |
 | `-pipe.vcsBranch`    | [Optional] Vcs branch for Pipelines tests (ex: "main").                                                |
 | `-access.accessToken`| [Optional] Access access token.                                                                        |
+| `-test.ciRunId`      | [Default: Timestamp] A uniq id for all the tests.                                                      |
 
 ## General APIs
 ### Setting the Logger

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ go test -v github.com/jfrog/jfrog-client-go/tests -timeout 0 -run TestGetArtifac
 | `-pipe.vcsRepo`      | [Optional] Vcs full repo path for Pipelines tests (ex: "domain/myrepo").                               |
 | `-pipe.vcsBranch`    | [Optional] Vcs branch for Pipelines tests (ex: "main").                                                |
 | `-access.accessToken`| [Optional] Access access token.                                                                        |
-| `-ci.runId`          | [Default: Timestamp] A unique run ID used as a suffix to create repositories tests.                    |
+| `-ci.runId`          | [Default: Timestamp] A unique identifier used as a suffix to create repositories and builds in the tests. |
 
 ## General APIs
 ### Setting the Logger

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # jfrog-client-go
 
-| Branch |                                                                                        Status                                                                                         |
-| :----: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| Branch |                                                                              Status                                                                               |
+| :----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | master | [![Build status](https://github.com/jfrog/jfrog-client-go/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/jfrog/jfrog-client-go/actions) |
-|  dev   |    [![Build status](https://github.com/jfrog/jfrog-client-go/actions/workflows/tests.yml/badge.svg?branch=dev)](https://github.com/jfrog/jfrog-client-go/actions) |
+|  dev   |  [![Build status](https://github.com/jfrog/jfrog-client-go/actions/workflows/tests.yml/badge.svg?branch=dev)](https://github.com/jfrog/jfrog-client-go/actions)   |
 
 ## Table of Contents
+
 - [jfrog-client-go](#jfrog-client-go)
   - [Table of Contents](#table-of-contents)
   - [General](#general)
@@ -143,64 +144,78 @@
       - [Add Pipeline Source](#add-pipeline-source)
 
 ## General
+
 _jfrog-client-go_ is a library which provides Go APIs to performs actions on JFrog Artifactory, Xray and Distribution from your Go application.
 The project is still relatively new, and its APIs may therefore change frequently between releases.
 The library can be used as a go-module, which should be added to your project's go.mod file. As a reference you may look at [JFrog CLI](https://github.com/jfrog/jfrog-cli-go)'s [go.mod](https://github.com/jfrog/jfrog-cli-go/blob/master/go.mod) file, which uses this library as a dependency.
 
 ## Pull Requests
+
 We welcome pull requests from the community.
 
 ### Guidelines
+
 - If the existing tests do not already cover your changes, please add tests.
 - Pull requests should be created on the **dev** branch.
 - Please use gofmt for formatting the code before submitting the pull request.
 
 ## Tests
-To run the tests on the source code, you'll need a running JFrog instance. See the *Prerequisites* column in the *Test Types* section below for more information.
+
+To run the tests on the source code, you'll need a running JFrog instance. See the _Prerequisites_ column in the _Test Types_ section below for more information.
 
 Use the following command with the below options to run the tests.
+
 ```sh
 go test -v github.com/jfrog/jfrog-client-go/tests -timeout 0 [test-types] [flags]
 ```
-If you'd like to run a specific test, add the test function name using the ```-run``` flag. For example:
+
+If you'd like to run a specific test, add the test function name using the `-run` flag. For example:
+
 ```sh
 go test -v github.com/jfrog/jfrog-client-go/tests -timeout 0 -run TestGetArtifactoryVersionWithCustomHttpClient -test.artifactory -rt.url=http://127.0.0.1:8081/artifactory -rt.user=admin -rt.password=password
 ```
+
 **Note:** The tests create an Artifactory repository named _jfrog-client-tests-repo1_. Once the tests are completed, the content of this repository is deleted.
+
 ### Flags
+
 #### Test Types
-| Type                | Description        | Prerequisites
-| ------------------- | ------------------ | ------------------------------|
-| `-test.artifactory` | Artifactory tests  | Artifactory Pro               |
-| `-test.distribution`| Distribution tests | Artifactory with Distribution |
-| `-test.xray`        | Xray tests         | Artifactory with Xray         |
-| `-test.pipelines`   | Pipelines tests    | JFrog Pipelines               |
-| `-test.access`      | Access tests       | Artifactory Pro               |
-| `-test.repository`  | Access tests       | Artifactory Pro               |
+
+| Type                 | Description        | Prerequisites                 |
+| -------------------- | ------------------ | ----------------------------- |
+| `-test.artifactory`  | Artifactory tests  | Artifactory Pro               |
+| `-test.distribution` | Distribution tests | Artifactory with Distribution |
+| `-test.xray`         | Xray tests         | Artifactory with Xray         |
+| `-test.pipelines`    | Pipelines tests    | JFrog Pipelines               |
+| `-test.access`       | Access tests       | Artifactory Pro               |
+| `-test.repository`   | Access tests       | Artifactory Pro               |
 
 #### Connection Details
-| Flag                 | Description                                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `-rt.url`            | [Default: http://localhost:8081/artifactory] Artifactory URL.                                          |
-| `-ds.url`            | [Optional] JFrog Distribution URL.                                                                     |
-| `-xr.url`            | [Optional] JFrog Xray URL.                                                                             |
-| `-pipe.url`          | [Optional] JFrog Pipelines URL.                                                                        |
-| `-access.url`        | [Optional] JFrog Access URL.                                                                           |
-| `-rt.user`           | [Default: admin] Artifactory username.                                                                 |
-| `-rt.password`       | [Default: password] Artifactory password.                                                              |
-| `-rt.apikey`         | [Optional] Artifactory API key.                                                                        |
-| `-rt.sshKeyPath`     | [Optional] Ssh key file path. Should be used only if the Artifactory URL format is ssh://[domain]:port |
-| `-rt.sshPassphrase`  | [Optional] Ssh key passphrase.                                                                         |
-| `-rt.accessToken`    | [Optional] Artifactory access token.                                                                   |
-| `-pipe.accessToken`  | [Optional] Pipelines access token.                                                                     |
-| `-pipe.vcsToken`     | [Optional] Vcs token for Pipelines tests (should have admin permissions).                              |
-| `-pipe.vcsRepo`      | [Optional] Vcs full repo path for Pipelines tests (ex: "domain/myrepo").                               |
-| `-pipe.vcsBranch`    | [Optional] Vcs branch for Pipelines tests (ex: "main").                                                |
-| `-access.accessToken`| [Optional] Access access token.                                                                        |
-| `-ci.runId`          | [Default: Timestamp] A unique identifier used as a suffix to create repositories and builds in the tests. |
+
+| Flag                  | Description                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `-rt.url`             | [Default: http://localhost:8081/artifactory] Artifactory URL.                                          |
+| `-ds.url`             | [Optional] JFrog Distribution URL.                                                                     |
+| `-xr.url`             | [Optional] JFrog Xray URL.                                                                             |
+| `-pipe.url`           | [Optional] JFrog Pipelines URL.                                                                        |
+| `-access.url`         | [Optional] JFrog Access URL.                                                                           |
+| `-rt.user`            | [Default: admin] Artifactory username.                                                                 |
+| `-rt.password`        | [Default: password] Artifactory password.                                                              |
+| `-rt.apikey`          | [Optional] Artifactory API key.                                                                        |
+| `-rt.sshKeyPath`      | [Optional] Ssh key file path. Should be used only if the Artifactory URL format is ssh://[domain]:port |
+| `-rt.sshPassphrase`   | [Optional] Ssh key passphrase.                                                                         |
+| `-rt.accessToken`     | [Optional] Artifactory access token.                                                                   |
+| `-pipe.accessToken`   | [Optional] Pipelines access token.                                                                     |
+| `-pipe.vcsToken`      | [Optional] Vcs token for Pipelines tests (should have admin permissions).                              |
+| `-pipe.vcsRepo`       | [Optional] Vcs full repo path for Pipelines tests (ex: "domain/myrepo").                               |
+| `-pipe.vcsBranch`     | [Optional] Vcs branch for Pipelines tests (ex: "main").                                                |
+| `-access.accessToken` | [Optional] Access access token.                                                                        |
+| `-ci.runId`           | [Optional] A unique identifier used as a suffix to create repositories in the tests.                   |
 
 ## General APIs
+
 ### Setting the Logger
+
 ```go
 var file *os.File
 ...
@@ -208,14 +223,19 @@ log.SetLogger(log.NewLogger(log.INFO, file))
 ```
 
 ### Setting the Temp Dir
+
 The default temp dir used is 'os.TempDir()'. Use the following API to set a new temp dir:
+
 ```go
 fileutils.SetTempDirBase(filepath.Join("my", "temp", "path"))
 ```
 
 ## Artifactory APIs
+
 ### Creating Artifactory Service Manager
+
 #### Creating Artifactory Details
+
 ```go
 rtDetails := auth.NewArtifactoryDetails()
 rtDetails.SetUrl("http://localhost:8081/artifactory")
@@ -230,6 +250,7 @@ rtDetails.SetClientCertKeyPath("path/to/.key")
 ```
 
 #### Creating Artifactory Details with Custom HTTP Client
+
 ```go
 proxyUrl, err := url.Parse("http://proxyIp:proxyPort")
 myCustomClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
@@ -249,6 +270,7 @@ serviceConfig, err := config.NewConfigBuilder().
 ```
 
 #### Creating Artifactory Service Config
+
 ```go
 serviceConfig, err := config.NewConfigBuilder().
     SetServiceDetails(rtDetails).
@@ -265,13 +287,17 @@ serviceConfig, err := config.NewConfigBuilder().
 ```
 
 #### Creating New Artifactory Service Manager
+
 ```go
 rtManager, err := artifactory.New(serviceConfig)
 ```
 
 ### Using Artifactory Services
+
 #### Uploading Files to Artifactory
+
 Using the `UploadFiles()` function, we can upload files and get the general statistics of the action (The actual number of successful and failed uploads), and the error value if it occurred.
+
 ```go
 params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
@@ -307,7 +333,9 @@ totalUploaded, totalFailed, err := rtManager.UploadFiles(params)
 ```
 
 #### Downloading Files from Artifactory
+
 Using the `DownloadFiles()` function, we can download files and get the general statistics of the action (The actual number of files downloaded, and the number of files we expected to download). In addition, we get the error value if it occurred.
+
 ```go
 params := services.NewDownloadParams()
 params.Pattern = "repo/*/*.zip"
@@ -332,6 +360,7 @@ totalDownloaded, totalFailed, err := rtManager.DownloadFiles(params)
 ```
 
 #### Downloading Release Bundles from Artifactory
+
 Using the `DownloadFiles()` function, we can download release bundles and get the general statistics of the action (The actual number of files downloaded, and the number of files we expected to download). In addition, we get the error value if it occurred.
 
 It is possible to validate the downloaded release bundle's files by providing a local path to a GPG public key file (the public GPG key should of course correspond to the private GPG key which was used to sign the release bundle).
@@ -346,18 +375,21 @@ params.Bundle = "bundleName/10"
 params.PublicGpgKey = "public/key/file/path"
 totalDownloaded, totalFailed, err := rtManager.DownloadFiles(params)
 ```
+
 Read more about GPG signing release bundles [here](https://www.jfrog.com/confluence/display/JFROG/GPG+Signing).
 
-
 #### Uploading and Downloading Files with Summary
+
 The methods `UploadFilesWithSummary()` and `DownloadFilesWithSummary()` are similar to `UploadFlies()` and `DownloadFlies()`, but return an OperationSummary struct, which allows iterating over the details of the uploaded/downloaded files.<br>
 The OperationSummary struct contains:
+
 - TotalSucceeded - the number of successful uploads/downloads
 - TotalFailed - the number of failed uploads/downloads
 - TransferDetailsReader - a ContentReader of FileTransferDetails structs, with a struct for each successful transfer of file
 - ArtifactsDetailsReader - a ContentReader of ArtifactDetails structs, with a struct for each artifact in Artifactory that was uploaded/downloaded successfully
 
 The ContentReaders can be closed separately by calling `Close()` on each of them, or they both can be closed at once by calling `Close()` on the OperationSummary struct.
+
 ```go
 params := services.NewUploadParams()
 params.Pattern = "repo/*/*.zip"
@@ -376,9 +408,11 @@ if err := reader.GetError(); err != nil {
     return err
 }
 ```
+
 Read more about [ContentReader](#using-contentReader).
 
 #### Copying Files in Artifactory
+
 ```go
 params := services.NewMoveCopyParams()
 params.Pattern = "repo/*/*.zip"
@@ -392,6 +426,7 @@ rtManager.Copy(params)
 ```
 
 #### Moving Files in Artifactory
+
 ```go
 params := services.NewMoveCopyParams()
 params.Pattern = "repo/*/*.zip"
@@ -405,6 +440,7 @@ rtManager.Move(params)
 ```
 
 #### Deleting Files from Artifactory
+
 ```go
 params := services.NewDeleteParams()
 params.Pattern = "repo/*/*.zip"
@@ -419,9 +455,11 @@ if err != nil {
 defer pathsToDelete.Close()
 rtManager.DeleteFiles(pathsToDelete)
 ```
+
 Read more about [ContentReader](#using-contentReader).
 
 #### Searching Files in Artifactory
+
 ```go
 params := services.NewSearchParams()
 params.Pattern = "repo/*/*.zip"
@@ -435,9 +473,11 @@ if err != nil {
 }
 defer reader.Close()
 ```
+
 Read more about [ContentReader](#using-contentReader).
 
 #### Setting Properties on Files in Artifactory
+
 ```go
 searchParams = services.NewSearchParams()
 searchParams.Recursive = true
@@ -456,9 +496,11 @@ propsParams.Props = "key=value"
 
 rtManager.SetProps(propsParams)
 ```
+
 Read more about [ContentReader](#using-contentReader).
 
 #### Deleting Properties from Files in Artifactory
+
 ```go
 searchParams = services.NewSearchParams()
 searchParams.Recursive = true
@@ -477,9 +519,11 @@ propsParams.Props = "key=value"
 
 rtManager.DeleteProps(propsParams)
 ```
+
 Read more about [ContentReader](#using-contentReader).
 
 #### Publishing Build Info to Artifactory
+
 ```go
 buildInfo := &buildinfo.BuildInfo{}
 // Optional Artifactory project key
@@ -489,6 +533,7 @@ rtManager.PublishBuildInfo(buildInfo, projectKey)
 ```
 
 #### Fetching Build Info from Artifactory
+
 ```go
 buildInfoParams := services.NewBuildInfoParams{}
 buildInfoParams.BuildName = "buildName"
@@ -500,6 +545,7 @@ rtManager.GetBuildInfo(buildInfoParams)
 ```
 
 #### Promoting Published Builds in Artifactory
+
 ```go
 params := services.NewPromotionParams()
 params.BuildName = "buildName"
@@ -518,6 +564,7 @@ rtManager.PromoteBuild(params)
 ```
 
 #### Promoting a Docker Image in Artifactory
+
 ```go
 sourceDockerImage := "hello-world"
 sourceRepo := "docker-local-1"
@@ -534,6 +581,7 @@ rtManager.PromoteDocker(params)
 ```
 
 #### Triggering Build Scanning with JFrog Xray
+
 ```go
 params := services.NewXrayScanParams()
 params.BuildName = buildName
@@ -543,6 +591,7 @@ rtManager.XrayScanBuild(params)
 ```
 
 #### Discarding Old Builds
+
 ```go
 params := services.NewDiscardBuildsParams()
 params.BuildName = "buildName"
@@ -558,6 +607,7 @@ rtManager.DiscardBuilds(params)
 ```
 
 #### Cleaning Unreferenced Git LFS Files from Artifactory
+
 ```go
 params := services.NewGitLfsCleanParams()
 params.Refs = "refs/remotes/*"
@@ -571,16 +621,19 @@ rtManager.DeleteFiles(reader)
 ```
 
 #### Executing AQLs
+
 ```go
 rtManager.Aql(aql string)
 ```
 
 #### Reading Files in Artifactory
+
 ```go
 rtManager.ReadRemoteFile(FilePath string)
 ```
 
 #### Creating an Access Token
+
 ```go
 params := services.NewCreateTokenParams()
 params.Scope = "api:* member-of-groups:readers"
@@ -594,16 +647,19 @@ results, err := rtManager.CreateToken(params)
 ```
 
 #### Fetching Access Tokens
+
 ```go
 results, err := rtManager.GetTokens()
 ```
 
 #### Fetching Access Tokens of a User
+
 ```g
 results, err := rtManager.GetUserTokens(username)
 ```
 
 #### Refreshing an Access Token
+
 ```go
 params := services.NewRefreshTokenParams()
 params.AccessToken = "<access token>"
@@ -614,6 +670,7 @@ results, err := rtManager.RefreshToken(params)
 ```
 
 #### Revoking an Access Token
+
 ```go
 params := services.NewRevokeTokenParams()
 
@@ -625,22 +682,26 @@ err := rtManager.RevokeToken(params)
 ```
 
 #### Create API Key
+
 ```go
 // Returns an error if API key already exists - use RegenerateAPIKey instead.
 apiKey, err := rtManager.CreateAPIKey()
 ```
 
 #### Regenerate API Key
+
 ```go
 apiKey, err := rtManager.RegenerateAPIKey()
 ```
 
 #### Get API Key
+
 ```go
 apiKey, err := rtManager.GetAPIKey()
 ```
 
 #### Creating and Updating Local Repository
+
 You can create and update a local repository for the following package types:
 
 Alpine, Bower, Cran, Cargo, Chef, Cocoapods, Composer, Conan, Conda, Debian, Docker, Gems, Generic, Gitlfs, Go, Gradle, Helm, Ivy, Maven, Npm, Nuget, Opkg, Puppet, Pypi, Rpm, Sbt, Vagrant, and Yum.
@@ -649,6 +710,7 @@ Each package type has its own parameters struct, can be created using the method
 `New<packageType>LocalRepositoryParams()`.
 
 Example for creating local Generic repository:
+
 ```go
 params := services.NewGenericLocalRepositoryParams()
 params.Key = "generic-repo"
@@ -665,6 +727,7 @@ err = servicesManager.CreateLocalRepository().Generic(params)
 ```
 
 You can also create a local repository with basic local params:
+
 ```go
 params := services.NewLocalRepositoryBaseParams()
 params.Key = "generic-repo"
@@ -674,11 +737,13 @@ err := servicesManager.CreateLocalRepository(params)
 ```
 
 Updating local Generic repository:
+
 ```go
 err = servicesManager.UpdateLocalRepository().Generic(params)
 ```
 
 #### Creating and Updating Remote Repository
+
 You can create and update a remote repository for the following package types:
 
 Alpine, Bower, Cran, Cargo, Chef, Cocoapods, Composer, Conan, Conda, Debian, Docker, Gems, Generic, Gitlfs, Go, Gradle, Helm, Ivy, Maven, Npm, Nuget, Opkg, P2, Puppet, Pypi, Rpm, Sbt, Vcs, and Yum.
@@ -687,6 +752,7 @@ Each package type has its own parameters struct, can be created using the method
 `New<packageType>RemoteRepositoryParams()`.
 
 Example for creating remote Maven repository:
+
 ```go
 params := services.NewMavenRemoteRepositoryParams()
 params.Key = "maven-central-remote"
@@ -705,11 +771,13 @@ err = servicesManager.CreateRemoteRepository().Maven(params)
 ```
 
 Updating remote Maven repository:
+
 ```go
 err = servicesManager.UpdateRemoteRepository().Maven(params)
 ```
 
 You can also create a remote repository with basic remote params:
+
 ```go
 params := services.NewRemoteRepositoryBaseParams()
 params.Key = "remote-repo"
@@ -718,6 +786,7 @@ err := servicesManager.CreateRemoteRepository(params)
 ```
 
 #### Creating and Updating Virtual Repository
+
 You can create and update a virtual repository for the following package types:
 
 Alpine, Bower, Cran, Chef, Conan, Conda, Debian, Docker, Gems, Generic, Gitlfs, Go, Gradle, Helm, Ivy, Maven, Npm, Nuget, P2, Puppet, Pypi, Rpm, Sbt, and Yum.
@@ -726,6 +795,7 @@ Each package type has its own parameters struct, can be created using the method
 `New<packageType>VirtualRepositoryParams()`.
 
 Example for creating virtual Go repository:
+
 ```go
 params := services.NewGoVirtualRepositoryParams()
 params.Description = "This is an aggregated repository for several go repositories"
@@ -740,6 +810,7 @@ err = servicesManager.CreateVirtualRepository().Go(params)
 ```
 
 You can also create a virtual repository with basic virtual params:
+
 ```go
 params := services.NewVirtualRepositoryBaseParams()
 params.Key = "generic-repo"
@@ -750,11 +821,13 @@ err := servicesManager.CreateVirtualRepository(params)
 ```
 
 Updating virtual Go repository:
+
 ```go
 err = servicesManager.UpdateVirtualRepository().Go(params)
 ```
 
 #### Creating and Updating Federated Repository
+
 You can create and update a federated repository for the following package types:
 
 Alpine, Bower, Cran, Cargo, Chef, Cocoapods, Composer, Conan, Conda, Debian, Docker, Gems, Generic, Gitlfs, Go, Gradle, Helm, Ivy, Maven, Npm, Nuget, Opkg, Puppet, Pypi, Rpm, Sbt, Vagrant and Yum
@@ -763,6 +836,7 @@ Each package type has its own parameters struct, can be created using the method
 `New<packageType>FederatedRepositoryParams()`.
 
 Example for creating federated Generic repository:
+
 ```go
 params := services.NewGenericFederatedRepositoryParams()
 params.Key = "generic-repo"
@@ -781,6 +855,7 @@ err = servicesManager.CreateFederatedRepository().Generic(params)
 ```
 
 You can also create a federated repository with basic federated params:
+
 ```go
 params := services.NewFederatedRepositoryBaseParams()
 params.Key = "generic-repo"
@@ -793,20 +868,25 @@ err := servicesManager.CreateFederatedRepository(params)
 ```
 
 Updating federated Generic repository:
+
 ```go
 err = servicesManager.UpdateFederatedRepository().Generic(params)
 ```
 
 #### Removing a Repository
+
 You can remove a repository from Artifactory using its key:
+
 ```go
 servicesManager.DeleteRepository("generic-repo")
 ```
 
 #### Getting Repository Details
+
 You can get repository details from Artifactory using its key, and the desired params struct.
 The function expects to get the repo key (name) and a pointer to a param struct that will be filled up.
 The param struct should contain the desired params fields corresponded to the Artifactory REST API:
+
 ```go
 repoDetails = services.RepositoryDetails{}
 err := servicesManager.GetRepository("maven-repo", &repoDetails)
@@ -821,15 +901,19 @@ err := servicesManager.GetRepository("maven-repo", &repoDetails)
 repoDetails = services.MavenLocalRepositoryParams{}
 err := servicesManager.GetRepository("maven-repo", &repoDetails)
 ```
+
 services.RepositoryDetails
 
 #### Getting All Repositories
+
 You can get all repositories from Artifactory:
+
 ```go
 servicesManager.GetAllRepositories()
 ```
 
 You can get all repositories from Artifactory filtered according to theirs type and/or theirs package type:
+
 ```go
 params := services.NewRepositoriesFilterParams()
 params.RepoType = "remote"
@@ -838,7 +922,9 @@ err := servicesManager.GetAllRepositoriesFiltered(params)
 ```
 
 #### Creating and Updating Repository Replications
+
 Example of creating a repository replication:
+
 ```go
 params := services.NewCreateReplicationParams()
 // Source replication repository.
@@ -859,6 +945,7 @@ err = servicesManager.CreateReplication(params)
 ```
 
 Example of updating a local repository replication:
+
 ```go
 params := services.NewUpdateReplicationParams()
 // Source replication repository.
@@ -876,41 +963,52 @@ err = servicesManager.UpdateReplication(params)
 ```
 
 #### Getting a Repository Replication
+
 You can get a repository replication configuration from Artifactory using its key:
+
 ```go
 replicationConfiguration, err := servicesManager.GetReplication("my-repository")
 ```
 
 #### Removing a Repository Replication
+
 You can remove a repository replication configuration from Artifactory using its key:
+
 ```go
 err := servicesManager.DeleteReplication("my-repository")
 ```
 
 #### Converting a Local Repository to a Federated Repository
+
 You can convert a local repository to a federated repository using its key:
+
 ```go
 err := servicesManager.ConvertLocalToFederatedRepository("my-repository")
 ```
 
 #### Triggering a Full Federated Repository Synchronisation
+
 You can trigger a full federated repository synchronisation for all members using its key:
+
 ```go
 err := servicesManager.TriggerFederatedRepositoryFullSyncAll("my-repository")
 ```
 
 You can also trigger a full federated repository synchronisation for a specific member using its key and the members URL
+
 ```go
 err := servicesManager.TriggerFederatedRepositoryFullSyncMirror("my-repository", "http://localhost:8081/artifactory/my-repository")
 ```
 
 #### Creating and Updating Permission Targets
+
 You can create or update a permission target in Artifactory.
 Permissions are set according to the following conventions:
 `read, write, annotate, delete, manage, managedXrayMeta, distribute`
 For repositories You can specify the name `"ANY"` in order to apply to all repositories, `"ANY REMOTE"` for all remote repositories or `"ANY LOCAL"` for all local repositories.
 
 Creating a new permission target :
+
 ```go
 params := services.NewPermissionTargetParams()
 params.Name = "java-developers"
@@ -933,36 +1031,45 @@ params.Build.Actions.Groups = map[string][]string {
 
 err = servicesManager.CreatePermissionTarget(params)
 ```
+
 Updating an existing permission target :
+
 ```go
 err = servicesManager.UpdatePermissionTarget(params)
 ```
 
 #### Removing a Permission Target
+
 You can remove a permission target from Artifactory using its name:
+
 ```go
 err = servicesManager.DeletePermissionTarget("java-developers")
 ```
 
 #### Fetching a Permission Target
+
 You can fetch a permission target from Artifactory using its name:
+
 ```go
 permissionTargetParams, err = servicesManager.GetPermissionTarget("java-developers")
 ```
 
-If the requested permission target does not exist, a nil value is returned for the *permissionTargetParams* param, with a nil error value
+If the requested permission target does not exist, a nil value is returned for the _permissionTargetParams_ param, with a nil error value
 
 #### Fetching Artifactory's Version
+
 ```go
 version, err := servicesManager.GetVersion()
 ```
 
 #### Fetching Artifactory's Service ID
+
 ```go
 serviceId, err := servicesManager.GetServiceId()
 ```
 
 #### Fetching Users Details
+
 ```go
 params := services.NewUserParams()
 params.UserDetails.Name = "myUserName"
@@ -970,15 +1077,18 @@ params.UserDetails.Name = "myUserName"
 user, err := serviceManager.GetUser(params)
 ```
 
-If the requested user does not exist, a nil value is returned for the *User* param, with a nil error value
+If the requested user does not exist, a nil value is returned for the _User_ param, with a nil error value
 
 #### Fetching All Users Details
+
 You can get all users from Artifactory:
+
 ```go
 users, err := servicesManager.GetAllUsers()
 ```
 
 #### Creating and Updating a User
+
 ```go
 params := services.NewUserParams()
 params.UserDetails.Name = "myUserName"
@@ -999,11 +1109,13 @@ err := serviceManager.UpdateUser(params)
 ```
 
 #### Deleting a User
+
 ```go
 err := serviceManager.DeleteUser("myUserName")
 ```
 
 #### Fetching Group Details
+
 ```go
 params := services.NewGroupParams()
 params.GroupDetails.Name = "myGroupName"
@@ -1013,9 +1125,10 @@ params.IncludeUsers = true
 group, err := serviceManager.GetGroup(params)
 ```
 
-If the requested group does not exist, a nil value is returned for the *Group* param, with a nil error value
+If the requested group does not exist, a nil value is returned for the _Group_ param, with a nil error value
 
 #### Creating and Updating a Group
+
 ```go
 params := services.NewGroupParams()
 params.GroupDetails.Name = "myGroupName"
@@ -1036,13 +1149,17 @@ err := serviceManager.UpdateGroup(params)
 ```
 
 #### Deleting a Group
+
 ```go
 err := serviceManager.DeleteGroup("myGroupName")
 ```
 
 ## Access APIs
+
 ### Creating Access Service Manager
+
 #### Creating Access Details
+
 ```go
 accessDetails := accessAuth.NewAccessDetails()
 accessDetails.SetUrl("http://localhost:8081/access/")
@@ -1068,6 +1185,7 @@ Build()
 ```
 
 #### Creating New Access Service Manager
+
 ```go
 accessManager, err := access.New(serviceConfig)
 ```
@@ -1117,24 +1235,30 @@ err = accessManager.UpdateProject(projectParams)
 ```
 
 #### Deleting a Project
+
 ```go
 err = accessManager.DeleteProject("tstprj")
 ```
 
 #### Assigning repository to project
+
 ```go
 // Params: (repositoryName, projectKey string, isForce bool)
 err = accessManager.AssignRepoToProject("repoName", "tstprj", true)
 ```
 
 #### Unassigning repository from project
+
 ```go
 err = accessManager.AssignRepoToProject("repoName")
 ```
 
 ## Distribution APIs
+
 ### Creating Distribution Service Manager
+
 #### Creating Distribution Details
+
 ```go
 distDetails := auth.NewDistributionDetails()
 distDetails.SetUrl("http://localhost:8081/distribution")
@@ -1149,6 +1273,7 @@ distDetails.SetClientCertKeyPath("path/to/.key")
 ```
 
 #### Creating Distribution Service Config
+
 ```go
 serviceConfig, err := config.NewConfigBuilder().
     SetServiceDetails(rtDetails).
@@ -1163,12 +1288,15 @@ serviceConfig, err := config.NewConfigBuilder().
 ```
 
 #### Creating New Distribution Service Manager
+
 ```go
 distManager, err := distribution.New(serviceConfig)
 ```
 
 ### Using Distribution Services
+
 #### Setting Distribution Signing Key
+
 ```go
 params := services.NewSetSigningKeyParams("private-gpg-key", "public-gpg-key")
 
@@ -1176,6 +1304,7 @@ err := distManager.SetSigningKey(params)
 ```
 
 #### Creating a Release Bundle
+
 ```go
 params := services.NewCreateReleaseBundleParams("bundle-name", "1")
 params.Description = "Description"
@@ -1202,6 +1331,7 @@ summary, err := distManager.CreateReleaseBundle(params)
 ```
 
 #### Updating a Release Bundle
+
 ```go
 params := services.NewUpdateReleaseBundleParams("bundle-name", "1")
 params.Description = "New Description"
@@ -1221,6 +1351,7 @@ summary, err := distManager.UpdateReleaseBundle(params)
 ```
 
 #### Signing a Release Bundle
+
 ```go
 params := services.NewSignBundleParams("bundle-name", "1")
 params.GpgPassphrase = "123456"
@@ -1229,6 +1360,7 @@ summary, err := distManager.SignReleaseBundle(params)
 ```
 
 #### Async Distributing a Release Bundle
+
 ```go
 params := services.NewDistributeReleaseBundleParams("bundle-name", "1")
 distributionRules := utils.DistributionCommonParams{SiteName: "Swamp-1", "CityName": "Tel-Aviv", "CountryCodes": []string{"123"}}}
@@ -1238,6 +1370,7 @@ err := distManager.DistributeReleaseBundle(params)
 ```
 
 #### Sync Distributing a Release Bundle
+
 ```go
 params := services.NewDistributeReleaseBundleParams("bundle-name", "1")
 distributionRules := utils.DistributionCommonParams{SiteName: "Swamp-1", "CityName": "Tel-Aviv", "CountryCodes": []string{"123"}}}
@@ -1247,6 +1380,7 @@ err := distManager.DistributeReleaseBundleSync(params, 120)
 ```
 
 #### Getting Distribution Status
+
 ```go
 params := services.NewDistributionStatusParams()
 // Optional parameters:
@@ -1261,6 +1395,7 @@ status, err := distributeBundleService.GetStatus(params)
 ```
 
 #### Deleting a Remote Release Bundle
+
 ```go
 params := services.NewDeleteReleaseBundleParams("bundle-name", "1")
 params.DeleteFromDistribution = true
@@ -1274,6 +1409,7 @@ err := distManager.DeleteReleaseBundle(params)
 ```
 
 #### Deleting a Local Release Bundle
+
 ```go
 params := services.NewDeleteReleaseBundleParams("bundle-name", "1")
 
@@ -1281,10 +1417,11 @@ err := distManager.DeleteLocalReleaseBundle(params)
 ```
 
 ## Using ContentReader
-Some APIs return a ```content.ContentReader``` struct, which allows reading the API's output. ```content.ContentReader``` provides access to large amounts of data safely, without loading all of it into the memory.
-Here's an example for how ```content.ContentReader``` should be used:
 
-```go
+Some APIs return a `content.ContentReader` struct, which allows reading the API's output. `content.ContentReader` provides access to large amounts of data safely, without loading all of it into the memory.
+Here's an example for how `content.ContentReader` should be used:
+
+````go
 reader, err := servicesManager.SearchFiles(searchParams)
 if err != nil {
     return err
@@ -1307,19 +1444,22 @@ if err := resultReader.GetError(); err != nil {
 
 // Resets the reader pointer back to the beginning of the output. Make sure not to call this method after the reader had been closed using ```reader.Close()```
 reader.Reset()
-```
+````
 
-* `reader.NextRecord(currentResult)` reads the next record from the reader into `currentResult` of type `ResultItem`.
+- `reader.NextRecord(currentResult)` reads the next record from the reader into `currentResult` of type `ResultItem`.
 
-* `reader.Close()` removes the file used by the reader after it is used (preferably using `defer`).
+- `reader.Close()` removes the file used by the reader after it is used (preferably using `defer`).
 
-* `reader.GetError()` returns any error that might have occurd during `NextRecord()`.
+- `reader.GetError()` returns any error that might have occurd during `NextRecord()`.
 
-* `reader.Reset()` resets the reader back to the beginning of the output.
+- `reader.Reset()` resets the reader back to the beginning of the output.
 
 ## Xray APIs
+
 ### Creating Xray Service Manager
+
 #### Creating Xray Details
+
 ```go
 xrayDetails := auth.NewXrayDetails()
 xrayDetails.SetUrl("http://localhost:8081/xray")
@@ -1334,6 +1474,7 @@ xrayDetails.SetClientCertKeyPath("path/to/.key")
 ```
 
 #### Creating Xray Service Config
+
 ```go
 serviceConfig, err := config.NewConfigBuilder().
     SetServiceDetails(xrayDetails).
@@ -1344,16 +1485,21 @@ serviceConfig, err := config.NewConfigBuilder().
 ```
 
 #### Creating New Xray Service Manager
+
 ```go
 xrayManager, err := xray.New(serviceConfig)
 ```
 
 ### Using Xray Services
+
 #### Fetching Xray's Version
+
 ```go
 version, err := xrayManager.GetVersion()
 ```
+
 #### Creating an Xray Watch
+
 This uses API version 2.
 
 You are able to configure repositories and builds on a watch.
@@ -1388,11 +1534,13 @@ err := xrayManager.CreateWatch(*params)
 ```
 
 #### Get an Xray Watch
+
 ```go
 watch, err := xrayManager.GetWatch("example-watch-all")
 ```
 
 #### Update an Xray Watch
+
 ```go
 watch, err := xrayManager.GetWatch("example-watch-all")
 watch.Description = "Updated description"
@@ -1401,11 +1549,13 @@ err := xrayManager.UpdateWatch(*watch)
 ```
 
 #### Delete an Xray Watch
+
 ```go
 err := xrayManager.DeleteWatch("example-watch-all")
 ```
 
 #### Creating a Security Xray Policy
+
 ```go
 params := utils.NewPolicyParams()
 params.Name = "example-security-policy"
@@ -1439,6 +1589,7 @@ err := xrayManager.CreatePolicy(params)
 ```
 
 #### Creating a License Xray Policy
+
 ```go
 params := utils.NewPolicyParams()
 params.Name = "example-licence-policy"
@@ -1460,11 +1611,13 @@ err := xrayManager.CreatePolicy(params)
 ```
 
 #### Get an Xray Policy
+
 ```go
 policy, err := xrayManager.GetPolicy("example-policy")
 ```
 
 #### Update an Xray Policy
+
 ```go
 policy, err := xrayManager.GetPolicy("example-policy")
 policy.Description = "Updated description"
@@ -1473,17 +1626,20 @@ err := xrayManager.UpdatePolicy(*policy)
 ```
 
 #### Delete an Xray Policy
+
 ```go
 err := xrayManager.DeletePolicy("example-policy")
 ```
 
 #### Add Builds to Indexing Configuration
+
 ```go
 buildsToIndex := []string{"buildName1", "buildName2"}
 err := xrayManager.AddBuildsToIndexing(buildsToIndex)
 ```
 
 #### Request Graph Scan
+
 ```go
 graphScanParams := &XrayGraphScanParams{}
 // Dependency tree. Each node must have a component identifier, see https://www.jfrog.com/confluence/display/JFROG/Xray+REST+API#XrayRESTAPI-ComponentIdentifiers.
@@ -1494,12 +1650,14 @@ scanId, err := xrayManager.ScanGraph(graphScanParams)
 ```
 
 #### Retrieve the Graph Scan Results
+
 ```go
 // scanId should be received from xrayManager.ScanGraph(graphScanParams) request.
 scanResults, err := xrayManager.GetScanGraphResults(scanId)
 ```
 
 #### Generate Vulnerabilities Report
+
 ```go
 reportRequest := services.ReportRequestParams{
   Name: "example-report",
@@ -1522,12 +1680,14 @@ reportRequestResponse, err := xrayManager.GenerateVulnerabilitiesReport(reportRe
 ```
 
 #### Get Vulnerabilities Report Details
+
 ```go
 // The reportId argument value is returned as part of the xrayManager.GenerateVulnerabilitiesReport API response.
 reportDetails, err := xrayManager.ReportDetails(reportId)
 ```
 
 #### Get Vulnerabilities Report Content
+
 ```go
 // The ReportId value is returned as part of the xrayManager.GenerateVulnerabilitiesReport API response.
 reportContentRequest := services.ReportContentRequestParams{
@@ -1541,14 +1701,18 @@ reportContent, err := xrayManager.ReportContent(reportContentRequest)
 ```
 
 #### Delete Vulnerabilities Report
+
 ```go
 // The reportId argument value is returned as part of the xrayManager.GenerateVulnerabilitiesReport API response.
 err := xrayManager.DeleteReport(reportId)
 ```
 
 ## Pipelines APIs
+
 ### Creating Pipelines Service Manager
+
 #### Creating Pipelines Details
+
 ```go
 pipelinesDetails := auth.NewPipelinesDetails()
 pipelinesDetails.SetUrl("http://localhost:8081/pipelines")
@@ -1559,6 +1723,7 @@ pipelinesDetails.SetClientCertKeyPath("path/to/.key")
 ```
 
 #### Creating Pipelines Service Config
+
 ```go
 serviceConfig, err := config.NewConfigBuilder().
     SetServiceDetails(pipelinesDetails).
@@ -1569,69 +1734,83 @@ serviceConfig, err := config.NewConfigBuilder().
 ```
 
 #### Creating New Pipelines Service Manager
+
 ```go
 pipelinesManager, err := pipelines.New(serviceConfig)
 ```
 
 ### Using Pipelines Services
+
 #### Fetching Pipelines' System Info
+
 ```go
 systemInfo, err := pipelinesManager.GetSystemInfo()
 ```
 
 #### Creating Github Integration
+
 ```go
 id, err := pipelinesManager.CreateGithubIntegration("integrationName", "token")
 ```
 
 #### Creating Github Enterprise Integration
+
 ```go
 id, err := pipelinesManager.CreateGithubEnterpriseIntegration("integrationName", "url", "token")
 ```
 
 #### Creating Bitbucket Integration
+
 ```go
 id, err := pipelinesManager.CreateBitbucketIntegration("integrationName", "username", "token")
 ```
 
 #### Creating Bitbucket Server Integration
+
 ```go
 id, err := pipelinesManager.CreateBitbucketServerIntegration("integrationName", "url", "username", "passwordOrToken")
 ```
 
 #### Creating Gitlab Integration
+
 ```go
 id, err := pipelinesManager.CreateGitlabIntegration("integrationName", "url", "token")
 ```
 
 #### Creating Artifactory Integration
+
 ```go
 id, err := pipelinesManager.CreateArtifactoryIntegration("integrationName", "url", "username", "apikey")
 ```
 
 #### Get Integration by Id
+
 ```go
 integrationId := 1234
 integration, err := pipelinesManager.GetIntegrationById(integrationId)
 ```
 
 #### Get Integration by Name
+
 ```go
 integration, err := pipelinesManager.GetIntegrationByName("integrationName")
 ```
 
 #### Get All Integrations
+
 ```go
 integrations, err := pipelinesManager.GetAllIntegrations()
 ```
 
 #### Delete Integration
+
 ```go
 integrationId := 1234
 err := pipelinesManager.DeleteIntegration(integrationId)
 ```
 
 #### Add Pipeline Source
+
 ```go
 projectIntegrationId := 1234
 err := pipelinesManager.AddSource(projectIntegrationId, "domain/repo", "master", "pipelines.yml")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang-jwt/jwt/v4 v4.1.0
-	github.com/google/uuid v1.3.0
 	github.com/gookit/color v1.4.2
 	github.com/jfrog/build-info-go v0.1.0
 	github.com/jfrog/gofrog v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
 github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/tests/accessproject_test.go
+++ b/tests/accessproject_test.go
@@ -41,7 +41,7 @@ func getTestProjectParams() services.ProjectParams {
 		ManageResources: true,
 		IndexResources:  true,
 	}
-	runNumberSuffix := runTimestamp[len(runTimestamp)-3 : len(runTimestamp)]
+	runNumberSuffix := getRunId()[len(getRunId())-3 : len(getRunId())]
 	projectDetails := services.Project{
 		DisplayName:       "testProject" + runNumberSuffix,
 		Description:       "My Test Project",

--- a/tests/artifactorydownload_test.go
+++ b/tests/artifactorydownload_test.go
@@ -35,7 +35,7 @@ func flatDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*"
+	downloadPattern := getRtTargetRepo() + "*"
 	downloadTarget := workingDir + string(filepath.Separator)
 	// Download all from TargetRepo with flat = true
 	_, err = testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true})
@@ -82,7 +82,7 @@ func recursiveDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*"
+	downloadPattern := getRtTargetRepo() + "*"
 	downloadTarget := workingDir + string(filepath.Separator)
 	_, err = testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true})
 	if err != nil {
@@ -129,7 +129,7 @@ func placeholderDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "(*).in"
+	downloadPattern := getRtTargetRepo() + "(*).in"
 	downloadTarget := workingDir + string(filepath.Separator) + "{1}" + string(filepath.Separator)
 	_, err = testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true})
 	if err != nil {
@@ -151,7 +151,7 @@ func includeDirsDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*"
+	downloadPattern := getRtTargetRepo() + "*"
 	downloadTarget := workingDir + string(filepath.Separator)
 	_, err = testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, IncludeDirs: true, Recursive: false, Target: downloadTarget}, Flat: false})
 	if err != nil {
@@ -175,7 +175,7 @@ func exclusionsDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*"
+	downloadPattern := getRtTargetRepo() + "*"
 	downloadTarget := workingDir + string(filepath.Separator)
 	exclusions := []string{"*b.in", "*.tar.gz"}
 	_, err = testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget, Exclusions: exclusions}, Flat: true})
@@ -200,7 +200,7 @@ func explodeArchiveDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*.tar.gz"
+	downloadPattern := getRtTargetRepo() + "*.tar.gz"
 	downloadTarget := workingDir + string(filepath.Separator)
 	downloadParams := services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true, Explode: false}
 	// First we'll download c.tar.gz without extracting it (explode = false by default).
@@ -254,7 +254,7 @@ func summaryDownload(t *testing.T) {
 	defer os.RemoveAll(workingDir)
 	testsDownloadService.SetSaveSummary(true)
 	defer testsDownloadService.SetSaveSummary(false)
-	downloadPattern := RtTargetRepo + "*.tar.gz"
+	downloadPattern := getRtTargetRepo() + "*.tar.gz"
 	downloadTarget := workingDir + string(filepath.Separator)
 	summary, err := testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true})
 	if err != nil {
@@ -272,14 +272,14 @@ func summaryDownload(t *testing.T) {
 		transfers = append(transfers, *item)
 	}
 	assert.Len(t, transfers, 1)
-	assert.Equal(t, testsUploadService.ArtDetails.GetUrl()+RtTargetRepo+"c.tar.gz", transfers[0].SourcePath)
+	assert.Equal(t, testsUploadService.ArtDetails.GetUrl()+getRtTargetRepo()+"c.tar.gz", transfers[0].SourcePath)
 	assert.Equal(t, filepath.Join(workingDir, "c.tar.gz"), transfers[0].TargetPath)
 	var artifacts []utils.ArtifactDetails
 	for item := new(utils.ArtifactDetails); summary.ArtifactsDetailsReader.NextRecord(item) == nil; item = new(utils.ArtifactDetails) {
 		artifacts = append(artifacts, *item)
 	}
 	assert.Len(t, artifacts, 1)
-	assert.Equal(t, RtTargetRepo+"c.tar.gz", artifacts[0].ArtifactoryPath)
+	assert.Equal(t, getRtTargetRepo()+"c.tar.gz", artifacts[0].ArtifactoryPath)
 }
 
 // Test downloading of two different files to the same path in the local machine. Only the first of them will be downloaded.
@@ -289,7 +289,7 @@ func duplicateDownload(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(workingDir)
-	downloadPattern := RtTargetRepo + "*.in"
+	downloadPattern := getRtTargetRepo() + "*.in"
 	downloadTarget := workingDir + string(filepath.Separator)
 	summary, err := testsDownloadService.DownloadFiles(services.DownloadParams{CommonParams: &utils.CommonParams{Pattern: downloadPattern, Recursive: true, Target: downloadTarget}, Flat: true})
 	if err != nil {

--- a/tests/artifactorygroup_test.go
+++ b/tests/artifactorygroup_test.go
@@ -64,7 +64,7 @@ func testDeleteGroup(t *testing.T) {
 
 func getTestGroupParams(includeUsers bool) services.GroupParams {
 	groupDetails := services.Group{
-		Name:            fmt.Sprintf("test-%s", runTimestamp),
+		Name:            fmt.Sprintf("test-%s", getRunId()),
 		Description:     "hello",
 		AutoJoin:        false,
 		AdminPrivileges: true,

--- a/tests/artifactorypermissiontarget_test.go
+++ b/tests/artifactorypermissiontarget_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	PermissionTargetNamePrefix = JfrogRepoPrefix + "-client-go-tests-target"
+	PermissionTargetNamePrefix = "client-go-tests-target"
 )
 
 func TestPermissionTarget(t *testing.T) {
 	initArtifactoryTest(t)
 	params := services.NewPermissionTargetParams()
-	params.Name = fmt.Sprintf("%s-%s", PermissionTargetNamePrefix, runTimestamp)
+	params.Name = fmt.Sprintf("%s-%s", PermissionTargetNamePrefix, getRunId())
 	params.Repo = &services.PermissionTargetSection{}
 	params.Repo.Repositories = []string{"ANY"}
 	params.Repo.ExcludePatterns = []string{"dir/*"}
@@ -69,7 +69,7 @@ func getPermissionTarget(targetName string) (targetParams *services.PermissionTa
 func TestPermissionTargetEmptyFields(t *testing.T) {
 	initArtifactoryTest(t)
 	params := services.NewPermissionTargetParams()
-	params.Name = fmt.Sprintf("%s-%s", PermissionTargetNamePrefix, runTimestamp)
+	params.Name = fmt.Sprintf("%s-%s", PermissionTargetNamePrefix, getRunId())
 
 	assert.Nil(t, params.Repo)
 	params.Repo = &services.PermissionTargetSection{}

--- a/tests/artifactoryreplication_test.go
+++ b/tests/artifactoryreplication_test.go
@@ -33,14 +33,14 @@ func createReplication() error {
 	params.Password = "password"
 	params.Url = "http://www.jfrog.com"
 	params.CronExp = "0 0 14 * * ?"
-	params.RepoKey = RtTargetRepoKey
+	params.RepoKey = getRtTargetRepoKey()
 	params.Enabled = true
 	params.SocketTimeoutMillis = 100
 	return testsCreateReplicationService.CreateReplication(params)
 }
 
 func getPushReplication(t *testing.T, expected []utils.ReplicationParams) error {
-	replicationConf, err := testsReplicationGetService.GetReplication(RtTargetRepoKey)
+	replicationConf, err := testsReplicationGetService.GetReplication(getRtTargetRepoKey())
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func getPushReplication(t *testing.T, expected []utils.ReplicationParams) error 
 }
 
 func deleteReplication(t *testing.T) error {
-	err := testsReplicationDeleteService.DeleteReplication(RtTargetRepoKey)
+	err := testsReplicationDeleteService.DeleteReplication(getRtTargetRepoKey())
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func GetReplicationConfig() []utils.ReplicationParams {
 			Username:               "anonymous",
 			Password:               "password",
 			CronExp:                "0 0 14 * * ?",
-			RepoKey:                RtTargetRepoKey,
+			RepoKey:                getRtTargetRepoKey(),
 			EnableEventReplication: false,
 			SocketTimeoutMillis:    100,
 			Enabled:                true,

--- a/tests/artifactoryupload_test.go
+++ b/tests/artifactoryupload_test.go
@@ -30,7 +30,7 @@ func flatUpload(t *testing.T) {
 
 	pattern := filepath.Join(workingDir, "out", "*")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: RtTargetRepo}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: getRtTargetRepo()}
 	up.Flat = true
 	summary, err := testsUploadService.UploadFiles(up)
 	if err != nil {
@@ -44,7 +44,7 @@ func flatUpload(t *testing.T) {
 	}
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
 	if err != nil {
@@ -70,7 +70,7 @@ func recursiveUpload(t *testing.T) {
 
 	pattern := filepath.Join(workingDir, "*")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: RtTargetRepo}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: getRtTargetRepo()}
 	up.Flat = true
 	summary, err := testsUploadService.UploadFiles(up)
 	if err != nil {
@@ -84,7 +84,7 @@ func recursiveUpload(t *testing.T) {
 	}
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
 	if err != nil {
@@ -113,7 +113,7 @@ func placeholderUpload(t *testing.T) {
 
 	pattern := filepath.Join(workingDir, "(*).in")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: RtTargetRepo + "{1}"}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: getRtTargetRepo() + "{1}"}
 	up.Flat = true
 	summary, err := testsUploadService.UploadFiles(up)
 	if err != nil {
@@ -127,7 +127,7 @@ func placeholderUpload(t *testing.T) {
 	}
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
 	if err != nil {
@@ -156,7 +156,7 @@ func includeDirsUpload(t *testing.T) {
 
 	pattern := filepath.Join(workingDir, "*")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, IncludeDirs: true, Recursive: false, Target: RtTargetRepo}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, IncludeDirs: true, Recursive: false, Target: getRtTargetRepo()}
 	up.Flat = true
 	summary, err := testsUploadService.UploadFiles(up)
 	if err != nil {
@@ -170,7 +170,7 @@ func includeDirsUpload(t *testing.T) {
 	}
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	searchParams.IncludeDirs = true
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
@@ -211,7 +211,7 @@ func explodeUpload(t *testing.T) {
 	}
 	pattern := filepath.Join(workingDir, "*.zip")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, IncludeDirs: true, Recursive: false, Target: RtTargetRepo}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, IncludeDirs: true, Recursive: false, Target: getRtTargetRepo()}
 	up.Flat = true
 	up.ExplodeArchive = true
 	summary, err := testsUploadService.UploadFiles(up)
@@ -226,7 +226,7 @@ func explodeUpload(t *testing.T) {
 	}
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	searchParams.IncludeDirs = true
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
@@ -259,7 +259,7 @@ func propsUpload(t *testing.T) {
 	targetProps, err := utils.ParseProperties("key1=val1")
 	assert.NoError(t, err)
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, Target: RtTargetRepo, TargetProps: targetProps}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, Target: getRtTargetRepo(), TargetProps: targetProps}
 	up.Flat = true
 	summary, err := testsUploadService.UploadFiles(up)
 	assert.NoError(t, err)
@@ -269,7 +269,7 @@ func propsUpload(t *testing.T) {
 	// Search a.in with property key1=val1
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
-	searchParams.Pattern = RtTargetRepo
+	searchParams.Pattern = getRtTargetRepo()
 	searchParams.Props = "key1=val1"
 	reader, err := testsSearchService.Search(searchParams)
 	defer reader.Close()
@@ -294,7 +294,7 @@ func propsUpload(t *testing.T) {
 func summaryUpload(t *testing.T) {
 	pattern := filepath.Join("testdata", "a", "*")
 	up := services.NewUploadParams()
-	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: RtTargetRepo}
+	up.CommonParams = &utils.CommonParams{Pattern: pattern, Recursive: true, Target: getRtTargetRepo()}
 	up.Flat = true
 	testsUploadService.SetSaveSummary(true)
 	defer testsUploadService.SetSaveSummary(false)
@@ -316,14 +316,14 @@ func summaryUpload(t *testing.T) {
 	expectedSha256 := "4eb341b5d2762a853d79cc25e622aa8b978eb6e12c3259e2d99dc9dc60d82c5d"
 	assert.Len(t, transfers, 1)
 	assert.Equal(t, filepath.Join("testdata", "a", "a.in"), transfers[0].SourcePath)
-	assert.Equal(t, testsUploadService.ArtDetails.GetUrl()+RtTargetRepo+"a.in", transfers[0].TargetPath)
+	assert.Equal(t, testsUploadService.ArtDetails.GetUrl()+getRtTargetRepo()+"a.in", transfers[0].TargetPath)
 	assert.Equal(t, expectedSha256, transfers[0].Sha256)
 	var artifacts []utils.ArtifactDetails
 	for item := new(utils.ArtifactDetails); summary.ArtifactsDetailsReader.NextRecord(item) == nil; item = new(utils.ArtifactDetails) {
 		artifacts = append(artifacts, *item)
 	}
 	assert.Len(t, artifacts, 1)
-	assert.Equal(t, RtTargetRepo+"a.in", artifacts[0].ArtifactoryPath)
+	assert.Equal(t, getRtTargetRepo()+"a.in", artifacts[0].ArtifactoryPath)
 	artifactoryCleanup(t)
 }
 

--- a/tests/artifactoryusers_test.go
+++ b/tests/artifactoryusers_test.go
@@ -66,7 +66,7 @@ func testDeleteUser(t *testing.T) {
 
 func getTestUserParams(replaceIfExists bool) services.UserParams {
 	userDetails := services.User{
-		Name:                     fmt.Sprintf("test%s", runTimestamp),
+		Name:                     fmt.Sprintf("test%s", getRunId()),
 		Email:                    "christianb@jfrog.com",
 		Password:                 "Password1",
 		Admin:                    false,

--- a/tests/artifactoryvirtualrepository_test.go
+++ b/tests/artifactoryvirtualrepository_test.go
@@ -43,9 +43,9 @@ import (
 func setVirtualRepositoryBaseParams(params *services.VirtualRepositoryBaseParams, isUpdate bool) {
 	setRepositoryBaseParams(&params.RepositoryBaseParams, isUpdate)
 	if !isUpdate {
-		params.Repositories = []string{RtTargetRepoKey}
+		params.Repositories = []string{getRtTargetRepoKey()}
 		params.ArtifactoryRequestsCanRetrieveRemoteArtifacts = &trueValue
-		params.DefaultDeploymentRepo = RtTargetRepoKey
+		params.DefaultDeploymentRepo = getRtTargetRepoKey()
 	} else {
 		params.Repositories = nil
 		params.ArtifactoryRequestsCanRetrieveRemoteArtifacts = &falseValue

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -87,13 +87,13 @@ func initRemoteDistributionTest(t *testing.T, bundleName string) string {
 }
 
 func createDelete(t *testing.T) {
-	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteLocalBundle(t, bundleName, true)
 
 	// Create signed release bundle
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.SignImmediately = true
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "b.in"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in"}}
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NotNil(t, summary)
 	verifyValidSha256(t, summary.GetSha256())
@@ -103,14 +103,14 @@ func createDelete(t *testing.T) {
 }
 
 func createUpdate(t *testing.T) {
-	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteLocalBundle(t, bundleName, true)
 
 	// Create release bundle params
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.Description = "Release bundle description 1"
 	createBundleParams.ReleaseNotes = "Release notes 1"
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "b.in"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in"}}
 
 	// Test DryRun first
 	err := createDryRun(createBundleParams)
@@ -135,7 +135,7 @@ func createUpdate(t *testing.T) {
 	updateBundleParams := services.NewUpdateReleaseBundleParams(bundleName, bundleVersion)
 	updateBundleParams.Description = "Release bundle description 2"
 	updateBundleParams.ReleaseNotes = "Release notes 2"
-	updateBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "test/a.in"}}
+	updateBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "test/a.in"}}
 
 	// Test DryRun first
 	err = updateDryRun(updateBundleParams)
@@ -194,7 +194,7 @@ func setServicesToDryRunFalse() {
 }
 
 func createWithProps(t *testing.T) {
-	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initLocalDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteLocalBundle(t, bundleName, true)
 
 	// Create release bundle with properties
@@ -202,7 +202,7 @@ func createWithProps(t *testing.T) {
 	assert.NoError(t, err)
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.SpecFiles = []*utils.CommonParams{{
-		Pattern:     RtTargetRepo + "b.in",
+		Pattern:     getRtTargetRepo() + "b.in",
 		TargetProps: targetProps,
 	}}
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
@@ -242,12 +242,12 @@ func createWithProps(t *testing.T) {
 }
 
 func createSignDistributeDelete(t *testing.T) {
-	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteRemoteAndLocalBundle(t, bundleName, true)
 
 	// Create unsigned release bundle
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "b.in"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in"}}
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
 	assert.Nil(t, summary)
@@ -296,12 +296,12 @@ func createSignDistributeDelete(t *testing.T) {
 }
 
 func createSignSyncDistributeDelete(t *testing.T) {
-	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteRemoteAndLocalBundle(t, bundleName, true)
 
 	// Create unsigned release bundle
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "b.in"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in"}}
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
 	assert.Nil(t, summary)
@@ -335,12 +335,12 @@ func createSignSyncDistributeDelete(t *testing.T) {
 }
 
 func createDistributeMapping(t *testing.T) {
-	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteRemoteAndLocalBundle(t, bundleName, true)
 
 	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: RtTargetRepo + "b.in", Target: RtTargetRepo + "b.out"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in", Target: getRtTargetRepo() + "b.out"}}
 	createBundleParams.SignImmediately = true
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
@@ -356,7 +356,7 @@ func createDistributeMapping(t *testing.T) {
 
 	// Make sure <RtTargetRepo>/b.out does exist in Artifactory
 	searchParams := artifactoryServices.NewSearchParams()
-	searchParams.Pattern = RtTargetRepo + "b.out"
+	searchParams.Pattern = getRtTargetRepo() + "b.out"
 	reader, err := testsSearchService.Search(searchParams)
 	assert.NoError(t, err)
 	assert.NoError(t, reader.Close())
@@ -366,12 +366,12 @@ func createDistributeMapping(t *testing.T) {
 }
 
 func createDistributeMappingPlaceholder(t *testing.T) {
-	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+runTimestamp)
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
 	defer deleteRemoteAndLocalBundle(t, bundleName, true)
 
 	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
-	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: "(" + RtTargetRepo + ")" + "(*).in", Target: "{1}{2}.out"}}
+	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: "(" + getRtTargetRepo() + ")" + "(*).in", Target: "{1}{2}.out"}}
 	createBundleParams.SignImmediately = true
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	assert.NoError(t, err)
@@ -387,7 +387,7 @@ func createDistributeMappingPlaceholder(t *testing.T) {
 
 	// Make sure <RtTargetRepo>/b.out does exist in Artifactory
 	searchParams := artifactoryServices.NewSearchParams()
-	searchParams.Pattern = RtTargetRepo + "b.out"
+	searchParams.Pattern = getRtTargetRepo() + "b.out"
 	reader, err := testsSearchService.Search(searchParams)
 	assert.NoError(t, err)
 	assert.NoError(t, reader.Close())

--- a/tests/pipelinesintegrations_test.go
+++ b/tests/pipelinesintegrations_test.go
@@ -114,7 +114,7 @@ func getIntegrationAndAssert(t *testing.T, id int, name, integrationType string)
 }
 
 func getUniqueIntegrationName(integrationType string) string {
-	return strings.Join([]string{integrationNamesPrefix, integrationType, runTimestamp}, "_")
+	return strings.Join([]string{integrationNamesPrefix, integrationType, timestampStr}, "_")
 }
 
 func deleteIntegrationAndAssert(t *testing.T, id int) {

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -130,7 +130,7 @@ const (
 )
 
 func init() {
-	ciRunId = flag.String("test.ciRunId", "", "CI Run ID")
+	ciRunId = flag.String("ci.runId", "", "A unique run ID used as a suffix to create repositories tests")
 	TestArtifactory = flag.Bool("test.artifactory", false, "Test Artifactory")
 	TestDistribution = flag.Bool("test.distribution", false, "Test distribution")
 	TestXray = flag.Bool("test.xray", false, "Test xray")

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -130,7 +130,7 @@ const (
 )
 
 func init() {
-	ciRunId = flag.String("ci.runId", "", "A unique run ID used as a suffix to create repositories tests")
+	ciRunId = flag.String("ci.runId", "", "A unique identifier used as a suffix to create repositories in the tests")
 	TestArtifactory = flag.Bool("test.artifactory", false, "Test Artifactory")
 	TestDistribution = flag.Bool("test.distribution", false, "Test distribution")
 	TestXray = flag.Bool("test.xray", false, "Test xray")
@@ -165,7 +165,7 @@ func getRtTargetRepo() string {
 
 func getRunId() string {
 	if ciRunId != nil && *ciRunId != "" {
-		return *ciRunId
+		return *ciRunId + "-" + timestampStr
 	}
 	return timestampStr
 }

--- a/tests/xraybinmgr_test.go
+++ b/tests/xraybinmgr_test.go
@@ -13,7 +13,7 @@ func TestXrayBinMgr(t *testing.T) {
 }
 
 func addBuildsToIndexing(t *testing.T) {
-	buildName := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "build1", runTimestamp)
+	buildName := fmt.Sprintf("%s-%s", "build1", getRunId())
 	defer deleteBuild(buildName)
 
 	// Create a build

--- a/tests/xraypolicy_test.go
+++ b/tests/xraypolicy_test.go
@@ -24,7 +24,7 @@ func deletePolicy(t *testing.T, policyName string) {
 }
 
 func createMinSeverity(t *testing.T) {
-	policyName := "create-min-severity" + runTimestamp
+	policyName := "create-min-severity" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{
@@ -36,7 +36,7 @@ func createMinSeverity(t *testing.T) {
 }
 
 func createRangeSeverity(t *testing.T) {
-	policyName := "create-range-severity" + runTimestamp
+	policyName := "create-range-severity" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{
@@ -48,7 +48,7 @@ func createRangeSeverity(t *testing.T) {
 }
 
 func createLicenseAllowed(t *testing.T) {
-	policyName := "create-allowed-licenses" + runTimestamp
+	policyName := "create-allowed-licenses" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{
@@ -60,7 +60,7 @@ func createLicenseAllowed(t *testing.T) {
 }
 
 func createLicenseBanned(t *testing.T) {
-	policyName := "create-banned-licenses" + runTimestamp
+	policyName := "create-banned-licenses" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{
@@ -72,7 +72,7 @@ func createLicenseBanned(t *testing.T) {
 }
 
 func create2Priorities(t *testing.T) {
-	policyName := "create-2-priorties" + runTimestamp
+	policyName := "create-2-priorties" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule1 := utils.PolicyRule{
@@ -89,7 +89,7 @@ func create2Priorities(t *testing.T) {
 }
 
 func createPolicyActions(t *testing.T) {
-	policyName := "create-policy-actions" + runTimestamp
+	policyName := "create-policy-actions" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{
@@ -112,7 +112,7 @@ func createPolicyActions(t *testing.T) {
 }
 
 func createUpdatePolicy(t *testing.T) {
-	policyName := "update-policy" + runTimestamp
+	policyName := "update-policy" + getRunId()
 	defer deletePolicy(t, policyName)
 
 	policyRule := utils.PolicyRule{

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -23,17 +23,17 @@ func TestXrayWatch(t *testing.T) {
 }
 
 func testXrayWatchAll(t *testing.T) {
-	policy1Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "policy1", runTimestamp)
+	policy1Name := fmt.Sprintf("%s-%s", "policy1", getRunId())
 	err := createDummyPolicy(policy1Name)
 	assert.NoError(t, err)
 	defer testsXrayPolicyService.Delete(policy1Name)
 
-	policy2Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "policy2", runTimestamp)
+	policy2Name := fmt.Sprintf("%s-%s", "policy2", getRunId())
 	err = createDummyPolicy(policy2Name)
 	assert.NoError(t, err)
 	defer testsXrayPolicyService.Delete(policy2Name)
 
-	AllWatchName := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "client-go-tests-watch-all-repos", runTimestamp)
+	AllWatchName := fmt.Sprintf("%s-%s", "client-go-tests-watch-all-repos", getRunId())
 	paramsAllRepos := utils.NewWatchParams()
 	paramsAllRepos.Name = AllWatchName
 	paramsAllRepos.Description = "All Repos"
@@ -117,30 +117,30 @@ func testXrayWatchAll(t *testing.T) {
 }
 
 func testXrayWatchSelectedRepos(t *testing.T) {
-	policy1Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "policy1-pattern", runTimestamp)
+	policy1Name := fmt.Sprintf("%s-%s", "policy1-pattern", getRunId())
 	err := createDummyPolicy(policy1Name)
 	assert.NoError(t, err)
 	defer testsXrayPolicyService.Delete(policy1Name)
 
-	repo1Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "repo1", runTimestamp)
+	repo1Name := fmt.Sprintf("%s-%s", "repo1", getRunId())
 	createRepoLocal(t, repo1Name)
 	defer deleteRepo(t, repo1Name)
-	repo2Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "repo2", runTimestamp)
+	repo2Name := fmt.Sprintf("%s-%s", "repo2", getRunId())
 	createRepoRemote(t, repo2Name)
 	defer deleteRepo(t, repo2Name)
 
-	build1Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "build1", runTimestamp)
+	build1Name := fmt.Sprintf("%s-%s", "build1", getRunId())
 	err = createAndIndexBuild(t, build1Name)
 	assert.NoError(t, err)
 	defer deleteBuild(build1Name)
 
-	build2Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "build2", runTimestamp)
+	build2Name := fmt.Sprintf("%s-%s", "build2", getRunId())
 	err = createAndIndexBuild(t, build2Name)
 	assert.NoError(t, err)
 	defer deleteBuild(build2Name)
 
 	paramsSelectedRepos := utils.NewWatchParams()
-	paramsSelectedRepos.Name = fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "client-go-tests-watch-selected-repos", runTimestamp)
+	paramsSelectedRepos.Name = fmt.Sprintf("%s-%s", "client-go-tests-watch-selected-repos", getRunId())
 	paramsSelectedRepos.Description = "Selected Repos"
 	paramsSelectedRepos.Active = true
 	paramsSelectedRepos.Policies = []utils.AssignedPolicy{
@@ -256,13 +256,13 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 }
 
 func testXrayWatchBuildsByPattern(t *testing.T) {
-	policy1Name := fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "policy1-pattern", runTimestamp)
+	policy1Name := fmt.Sprintf("%s-%s", "policy1-pattern", getRunId())
 	err := createDummyPolicy(policy1Name)
 	assert.NoError(t, err)
 	defer testsXrayPolicyService.Delete(policy1Name)
 
 	paramsBuildsByPattern := utils.NewWatchParams()
-	paramsBuildsByPattern.Name = fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "client-go-tests-watch-builds-by-pattern", runTimestamp)
+	paramsBuildsByPattern.Name = fmt.Sprintf("%s-%s", "client-go-tests-watch-builds-by-pattern", getRunId())
 	paramsBuildsByPattern.Description = "Builds By Pattern"
 	paramsBuildsByPattern.Builds.Type = utils.WatchBuildAll
 	paramsBuildsByPattern.Builds.All.ExcludePatterns = []string{"excludePath"}
@@ -302,7 +302,7 @@ func testXrayWatchBuildsByPattern(t *testing.T) {
 
 func testXrayWatchUpdateMissingWatch(t *testing.T) {
 	paramsMissingWatch := utils.NewWatchParams()
-	paramsMissingWatch.Name = fmt.Sprintf("%s-%s-%s", JfrogRepoPrefix, "client-go-tests-watch-missing", runTimestamp)
+	paramsMissingWatch.Name = fmt.Sprintf("%s-%s", "client-go-tests-watch-missing", getRunId())
 	paramsMissingWatch.Description = "Missing Watch"
 	paramsMissingWatch.Builds.Type = utils.WatchBuildAll
 	paramsMissingWatch.Policies = []utils.AssignedPolicy{}
@@ -312,12 +312,12 @@ func testXrayWatchUpdateMissingWatch(t *testing.T) {
 }
 
 func testXrayWatchDeleteMissingWatch(t *testing.T) {
-	err := testsXrayWatchService.Delete(JfrogRepoPrefix + "-client-go-tests-watch-builds-missing")
+	err := testsXrayWatchService.Delete("client-go-tests-watch-builds-missing")
 	assert.EqualError(t, err, "Server response: 404 Not Found\n{\n  \"error\": \"Failed to delete Watch: Watch was not found\"\n}")
 }
 
 func testXrayWatchGetMissingWatch(t *testing.T) {
-	_, err := testsXrayWatchService.Get(JfrogRepoPrefix + "-client-go-tests-watch-builds-missing")
+	_, err := testsXrayWatchService.Get("client-go-tests-watch-builds-missing")
 	assert.EqualError(t, err, "Server response: 404 Not Found\n{\n  \"error\": \"Watch was not found\"\n}")
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Using the timestamp as a unique repository name is not 100% bullet-prove as two parallel tests in GitHub-Actions could get the same timestamp. 
In addition to the time stamp, there will be for each test its running os & test type (e.g. for Artifactory test in mac machine, the repository will be named, client-tests-ar-m-1637049275)