### PR TITLE
Fixes #523 Add capability to specify proxy for repository replications

### DIFF
--- a/artifactory/services/createreplication.go
+++ b/artifactory/services/createreplication.go
@@ -25,7 +25,7 @@ func (rs *CreateReplicationService) GetJfrogHttpClient() *jfroghttpclient.JfrogH
 	return rs.client
 }
 
-func (rs *CreateReplicationService) performRequest(params *utils.ReplicationBody) error {
+func (rs *CreateReplicationService) performRequest(params *utils.UpdateReplicationBody) error {
 	content, err := json.Marshal(params)
 	if err != nil {
 		return errorutils.CheckError(err)
@@ -50,7 +50,7 @@ func (rs *CreateReplicationService) performRequest(params *utils.ReplicationBody
 }
 
 func (rs *CreateReplicationService) CreateReplication(params CreateReplicationParams) error {
-	return rs.performRequest(utils.CreateReplicationBody(params.ReplicationParams))
+	return rs.performRequest(utils.CreateUpdateReplicationBody(params.ReplicationParams))
 }
 
 func NewCreateReplicationParams() CreateReplicationParams {

--- a/artifactory/services/getreplication.go
+++ b/artifactory/services/getreplication.go
@@ -30,10 +30,16 @@ func (drs *GetReplicationService) GetReplication(repoKey string) ([]utils.Replic
 	if err != nil {
 		return nil, err
 	}
-	var replicationConf []utils.ReplicationParams
-	if err := json.Unmarshal(body, &replicationConf); err != nil {
+	var replicationBody []utils.GetReplicationBody
+	if err := json.Unmarshal(body, &replicationBody); err != nil {
 		return nil, errorutils.CheckError(err)
 	}
+
+	var replicationConf = make([]utils.ReplicationParams, len(replicationBody))
+	for i, body := range replicationBody {
+		replicationConf[i] = *utils.CreateReplicationParams(body)
+	}
+
 	return replicationConf, nil
 }
 

--- a/artifactory/services/updatereplication.go
+++ b/artifactory/services/updatereplication.go
@@ -25,7 +25,7 @@ func (rs *UpdateReplicationService) GetJfrogHttpClient() *jfroghttpclient.JfrogH
 	return rs.client
 }
 
-func (rs *UpdateReplicationService) performRequest(params *utils.ReplicationBody) error {
+func (rs *UpdateReplicationService) performRequest(params *utils.UpdateReplicationBody) error {
 	content, err := json.Marshal(params)
 	if err != nil {
 		return errorutils.CheckError(err)
@@ -50,7 +50,7 @@ func (rs *UpdateReplicationService) performRequest(params *utils.ReplicationBody
 }
 
 func (rs *UpdateReplicationService) UpdateReplication(params UpdateReplicationParams) error {
-	return rs.performRequest(utils.CreateReplicationBody(params.ReplicationParams))
+	return rs.performRequest(utils.CreateUpdateReplicationBody(params.ReplicationParams))
 }
 
 func NewUpdateReplicationParams() UpdateReplicationParams {

--- a/artifactory/services/utils/replication.go
+++ b/artifactory/services/utils/replication.go
@@ -1,14 +1,11 @@
 package utils
 
-import "encoding/json"
-
-type ReplicationBody struct {
+type replicationBody struct {
 	Username               string `json:"username"`
 	Password               string `json:"password"`
 	URL                    string `json:"url"`
 	CronExp                string `json:"cronExp"`
 	RepoKey                string `json:"repoKey"`
-	Proxy                  string `json:"proxy"`
 	EnableEventReplication bool   `json:"enableEventReplication"`
 	SocketTimeoutMillis    int    `json:"socketTimeoutMillis"`
 	Enabled                bool   `json:"enabled"`
@@ -16,6 +13,16 @@ type ReplicationBody struct {
 	SyncProperties         bool   `json:"syncProperties"`
 	SyncStatistics         bool   `json:"syncStatistics"`
 	PathPrefix             string `json:"pathPrefix"`
+}
+
+type GetReplicationBody struct {
+	replicationBody
+	ProxyRef string `json:"proxyRef"`
+}
+
+type UpdateReplicationBody struct {
+	replicationBody
+	Proxy string `json:"proxy"`
 }
 
 type ReplicationParams struct {
@@ -36,41 +43,40 @@ type ReplicationParams struct {
 	IncludePathPrefixPattern string
 }
 
-// UnmarshalJSON overrides the default JSON unmarshal function because the POST request to create a replication
-// has a field named `proxy` but the GET request returns a JSON with a field named `proxyRef`
-func (rp *ReplicationParams) UnmarshalJSON(data []byte) error {
-	type Alias ReplicationParams
-
-	aux := &struct {
-		ProxyRef string `json:"proxyRef"`
-		*Alias
-	}{
-		Alias: (*Alias)(rp),
+func CreateUpdateReplicationBody(params ReplicationParams) *UpdateReplicationBody {
+	return &UpdateReplicationBody{
+		replicationBody: replicationBody{
+			Username:               params.Username,
+			Password:               params.Password,
+			URL:                    params.Url,
+			CronExp:                params.CronExp,
+			RepoKey:                params.RepoKey,
+			EnableEventReplication: params.EnableEventReplication,
+			SocketTimeoutMillis:    params.SocketTimeoutMillis,
+			Enabled:                params.Enabled,
+			SyncDeletes:            params.SyncDeletes,
+			SyncProperties:         params.SyncProperties,
+			SyncStatistics:         params.SyncStatistics,
+			PathPrefix:             params.PathPrefix,
+		},
+		Proxy: params.Proxy,
 	}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-
-	rp.Proxy = aux.ProxyRef
-
-	return nil
 }
 
-func CreateReplicationBody(params ReplicationParams) *ReplicationBody {
-	return &ReplicationBody{
-		Username:               params.Username,
-		Password:               params.Password,
-		URL:                    params.Url,
-		CronExp:                params.CronExp,
-		RepoKey:                params.RepoKey,
-		Proxy:                  params.Proxy,
-		EnableEventReplication: params.EnableEventReplication,
-		SocketTimeoutMillis:    params.SocketTimeoutMillis,
-		Enabled:                params.Enabled,
-		SyncDeletes:            params.SyncDeletes,
-		SyncProperties:         params.SyncProperties,
-		SyncStatistics:         params.SyncStatistics,
-		PathPrefix:             params.PathPrefix,
+func CreateReplicationParams(body GetReplicationBody) *ReplicationParams {
+	return &ReplicationParams{
+		Username:               body.Username,
+		Password:               body.Password,
+		Url:                    body.URL,
+		CronExp:                body.CronExp,
+		RepoKey:                body.RepoKey,
+		Proxy:                  body.ProxyRef,
+		EnableEventReplication: body.EnableEventReplication,
+		SocketTimeoutMillis:    body.SocketTimeoutMillis,
+		Enabled:                body.Enabled,
+		SyncDeletes:            body.SyncDeletes,
+		SyncProperties:         body.SyncProperties,
+		SyncStatistics:         body.SyncStatistics,
+		PathPrefix:             body.PathPrefix,
 	}
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----

I have a use case where I am trying to configure Artifactory replications through Terraform and need to be able to set a proxy for the replication.  Couple things to note about the current changes:
1. The GET JSON response for getting a replication has changed between Artifactory 6.x and 7.x such that this change would only work for 7.x.  See https://github.com/atlassian/go-artifactory/pull/33, an old PR,  for the change for Artifactory 6.x.
2. I wanted to added a test for this, but unfortunately was not able to figure out how to dynamically create a proxy via a REST API (couldn't find anything on https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API).  If you can help point me in the right direction wrt this, I would love to add a test for configuring proxy.  I have tested the changes using a GUI/manually created proxy.