### PR TITLE
Polling executor refactor

### DIFF
--- a/distribution/services/distribute.go
+++ b/distribution/services/distribute.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	artifactoryUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
@@ -104,29 +103,33 @@ func (dr *DistributeReleaseBundleService) waitForDistribution(distributeParams *
 		maxWaitMinutes = dr.MaxWaitMinutes
 	}
 	distributingMessage := fmt.Sprintf("Sync: Distributing %s/%s...", distributeParams.Name, distributeParams.Version)
-	for timeElapsed := 0; timeElapsed < maxWaitMinutes*60; timeElapsed += defaultSyncSleepIntervalSeconds {
-		if timeElapsed%60 == 0 {
-			log.Info(distributingMessage)
-		}
-		response, err := distributeBundleService.GetStatus(distributionStatusParams)
-		if err != nil {
-			return err
-		}
-
-		if (*response)[0].Status == Failed {
-			bytes, err := json.Marshal(response)
+	retrayExecutor := &utils.RetryExecutor{
+		MaxRetries:               maxWaitMinutes * 60 / defaultMaxWaitMinutes,
+		RetriesIntervalMilliSecs: defaultSyncSleepIntervalSeconds * 1000,
+		ErrorMessage:             "",
+		LogMsgPrefix:             distributingMessage,
+		ExecutionHandler: func() (bool, error) {
+			response, err := distributeBundleService.GetStatus(distributionStatusParams)
 			if err != nil {
-				return errorutils.CheckError(err)
+				return false, err
 			}
-			return errorutils.CheckErrorf("Distribution failed: " + utils.IndentJson(bytes))
-		}
-		if (*response)[0].Status == Completed {
-			log.Info("Distribution Completed!")
-			return nil
-		}
-		time.Sleep(time.Second * defaultSyncSleepIntervalSeconds)
+			if (*response)[0].Status == Failed {
+				bytes, err := json.Marshal(response)
+				if err != nil {
+					return false, errorutils.CheckError(err)
+				}
+				return false, errorutils.CheckErrorf("Distribution failed: " + utils.IndentJson(bytes))
+			}
+			if (*response)[0].Status == Completed {
+				log.Info("Distribution Completed!")
+				return false, nil
+			}
+			// Keep trying to get an answer
+			log.Info(distributingMessage)
+			return true, nil
+		},
 	}
-	return errorutils.CheckErrorf("Timeout for sync distribution")
+	return retrayExecutor.Execute()
 }
 
 type DistributionBody struct {

--- a/distribution/services/distribute.go
+++ b/distribution/services/distribute.go
@@ -111,7 +111,7 @@ func (dr *DistributeReleaseBundleService) waitForDistribution(distributeParams *
 		ExecutionHandler: func() (bool, error) {
 			response, err := distributeBundleService.GetStatus(distributionStatusParams)
 			if err != nil {
-				return false, err
+				return false, errorutils.CheckError(err)
 			}
 			if (*response)[0].Status == Failed {
 				bytes, err := json.Marshal(response)

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -46,7 +46,7 @@ func (runner *RetryExecutor) Execute() error {
 			time.Sleep(time.Millisecond * time.Duration(runner.RetriesIntervalMilliSecs))
 		}
 	}
-	log.Info(fmt.Sprintf("%s executor timeout after %v attempts (%v seconds)", runner.LogMsgPrefix, runner.MaxRetries, runner.MaxRetries*runner.RetriesIntervalMilliSecs/1000))
+	log.Info(fmt.Sprintf("%s executor timeout after %v attempts with %v milliseconds wait intervals", runner.LogMsgPrefix, runner.MaxRetries, runner.RetriesIntervalMilliSecs))
 	return err
 }
 

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -47,8 +46,8 @@ func (runner *RetryExecutor) Execute() error {
 			time.Sleep(time.Millisecond * time.Duration(runner.RetriesIntervalMilliSecs))
 		}
 	}
-
-	return errorutils.CheckErrorf("%s executor timeout after %v attempts (%v seconds)", runner.LogMsgPrefix, runner.MaxRetries, runner.MaxRetries*runner.RetriesIntervalMilliSecs/1000)
+	log.Info(fmt.Sprintf("%s executor timeout after %v attempts (%v seconds)", runner.LogMsgPrefix, runner.MaxRetries, runner.MaxRetries*runner.RetriesIntervalMilliSecs/1000))
+	return err
 }
 
 func (runner *RetryExecutor) getLogRetryMessage(attemptNumber int, err error) (message string) {

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -2,9 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"strconv"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type ExecutionHandlerFunc func() (bool, error)
@@ -46,7 +48,7 @@ func (runner *RetryExecutor) Execute() error {
 		}
 	}
 
-	return err
+	return errorutils.CheckErrorf("%s executor timeout after %v attempts (%v seconds)", runner.LogMsgPrefix, runner.MaxRetries, runner.MaxRetries*runner.RetriesIntervalMilliSecs/1000)
 }
 
 func (runner *RetryExecutor) getLogRetryMessage(attemptNumber int, err error) (message string) {


### PR DESCRIPTION
Unify polling and retry executor logic.
From now on, the polling executor will use the retry implemented utility instead
of its separate implementation.

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
