### PR TITLE
Build promotion failFast error logs

### DIFF
--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -92,8 +92,7 @@ type BuildPromotionBody struct {
 	Status              string `json:"status,omitempty"`
 	IncludeDependencies *bool  `json:"dependencies,omitempty"`
 	Copy                *bool  `json:"copy,omitempty"`
-	// FailFast options default is true. We need to avoid omitempty, otherwise, it would be forced to false if omitted.
-	// Notice that when running 'JFrog CLI V1' FailFast's default is false.
+	// Notice that FailFast is boolean and therfore if not assigned, FailFast is false.
 	FailFast   bool                `json:"failFast"`
 	DryRun     *bool               `json:"dryRun,omitempty"`
 	Properties map[string][]string `json:"properties,omitempty"`

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -77,10 +77,10 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
 		return errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
 	}
+	log.Debug("Artifactory response:", resp.Status)
 	if !data.FailFast {
 		log.Info(string(body))
 	}
-	log.Debug("Artifactory response:", resp.Status)
 	log.Info("Promoted build", promotionParams.GetBuildName()+"/"+promotionParams.GetBuildNumber(), "to:", promotionParams.GetTargetRepo(), "repository.")
 	return nil
 }

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -77,7 +77,9 @@ func (ps *PromoteService) BuildPromote(promotionParams PromotionParams) error {
 	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
 		return errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
 	}
-
+	if !data.FailFast {
+		log.Info(string(body))
+	}
 	log.Debug("Artifactory response:", resp.Status)
 	log.Info("Promoted build", promotionParams.GetBuildName()+"/"+promotionParams.GetBuildNumber(), "to:", promotionParams.GetTargetRepo(), "repository.")
 	return nil

--- a/artifactory/services/promote.go
+++ b/artifactory/services/promote.go
@@ -93,6 +93,7 @@ type BuildPromotionBody struct {
 	IncludeDependencies *bool  `json:"dependencies,omitempty"`
 	Copy                *bool  `json:"copy,omitempty"`
 	// FailFast options default is true. We need to avoid omitempty, otherwise, it would be forced to false if omitted.
+	// Notice that when running 'JFrog CLI V1' FailFast's default is false.
 	FailFast   bool                `json:"failFast"`
 	DryRun     *bool               `json:"dryRun,omitempty"`
 	Properties map[string][]string `json:"properties,omitempty"`


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
When running build promotion with failFast=false the command runs despite any errors that happen during the promotion.
Added a log to print the errors.