### PR TITLE
Support IncludePathPrefixPattern param in replication

### DIFF
--- a/artifactory/services/utils/replication.go
+++ b/artifactory/services/utils/replication.go
@@ -12,7 +12,9 @@ type replicationBody struct {
 	SyncDeletes            bool   `json:"syncDeletes"`
 	SyncProperties         bool   `json:"syncProperties"`
 	SyncStatistics         bool   `json:"syncStatistics"`
-	PathPrefix             string `json:"pathPrefix"`
+	// Deprecated
+	PathPrefix               string `json:"pathPrefix"`
+	IncludePathPrefixPattern string `json:"includePathPrefixPattern"`
 }
 
 type GetReplicationBody struct {
@@ -31,14 +33,15 @@ type ReplicationParams struct {
 	Url      string
 	CronExp  string
 	// Source replication repository.
-	RepoKey                  string
-	Proxy                    string
-	EnableEventReplication   bool
-	SocketTimeoutMillis      int
-	Enabled                  bool
-	SyncDeletes              bool
-	SyncProperties           bool
-	SyncStatistics           bool
+	RepoKey                string
+	Proxy                  string
+	EnableEventReplication bool
+	SocketTimeoutMillis    int
+	Enabled                bool
+	SyncDeletes            bool
+	SyncProperties         bool
+	SyncStatistics         bool
+	// Deprecated
 	PathPrefix               string
 	IncludePathPrefixPattern string
 }
@@ -46,18 +49,19 @@ type ReplicationParams struct {
 func CreateUpdateReplicationBody(params ReplicationParams) *UpdateReplicationBody {
 	return &UpdateReplicationBody{
 		replicationBody: replicationBody{
-			Username:               params.Username,
-			Password:               params.Password,
-			URL:                    params.Url,
-			CronExp:                params.CronExp,
-			RepoKey:                params.RepoKey,
-			EnableEventReplication: params.EnableEventReplication,
-			SocketTimeoutMillis:    params.SocketTimeoutMillis,
-			Enabled:                params.Enabled,
-			SyncDeletes:            params.SyncDeletes,
-			SyncProperties:         params.SyncProperties,
-			SyncStatistics:         params.SyncStatistics,
-			PathPrefix:             params.PathPrefix,
+			Username:                 params.Username,
+			Password:                 params.Password,
+			URL:                      params.Url,
+			CronExp:                  params.CronExp,
+			RepoKey:                  params.RepoKey,
+			EnableEventReplication:   params.EnableEventReplication,
+			SocketTimeoutMillis:      params.SocketTimeoutMillis,
+			Enabled:                  params.Enabled,
+			SyncDeletes:              params.SyncDeletes,
+			SyncProperties:           params.SyncProperties,
+			SyncStatistics:           params.SyncStatistics,
+			PathPrefix:               params.PathPrefix,
+			IncludePathPrefixPattern: params.IncludePathPrefixPattern,
 		},
 		Proxy: params.Proxy,
 	}
@@ -65,18 +69,19 @@ func CreateUpdateReplicationBody(params ReplicationParams) *UpdateReplicationBod
 
 func CreateReplicationParams(body GetReplicationBody) *ReplicationParams {
 	return &ReplicationParams{
-		Username:               body.Username,
-		Password:               body.Password,
-		Url:                    body.URL,
-		CronExp:                body.CronExp,
-		RepoKey:                body.RepoKey,
-		Proxy:                  body.ProxyRef,
-		EnableEventReplication: body.EnableEventReplication,
-		SocketTimeoutMillis:    body.SocketTimeoutMillis,
-		Enabled:                body.Enabled,
-		SyncDeletes:            body.SyncDeletes,
-		SyncProperties:         body.SyncProperties,
-		SyncStatistics:         body.SyncStatistics,
-		PathPrefix:             body.PathPrefix,
+		Username:                 body.Username,
+		Password:                 body.Password,
+		Url:                      body.URL,
+		CronExp:                  body.CronExp,
+		RepoKey:                  body.RepoKey,
+		Proxy:                    body.ProxyRef,
+		EnableEventReplication:   body.EnableEventReplication,
+		SocketTimeoutMillis:      body.SocketTimeoutMillis,
+		Enabled:                  body.Enabled,
+		SyncDeletes:              body.SyncDeletes,
+		SyncProperties:           body.SyncProperties,
+		SyncStatistics:           body.SyncStatistics,
+		PathPrefix:               body.PathPrefix,
+		IncludePathPrefixPattern: body.IncludePathPrefixPattern,
 	}
 }

--- a/tests/artifactoryreplication_test.go
+++ b/tests/artifactoryreplication_test.go
@@ -14,7 +14,7 @@ func TestReplication(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = getPushReplication(t, GetReplicationConfig())
+	err = getAndAssertReplication(t, GetReplicationConfig())
 	if err != nil {
 		t.Error(err)
 	}
@@ -22,7 +22,7 @@ func TestReplication(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = getPushReplication(t, nil)
+	err = getAndAssertReplication(t, nil)
 	assert.Error(t, err)
 }
 
@@ -36,10 +36,11 @@ func createReplication() error {
 	params.RepoKey = getRtTargetRepoKey()
 	params.Enabled = true
 	params.SocketTimeoutMillis = 100
+	params.IncludePathPrefixPattern = "/include/path"
 	return testsCreateReplicationService.CreateReplication(params)
 }
 
-func getPushReplication(t *testing.T, expected []utils.ReplicationParams) error {
+func getAndAssertReplication(t *testing.T, expected []utils.ReplicationParams) error {
 	replicationConf, err := testsReplicationGetService.GetReplication(getRtTargetRepoKey())
 	if err != nil {
 		return err
@@ -68,18 +69,18 @@ func deleteReplication(t *testing.T) error {
 func GetReplicationConfig() []utils.ReplicationParams {
 	return []utils.ReplicationParams{
 		{
-			Url:                    "http://www.jfrog.com",
-			Username:               "anonymous",
-			Password:               "password",
-			CronExp:                "0 0 14 * * ?",
-			RepoKey:                getRtTargetRepoKey(),
-			EnableEventReplication: false,
-			SocketTimeoutMillis:    100,
-			Enabled:                true,
-			SyncDeletes:            false,
-			SyncProperties:         false,
-			SyncStatistics:         false,
-			PathPrefix:             "",
+			Url:                      "http://www.jfrog.com",
+			Username:                 "anonymous",
+			Password:                 "password",
+			CronExp:                  "0 0 14 * * ?",
+			RepoKey:                  getRtTargetRepoKey(),
+			EnableEventReplication:   false,
+			SocketTimeoutMillis:      100,
+			Enabled:                  true,
+			SyncDeletes:              false,
+			SyncProperties:           false,
+			SyncStatistics:           false,
+			IncludePathPrefixPattern: "/include/path",
 		},
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Allow using the IncludePathPrefixPattern parameter in replication.