### PR TITLE
Change log level for missing LATEST build in Artifactory

### DIFF
--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -245,7 +245,7 @@ func getLatestBuildNumberFromArtifactory(buildName, buildNumber, projectKey stri
 			return buildName, buildNumber, nil
 		}
 	}
-	log.Info(fmt.Sprintf("A build-name: <%s> with a build-number: <%s> could not be found in Artifactory.", buildName, buildNumber))
+	log.Debug(fmt.Sprintf("A build-name: <%s> with a build-number: <%s> could not be found in Artifactory.", buildName, buildNumber))
 	return "", "", nil
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The log level is incorrect as it shows the following messages for the first time while using `jf project init`:

![image](https://user-images.githubusercontent.com/9606235/155278026-bf4f5144-3dc7-42f4-9005-88d5189d4c58.png)
