### PR TITLE
Run pipelines tests on one os only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,8 @@ jobs:
       run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.suite }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ runner.os }}-${{ matrix.suite }}
   JFrog-Client-Go-Pipelines-Tests:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
-    name: pipelines ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    name: pipelines ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
Pipelines tests are remote only and does not the involve the filesystem, hence running them on more than one os is redundant.