### PR TITLE
Bugfix - append ending slash to sort key

### DIFF
--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -326,6 +326,9 @@ type ResultItem struct {
 }
 
 func (item ResultItem) GetSortKey() string {
+	if item.Type == "folder" {
+		return appendFolderSuffix(item.GetItemRelativePath())
+	}
 	return item.GetItemRelativePath()
 }
 
@@ -345,8 +348,8 @@ func (item ResultItem) GetItemRelativePath() string {
 	url := item.Repo
 	url = addSeparator(url, "/", item.Path)
 	url = addSeparator(url, "/", item.Name)
-	if item.Type == "folder" && !strings.HasSuffix(url, "/") {
-		url = url + "/"
+	if item.Type == "folder" {
+		url = appendFolderSuffix(url)
 	}
 	return url
 }
@@ -487,4 +490,11 @@ func DisableTransitiveSearchIfNotAllowed(params *CommonParams, artifactoryVersio
 			transitiveSearchMinVersion, artifactoryVersion.GetVersion()))
 		params.Transitive = false
 	}
+}
+
+func appendFolderSuffix(folderPath string) string {
+	if !strings.HasSuffix(folderPath, "/") {
+		folderPath = folderPath + "/"
+	}
+	return folderPath
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Readers' sort fails for missing ending slash in folders' key.

Before the fix:
"cli-rt2-1641454539/()"                     "cli-rt2-1641454539/("
"cli-rt2-1641454539/("          ->.       "cli-rt2-1641454539/()" 
"cli-rt2-1641454539/(/b(.in".             "cli-rt2-1641454539/(/b(.in"

After:
"cli-rt2-1641454539/()"                     "cli-rt2-1641454539/(/"
"cli-rt2-1641454539/(/"          ->.       "cli-rt2-1641454539/(/b(.in" 
"cli-rt2-1641454539/(/b(.in".             "cli-rt2-1641454539/()"
