### PR TITLE
Add Operational Risk fields to Xray Scan Violation schema

### DIFF
--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -211,6 +211,14 @@ type Violation struct {
 	LicenseKey    string               `json:"license_key,omitempty"`
 	LicenseName   string               `json:"license_name,omitempty"`
 	IgnoreUrl     string               `json:"ignore_url,omitempty"`
+	RiskReason    string               `json:"risk_reason,omitempty"`
+	IsEol         *bool                `json:"is_eol,omitempty"`
+	EolMessage    string               `json:"eol_message,omitempty"`
+	LatestVersion string               `json:"latest_version,omitempty"`
+	NewerVersions *int                 `json:"newer_versions,omitempty"`
+	Cadence       *float64             `json:"cadence,omitempty"`
+	Commits       *int64               `json:"commits,omitempty"`
+	Committers    *int                 `json:"committers,omitempty"`
 }
 
 type Vulnerability struct {


### PR DESCRIPTION
Extend the existing violation schema to allow populating operational risk data.

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----