### PR TITLE
V1 - Remove 'build-info published' log message

### DIFF
--- a/artifactory/services/buildinfo.go
+++ b/artifactory/services/buildinfo.go
@@ -3,9 +3,6 @@ package services
 import (
 	"encoding/json"
 	"errors"
-	"net/http"
-	"net/url"
-
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
@@ -13,6 +10,7 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/http"
 )
 
 type BuildInfoService struct {
@@ -79,6 +77,5 @@ func (bis *BuildInfoService) PublishBuildInfo(build *buildinfo.BuildInfo, projec
 	summary.SetSha256(resp.Header.Get("X-Checksum-Sha256"))
 
 	log.Debug("Artifactory response:", resp.Status)
-	log.Info("Build info successfully deployed. Browse it in Artifactory under " + bis.GetArtifactoryDetails().GetUrl() + "webapp/builds/" + url.QueryEscape(build.Name) + "/" + url.QueryEscape(build.Number))
 	return summary, nil
 }

--- a/auth/cert/sslutils_default.go
+++ b/auth/cert/sslutils_default.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cert

--- a/auth/cert/sslutils_windows.go
+++ b/auth/cert/sslutils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cert


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This is part of a fix for V1, which has already been implemented for V2 a few months ago.
This PR removes the "Build info successfully published" log message. It is a duplicate of https://github.com/jfrog/jfrog-client-go/pull/419 which has been merged to v2 a few months ago. This was done, in order to support a fix for an issue, whereby the build-info link displayed in the log, was incorrect, when the build is published as part of a project. 
As part of the fix, the fixed link is built and displayed by jfrog-cli-core, and is therefore removed from jfrog-client-go in this PR.
A PR for jfrog-cli-core will be soon created.