### PR TITLE
Follow transitive search limitations

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -19,7 +19,7 @@ func CreateAqlBodyForSpecWithPattern(params *CommonParams) (string, error) {
 		return "", err
 	}
 	if params.Transitive && !singleRepo {
-		return "", errorutils.CheckErrorf("Repository name cannot contain wildcards in transitive search.")
+		return "", errorutils.CheckErrorf("When searching or downloading with the transitive setting, the pattern must include a single repository only, meaning wildcards are allowed only after the first slash.")
 	}
 	includeRoot := strings.Count(searchPattern, "/") < 2
 	triplesSize := len(repoPathFileTriples)

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"strconv"
 	"strings"
 
@@ -13,9 +14,12 @@ import (
 // Returns an AQL body string to search file in Artifactory by pattern, according the specified arguments requirements.
 func CreateAqlBodyForSpecWithPattern(params *CommonParams) (string, error) {
 	searchPattern := prepareSourceSearchPattern(params.Pattern, params.Target, true)
-	repoPathFileTriples, err := createRepoPathFileTriples(searchPattern, params.Recursive)
+	repoPathFileTriples, singleRepo, err := createRepoPathFileTriples(searchPattern, params.Recursive)
 	if err != nil {
 		return "", err
+	}
+	if params.Transitive && !singleRepo {
+		return "", errorutils.CheckErrorf("Repository name cannot contain wildcards in transitive search.")
 	}
 	includeRoot := strings.Count(searchPattern, "/") < 2
 	triplesSize := len(repoPathFileTriples)
@@ -253,7 +257,7 @@ func buildExcludeQueryPart(params *CommonParams, useLocalPath, recursive bool) (
 	excludeQuery := ""
 	var excludeTriples []RepoPathFile
 	for _, exclusion := range params.GetExclusions() {
-		repoPathFileTriples, err := createRepoPathFileTriples(prepareSearchPattern(exclusion, true), recursive)
+		repoPathFileTriples, _, err := createRepoPathFileTriples(prepareSearchPattern(exclusion, true), recursive)
 		if err != nil {
 			return "", err
 		}
@@ -337,8 +341,8 @@ func BuildQueryFromSpecFile(specFile *CommonParams, requiredArtifactProps Requir
 	query := fmt.Sprintf(`items.find(%s)%s`, aqlBody, buildIncludeQueryPart(getQueryReturnFields(specFile, requiredArtifactProps)))
 	query = appendSortQueryPart(specFile, query)
 	query = appendOffsetQueryPart(specFile, query)
-	query = appendLimitQueryPart(specFile, query)
 	query = appendTransitiveQueryPart(specFile, query)
+	query = appendLimitQueryPart(specFile, query)
 	return query
 }
 

--- a/artifactory/services/utils/repopathfile_test.go
+++ b/artifactory/services/utils/repopathfile_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 )
 
-type CreateRepoPathFileTest struct {
-	pattern   string
-	recursive bool
-	expected  []RepoPathFile
+type createPathFilePairsTest struct {
+	pattern         string
+	recursive       bool
+	expectedTriples []RepoPathFile
 }
 
-var pathFilesDataProvider = []CreateRepoPathFileTest{
+var pathFilesDataProvider = []createPathFilePairsTest{
 	{"a", true,
 		[]RepoPathFile{{"r", ".", "a"}}},
 	{"a/*", true,
@@ -43,47 +43,54 @@ var pathFilesDataProvider = []CreateRepoPathFileTest{
 		[]RepoPathFile{{"r", "*b*", "*"}, {"r", "*", "*b*"}}},
 }
 
-var repoPathFilesDataProvider = []CreateRepoPathFileTest{
+type createRepoPathFileTriplesTest struct {
+	pattern            string
+	recursive          bool
+	expectedTriples    []RepoPathFile
+	expectedSingleRepo bool
+}
+
+var repoPathFilesDataProvider = []createRepoPathFileTriplesTest{
 	{"a/*", true,
-		[]RepoPathFile{{"a", "*", "*"}}},
+		[]RepoPathFile{{"a", "*", "*"}}, true},
 	{"a/a*b", true,
-		[]RepoPathFile{{"a", "a*", "*b"}, {"a", ".", "a*b"}}},
+		[]RepoPathFile{{"a", "a*", "*b"}, {"a", ".", "a*b"}}, true},
 	{"a/a*b*", true,
-		[]RepoPathFile{{"a", "a*b*", "*"}, {"a", "a*", "*b*"}, {"a", ".", "a*b*"}}},
+		[]RepoPathFile{{"a", "a*b*", "*"}, {"a", "a*", "*b*"}, {"a", ".", "a*b*"}}, true},
 	{"a/a*b*/a/b", true,
-		[]RepoPathFile{{"a", "a*b*/a", "b"}}},
+		[]RepoPathFile{{"a", "a*b*/a", "b"}}, true},
 	{"*a/b*/*c*d*", true,
 		[]RepoPathFile{{"*", "*a/b*/*c*d*", "*"}, {"*", "*a/b*/*c*", "*d*"}, {"*", "*a/b*/*", "*c*d*"}, {"*", "*a/b*", "*c*d*"},
-			{"*a", "b*", "*c*d*"}, {"*a", "b*/*c*", "*d*"}, {"*a", "b*/*", "*c*d*"}, {"*a", "b*/*c*d*", "*"}}},
+			{"*a", "b*", "*c*d*"}, {"*a", "b*/*c*", "*d*"}, {"*a", "b*/*", "*c*d*"}, {"*a", "b*/*c*d*", "*"}}, false},
 	{"*aa/b*/*c*d*", true,
 		[]RepoPathFile{{"*", "*aa/b*/*c*d*", "*"}, {"*", "*aa/b*/*c*", "*d*"}, {"*", "*aa/b*/*", "*c*d*"}, {"*", "*aa/b*", "*c*d*"},
-			{"*aa", "b*", "*c*d*"}, {"*aa", "b*/*c*", "*d*"}, {"*aa", "b*/*", "*c*d*"}, {"*aa", "b*/*c*d*", "*"}}},
+			{"*aa", "b*", "*c*d*"}, {"*aa", "b*/*c*", "*d*"}, {"*aa", "b*/*", "*c*d*"}, {"*aa", "b*/*c*d*", "*"}}, false},
 	{"*/a*/*b*a*", true,
-		[]RepoPathFile{{"*", "*a*/*b*a*", "*"}, {"*", "*a*", "*b*a*"}, {"*", "*a*/*b*", "*a*"}, {"*", "*a*/*", "*b*a*"}}},
+		[]RepoPathFile{{"*", "*a*/*b*a*", "*"}, {"*", "*a*", "*b*a*"}, {"*", "*a*/*b*", "*a*"}, {"*", "*a*/*", "*b*a*"}}, false},
 	{"*", true,
-		[]RepoPathFile{{"*", "*", "*"}}},
+		[]RepoPathFile{{"*", "*", "*"}}, false},
 	{"*/*", true,
-		[]RepoPathFile{{"*", "*", "*"}}},
+		[]RepoPathFile{{"*", "*", "*"}}, false},
 	{"*/a.z", true,
-		[]RepoPathFile{{"*", "*", "a.z"}}},
+		[]RepoPathFile{{"*", "*", "a.z"}}, false},
 	{"a/b", true,
-		[]RepoPathFile{{"a", ".", "b"}}},
+		[]RepoPathFile{{"a", ".", "b"}}, true},
 	{"a/b", false,
-		[]RepoPathFile{{"a", ".", "b"}}},
+		[]RepoPathFile{{"a", ".", "b"}}, true},
 	{"a//*", false,
-		[]RepoPathFile{{"a", "", "*"}}},
+		[]RepoPathFile{{"a", "", "*"}}, true},
 	{"r//a*b", false,
-		[]RepoPathFile{{"r", "", "a*b"}}},
+		[]RepoPathFile{{"r", "", "a*b"}}, true},
 	{"a*b", true,
-		[]RepoPathFile{{"a*", "*", "*b"}, {"a*b", "*", "*"}}},
+		[]RepoPathFile{{"a*", "*", "*b"}, {"a*b", "*", "*"}}, false},
 	{"a*b*", true,
-		[]RepoPathFile{{"a*", "*b*", "*"}, {"a*", "*", "*b*"}, {"a*b*", "*", "*"}}},
+		[]RepoPathFile{{"a*", "*b*", "*"}, {"a*", "*", "*b*"}, {"a*b*", "*", "*"}}, false},
 }
 
 func TestCreatePathFilePairs(t *testing.T) {
 	for _, sample := range pathFilesDataProvider {
 		t.Run(sample.pattern+"_recursive_"+strconv.FormatBool(sample.recursive), func(t *testing.T) {
-			validateRepoPathFile(createPathFilePairs("r", sample.pattern, sample.recursive), sample.expected, sample.pattern, t)
+			validateRepoPathFile(createPathFilePairs("r", sample.pattern, sample.recursive), sample.expectedTriples, sample.pattern, t)
 		})
 	}
 }
@@ -91,9 +98,10 @@ func TestCreatePathFilePairs(t *testing.T) {
 func TestCreateRepoPathFileTriples(t *testing.T) {
 	for _, sample := range repoPathFilesDataProvider {
 		t.Run(sample.pattern+"_recursive_"+strconv.FormatBool(sample.recursive), func(t *testing.T) {
-			repoPathFileTriples, err := createRepoPathFileTriples(sample.pattern, sample.recursive)
+			repoPathFileTriples, singleRepo, err := createRepoPathFileTriples(sample.pattern, sample.recursive)
 			assert.NoError(t, err)
-			validateRepoPathFile(repoPathFileTriples, sample.expected, sample.pattern, t)
+			assert.Equal(t, sample.expectedSingleRepo, singleRepo)
+			validateRepoPathFile(repoPathFileTriples, sample.expectedTriples, sample.pattern, t)
 		})
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixed some issues regarding limitations in transitive search: repository name cannot contain wildcards; limit() comes after transitive() in the complete AQL query.