### PR TITLE
Add support for new free-tier setup command

### DIFF
--- a/utils/io/httputils/pollingexecutor.go
+++ b/utils/io/httputils/pollingexecutor.go
@@ -10,7 +10,7 @@ type PollingAction func() (shouldStop bool, responseBody []byte, err error)
 
 type PollingExecutor struct {
 	// The amount of max wait time.
-	Timout time.Duration
+	Timeout time.Duration
 	// Number of seconds to sleep between polling attempts.
 	PollingInterval time.Duration
 	// Prefix to add at the beginning of each info/error message.
@@ -20,7 +20,6 @@ type PollingExecutor struct {
 }
 
 func (runner *PollingExecutor) Execute() ([]byte, error) {
-	//The scan request may take some time to complete. We expect to receive a 202 response, until the completion.
 	ticker := time.NewTicker(runner.PollingInterval)
 	timeout := make(chan bool)
 	errChan := make(chan error)
@@ -29,7 +28,7 @@ func (runner *PollingExecutor) Execute() ([]byte, error) {
 		for {
 			select {
 			case <-timeout:
-				errChan <- errorutils.CheckErrorf("%s Polling executer timeouted after %d secondes", runner.MsgPrefix, runner.Timout.Seconds())
+				errChan <- errorutils.CheckErrorf("%s Polling executer timeouted after %d secondes", runner.MsgPrefix, runner.Timeout.Seconds())
 				resultChan <- nil
 				return
 			case _ = <-ticker.C:
@@ -50,7 +49,7 @@ func (runner *PollingExecutor) Execute() ([]byte, error) {
 	}()
 	// Make sure we don't wait forever
 	go func() {
-		time.Sleep(runner.Timout)
+		time.Sleep(runner.Timeout)
 		timeout <- true
 	}()
 	// Wait for result or error

--- a/utils/io/httputils/pollingexecutor.go
+++ b/utils/io/httputils/pollingexecutor.go
@@ -1,0 +1,61 @@
+package httputils
+
+import (
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+type PollingAction func() (shouldStop bool, responseBody []byte, err error)
+
+type PollingExecutor struct {
+	// The amount of max wait time.
+	Timout time.Duration
+	// Number of seconds to sleep between polling attempts.
+	PollingInterval time.Duration
+	// Prefix to add at the beginning of each info/error message.
+	MsgPrefix string
+	// pollingAction is the operation to run until the condition fullfiled.
+	PollingAction PollingAction
+}
+
+func (runner *PollingExecutor) Execute() ([]byte, error) {
+	//The scan request may take some time to complete. We expect to receive a 202 response, until the completion.
+	ticker := time.NewTicker(runner.PollingInterval)
+	timeout := make(chan bool)
+	errChan := make(chan error)
+	resultChan := make(chan []byte)
+	go func() {
+		for {
+			select {
+			case <-timeout:
+				errChan <- errorutils.CheckErrorf("%s Polling executer timeouted after %d secondes", runner.MsgPrefix, runner.Timout.Seconds())
+				resultChan <- nil
+				return
+			case _ = <-ticker.C:
+				shouldStop, responseBody, err := runner.PollingAction()
+				if err != nil {
+					errChan <- err
+					resultChan <- nil
+					return
+				}
+				// Got the full valid response.
+				if shouldStop {
+					errChan <- nil
+					resultChan <- responseBody
+					return
+				}
+			}
+		}
+	}()
+	// Make sure we don't wait forever
+	go func() {
+		time.Sleep(runner.Timout)
+		timeout <- true
+	}()
+	// Wait for result or error
+	err := <-errChan
+	body := <-resultChan
+	ticker.Stop()
+	return body, err
+}

--- a/utils/io/httputils/pollingexecutor.go
+++ b/utils/io/httputils/pollingexecutor.go
@@ -9,7 +9,7 @@ import (
 type PollingAction func() (shouldStop bool, responseBody []byte, err error)
 
 type PollingExecutor struct {
-	// The amount of max wait time.
+	// Maximum wait time in seconds.
 	Timeout time.Duration
 	// Number of seconds to sleep between polling attempts.
 	PollingInterval time.Duration
@@ -28,7 +28,7 @@ func (runner *PollingExecutor) Execute() ([]byte, error) {
 		for {
 			select {
 			case <-timeout:
-				errChan <- errorutils.CheckErrorf("%s Polling executer timeouted after %d secondes", runner.MsgPrefix, runner.Timeout.Seconds())
+				errChan <- errorutils.CheckErrorf("%s Polling executor timeout after %v secondes", runner.MsgPrefix, runner.Timeout.Seconds())
 				resultChan <- nil
 				return
 			case _ = <-ticker.C:

--- a/utils/io/progress.go
+++ b/utils/io/progress.go
@@ -8,21 +8,22 @@ type ProgressMgr interface {
 	// Input: 'total' - file size, 'label' - the title of the operation, 'path' - the path of the file being processed.
 	// Output: progress indicator id
 	NewProgressReader(total int64, label, path string) (progress Progress)
-	// Changes progress indicator state
+	// Changes progress indicator state.
 	SetProgressState(id int, state string)
 	// Returns the requested progress indicator.
 	GetProgress(id int) (progress Progress)
-	// Aborts a progress indicator. Called on both successful and unsuccessful operations
+	// Aborts a progress indicator. Called on both successful and unsuccessful operations.
 	RemoveProgress(id int)
-	// Quits the whole progress mechanism
+	// Quits the whole progress mechanism.
 	Quit()
 	// Increments the general progress total count by given n.
 	IncGeneralProgressTotalBy(n int64)
 	// Replace the headline progress indicator message with new one.
 	SetHeadlineMsg(msg string)
-	// Terminate the progress indicator
+	// Terminate the headline progress indicator.
 	ClearHeadlineMsg()
-	// Init the specific progress indicators for files readers progresses
+	// Specific initialization of reader progress indicators.
+	// Should be called before the first call to NewProgressReader.
 	InitProgressReaders()
 }
 

--- a/utils/io/progress.go
+++ b/utils/io/progress.go
@@ -18,6 +18,12 @@ type ProgressMgr interface {
 	Quit()
 	// Increments the general progress total count by given n.
 	IncGeneralProgressTotalBy(n int64)
+	// Replace the headline progress indicator message with new one.
+	SetHeadlineMsg(msg string)
+	// Terminate the progress indicator
+	ClearHeadlineMsg()
+	// Init the specific progress indicators for files readers progresses
+	InitProgressReaders()
 }
 
 type Progress interface {

--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -129,7 +129,7 @@ func (ss *ScanService) GetScanGraphResults(scanId string, includeVulnerabilities
 		return false, nil, nil
 	}
 	pollingExecutor := &httputils.PollingExecutor{
-		Timout:          defaultMaxWaitMinutes,
+		Timeout:         defaultMaxWaitMinutes,
 		PollingInterval: defaultSyncSleepInterval,
 		PollingAction:   pollingAction,
 	}

--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -42,8 +43,8 @@ const (
 type ScanType string
 
 type ScanService struct {
-	client         *jfroghttpclient.JfrogHttpClient
-	XrayDetails    auth.ServiceDetails
+	client      *jfroghttpclient.JfrogHttpClient
+	XrayDetails auth.ServiceDetails
 }
 
 // NewScanService creates a new service to scan Binaries and VCS projects.
@@ -101,10 +102,6 @@ func (ss *ScanService) GetScanGraphResults(scanId string, includeVulnerabilities
 
 	message := fmt.Sprintf("Sync: Get Scan Graph results. Scan ID:%s...", scanId)
 	//The scan request may take some time to complete. We expect to receive a 202 response, until the completion.
-	ticker := time.NewTicker(defaultSyncSleepInterval)
-	timeout := make(chan bool)
-	errChan := make(chan error)
-	resultChan := make(chan []byte)
 	endPoint := ss.XrayDetails.GetUrl() + scanGraphAPI + "/" + scanId
 	if includeVulnerabilities {
 		endPoint += includeVulnerabilitiesParam
@@ -114,44 +111,30 @@ func (ss *ScanService) GetScanGraphResults(scanId string, includeVulnerabilities
 	} else if includeLicenses {
 		endPoint += includeLicensesParam
 	}
-	go func() {
-		for {
-			select {
-			case <-timeout:
-				errChan <- errorutils.CheckErrorf("Timeout for sync get scan graph results.")
-				resultChan <- nil
-				return
-			case _ = <-ticker.C:
-				log.Debug(message)
-				resp, body, _, err := ss.client.SendGet(endPoint, true, &httpClientsDetails)
-				if err != nil {
-					errChan <- err
-					resultChan <- nil
-					return
-				}
-				if err = errorutils.CheckResponseStatus(resp, http.StatusOK, http.StatusAccepted); err != nil {
-					errChan <- errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
-					resultChan <- nil
-					return
-				}
-				// Got the full valid response.
-				if resp.StatusCode == http.StatusOK {
-					errChan <- nil
-					resultChan <- body
-					return
-				}
-			}
+
+	pollingAction := func() (shouldStop bool, responseBody []byte, err error) {
+		log.Debug(message)
+		resp, body, _, err := ss.client.SendGet(endPoint, true, &httpClientsDetails)
+		if err != nil {
+			return true, nil, err
 		}
-	}()
-	// Make sure we don't wait forever
-	go func() {
-		time.Sleep(defaultMaxWaitMinutes)
-		timeout <- true
-	}()
-	// Wait for result or error
-	err := <-errChan
-	body := <-resultChan
-	ticker.Stop()
+		if err = errorutils.CheckResponseStatus(resp, http.StatusOK, http.StatusAccepted); err != nil {
+			err = errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
+			return true, nil, err
+		}
+		// Got the full valid response.
+		if resp.StatusCode == http.StatusOK {
+			return true, body, nil
+		}
+		return false, nil, nil
+	}
+	pollingExecutor := &httputils.PollingExecutor{
+		Timout:          defaultMaxWaitMinutes,
+		PollingInterval: defaultSyncSleepInterval,
+		PollingAction:   pollingAction,
+	}
+
+	body, err := pollingExecutor.Execute()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This pull request adds the new PollingExecutor that introduces HTTP polling implementation.
As well as minor progress API changes needed for the new free-tier setup command.