### PR TITLE
Increase scan timeout to 45 minutes

### DIFF
--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -31,7 +31,7 @@ const (
 	andIncludeLicensesParam     = "&include_licenses=true"
 
 	// Get scan results timeouts
-	defaultMaxWaitMinutes    = 15 * time.Minute // 15 minutes
+	defaultMaxWaitMinutes    = 45 * time.Minute // 45 minutes
 	defaultSyncSleepInterval = 5 * time.Second  // 5 seconds
 
 	// ScanType values


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Increase build-scan and scan-graph default timeout to 45 minutes.