### PR TITLE
Add "invite" and "createToken" access commands.

### DIFF
--- a/access/manager.go
+++ b/access/manager.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"github.com/jfrog/jfrog-client-go/access/services"
+	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/config"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 )
@@ -85,4 +86,16 @@ func (sm *AccessServicesManager) DeleteExistingProjectGroup(projectKey string, g
 	projectService := services.NewProjectService(sm.client)
 	projectService.ServiceDetails = sm.config.GetServiceDetails()
 	return projectService.DeleteExistingGroup(projectKey, groupName)
+}
+
+func (sm *AccessServicesManager) CreateAccessToken(params services.TokenParams) (auth.CreateTokenResponseData, error) {
+	tokenService := services.NewTokenService(sm.client)
+	tokenService.ServiceDetails = sm.config.GetServiceDetails()
+	return tokenService.CreateAccessToken(params)
+}
+
+func (sm *AccessServicesManager) InviteUser(email string) error {
+	inviteService := services.NewInviteService(sm.client)
+	inviteService.ServiceDetails = sm.config.GetServiceDetails()
+	return inviteService.InviteUser(email)
 }

--- a/access/services/accesstoken.go
+++ b/access/services/accesstoken.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"net/http"
+)
+
+const tokensApi = "api/v1/tokens"
+
+type TokenService struct {
+	client         *jfroghttpclient.JfrogHttpClient
+	ServiceDetails auth.ServiceDetails
+}
+
+type TokenParams struct {
+	auth.CreateTokenData
+}
+
+func NewTokenService(client *jfroghttpclient.JfrogHttpClient) *TokenService {
+	return &TokenService{client: client}
+}
+
+func (ps *TokenService) CreateAccessToken(params TokenParams) (auth.CreateTokenResponseData, error) {
+	// Set request's headers
+	httpDetails := ps.ServiceDetails.CreateHttpClientDetails()
+	utils.SetContentType("application/json", &httpDetails.Headers)
+	utils.AddHeader("Authorization", fmt.Sprintf("Bearer %s", ps.ServiceDetails.GetAccessToken()), &httpDetails.Headers)
+	tokenInfo := auth.CreateTokenResponseData{}
+	requestContent, err := json.Marshal(params)
+	if errorutils.CheckError(err) != nil {
+		return tokenInfo, err
+	}
+
+	url := fmt.Sprintf("%s%s", ps.ServiceDetails.GetUrl(), tokensApi)
+	resp, body, err := ps.client.SendPost(url, requestContent, &httpDetails)
+
+	if err != nil {
+		return tokenInfo, err
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		return tokenInfo, errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
+	}
+	err = json.Unmarshal(body, &tokenInfo)
+	return tokenInfo, errorutils.CheckError(err)
+}

--- a/access/services/accesstoken.go
+++ b/access/services/accesstoken.go
@@ -31,15 +31,14 @@ func (ps *TokenService) CreateAccessToken(params TokenParams) (auth.CreateTokenR
 	httpDetails := ps.ServiceDetails.CreateHttpClientDetails()
 	utils.SetContentType("application/json", &httpDetails.Headers)
 	utils.AddHeader("Authorization", fmt.Sprintf("Bearer %s", ps.ServiceDetails.GetAccessToken()), &httpDetails.Headers)
+
 	tokenInfo := auth.CreateTokenResponseData{}
 	requestContent, err := json.Marshal(params)
 	if errorutils.CheckError(err) != nil {
 		return tokenInfo, err
 	}
-
 	url := fmt.Sprintf("%s%s", ps.ServiceDetails.GetUrl(), tokensApi)
 	resp, body, err := ps.client.SendPost(url, requestContent, &httpDetails)
-
 	if err != nil {
 		return tokenInfo, err
 	}

--- a/access/services/invite.go
+++ b/access/services/invite.go
@@ -11,7 +11,10 @@ import (
 	"net/http"
 )
 
-const inviteApi = "api/v1/users/invite"
+const (
+	inviteApi           = "api/v1/users/invite"
+	InviteCliSourceName = "cli"
+)
 
 type InviteService struct {
 	client         *jfroghttpclient.JfrogHttpClient
@@ -32,7 +35,7 @@ func (us *InviteService) InviteUser(email string) error {
 	url := fmt.Sprintf("%s%s", us.ServiceDetails.GetUrl(), inviteApi)
 	data := InvitedUser{
 		InvitedEmail: email,
-		Source:       "cli",
+		Source:       InviteCliSourceName,
 	}
 	requestContent, err := json.Marshal(data)
 	if err != nil {

--- a/access/services/invite.go
+++ b/access/services/invite.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"net/http"
+)
+
+const inviteApi = "api/v1/users/invite"
+
+type InviteService struct {
+	client         *jfroghttpclient.JfrogHttpClient
+	ServiceDetails auth.ServiceDetails
+}
+
+type InvitedUser struct {
+	InvitedEmail string `json:"invitedEmail,omitempty" csv:"invitedEmail,omitempty"`
+	Source       string `json:"source,omitempty" csv:"source,omitempty"`
+}
+
+func NewInviteService(client *jfroghttpclient.JfrogHttpClient) *InviteService {
+	return &InviteService{client: client}
+}
+
+func (us *InviteService) InviteUser(email string) error {
+	httpDetails := us.ServiceDetails.CreateHttpClientDetails()
+	url := fmt.Sprintf("%s%s", us.ServiceDetails.GetUrl(), inviteApi)
+	data := InvitedUser{
+		InvitedEmail: email,
+		Source:       "cli",
+	}
+	requestContent, err := json.Marshal(data)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	utils.SetContentType("application/json", &httpDetails.Headers)
+	resp, body, err := us.client.SendPost(url, requestContent, &httpDetails)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return errorutils.CheckErrorf("no response provided (including status code)")
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		return errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
+	}
+	return err
+}

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -1,6 +1,7 @@
 package artifactory
 
 import (
+	"github.com/jfrog/jfrog-client-go/auth"
 	"io"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
@@ -62,10 +63,10 @@ type ArtifactoryServicesManager interface {
 	CreateAPIKey() (string, error)
 	RegenerateAPIKey() (string, error)
 	GetAPIKey() (string, error)
-	CreateToken(params services.CreateTokenParams) (services.CreateTokenResponseData, error)
+	CreateToken(params services.CreateTokenParams) (auth.CreateTokenResponseData, error)
 	GetTokens() (services.GetTokensResponseData, error)
 	GetUserTokens(username string) ([]string, error)
-	RefreshToken(params services.RefreshTokenParams) (services.CreateTokenResponseData, error)
+	RefreshToken(params services.RefreshTokenParams) (auth.CreateTokenResponseData, error)
 	RevokeToken(params services.RevokeTokenParams) (string, error)
 	CreateReplication(params services.CreateReplicationParams) error
 	UpdateReplication(params services.UpdateReplicationParams) error
@@ -84,7 +85,6 @@ type ArtifactoryServicesManager interface {
 	CreateUser(params services.UserParams) error
 	UpdateUser(params services.UserParams) error
 	DeleteUser(name string) error
-	InviteUser(email string) error
 	ConvertLocalToFederatedRepository(repoKey string) error
 	TriggerFederatedRepositoryFullSyncAll(repoKey string) error
 	TriggerFederatedRepositoryFullSyncMirror(repoKey string, mirrorUrl string) error
@@ -276,7 +276,7 @@ func (esm *EmptyArtifactoryServicesManager) GetAPIKey() (string, error) {
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) CreateToken(params services.CreateTokenParams) (services.CreateTokenResponseData, error) {
+func (esm *EmptyArtifactoryServicesManager) CreateToken(params services.CreateTokenParams) (auth.CreateTokenResponseData, error) {
 	panic("Failed: Method is not implemented")
 }
 
@@ -288,7 +288,7 @@ func (esm *EmptyArtifactoryServicesManager) GetUserTokens(username string) ([]st
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) RefreshToken(params services.RefreshTokenParams) (services.CreateTokenResponseData, error) {
+func (esm *EmptyArtifactoryServicesManager) RefreshToken(params services.RefreshTokenParams) (auth.CreateTokenResponseData, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -84,6 +84,7 @@ type ArtifactoryServicesManager interface {
 	CreateUser(params services.UserParams) error
 	UpdateUser(params services.UserParams) error
 	DeleteUser(name string) error
+	InviteUser(email string) error
 	ConvertLocalToFederatedRepository(repoKey string) error
 	TriggerFederatedRepositoryFullSyncAll(repoKey string) error
 	TriggerFederatedRepositoryFullSyncMirror(repoKey string, mirrorUrl string) error
@@ -352,6 +353,10 @@ func (esm *EmptyArtifactoryServicesManager) UpdateUser(params services.UserParam
 }
 
 func (esm *EmptyArtifactoryServicesManager) DeleteUser(name string) error {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) InviteUser(email string) error {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -356,10 +356,6 @@ func (esm *EmptyArtifactoryServicesManager) DeleteUser(name string) error {
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) InviteUser(email string) error {
-	panic("Failed: Method is not implemented")
-}
-
 func (esm *EmptyArtifactoryServicesManager) GetGroup(params services.GroupParams) (*services.Group, error) {
 	panic("Failed: Method is not implemented")
 }

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -1,6 +1,7 @@
 package artifactory
 
 import (
+	"github.com/jfrog/jfrog-client-go/auth"
 	"io"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
@@ -369,7 +370,7 @@ func (sm *ArtifactoryServicesManagerImp) GetAPIKey() (string, error) {
 	return securityService.GetAPIKey()
 }
 
-func (sm *ArtifactoryServicesManagerImp) CreateToken(params services.CreateTokenParams) (services.CreateTokenResponseData, error) {
+func (sm *ArtifactoryServicesManagerImp) CreateToken(params services.CreateTokenParams) (auth.CreateTokenResponseData, error) {
 	securityService := services.NewSecurityService(sm.client)
 	securityService.ArtDetails = sm.config.GetServiceDetails()
 	return securityService.CreateToken(params)
@@ -387,7 +388,7 @@ func (sm *ArtifactoryServicesManagerImp) GetUserTokens(username string) ([]strin
 	return securityService.GetUserTokens(username)
 }
 
-func (sm *ArtifactoryServicesManagerImp) RefreshToken(params services.RefreshTokenParams) (services.CreateTokenResponseData, error) {
+func (sm *ArtifactoryServicesManagerImp) RefreshToken(params services.RefreshTokenParams) (auth.CreateTokenResponseData, error) {
 	securityService := services.NewSecurityService(sm.client)
 	securityService.ArtDetails = sm.config.GetServiceDetails()
 	return securityService.RefreshToken(params)
@@ -503,12 +504,6 @@ func (sm *ArtifactoryServicesManagerImp) DeleteUser(name string) error {
 	userService := services.NewUserService(sm.client)
 	userService.ArtDetails = sm.config.GetServiceDetails()
 	return userService.DeleteUser(name)
-}
-
-func (sm *ArtifactoryServicesManagerImp) InviteUser(email string) error {
-	userService := services.NewUserService(sm.client)
-	userService.ArtDetails = sm.config.GetServiceDetails()
-	return userService.InviteUser(email)
 }
 
 func (sm *ArtifactoryServicesManagerImp) PromoteDocker(params services.DockerPromoteParams) error {

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -505,6 +505,12 @@ func (sm *ArtifactoryServicesManagerImp) DeleteUser(name string) error {
 	return userService.DeleteUser(name)
 }
 
+func (sm *ArtifactoryServicesManagerImp) InviteUser(email string) error {
+	userService := services.NewUserService(sm.client)
+	userService.ArtDetails = sm.config.GetServiceDetails()
+	return userService.InviteUser(email)
+}
+
 func (sm *ArtifactoryServicesManagerImp) PromoteDocker(params services.DockerPromoteParams) error {
 	systemService := services.NewDockerPromoteService(sm.config.GetServiceDetails(), sm.client)
 	return systemService.PromoteDocker(params)

--- a/artifactory/services/security.go
+++ b/artifactory/services/security.go
@@ -105,12 +105,12 @@ func getApiKeyFromBody(body []byte) (string, error) {
 	return apiKey, nil
 }
 
-func (ss *SecurityService) CreateToken(params CreateTokenParams) (CreateTokenResponseData, error) {
+func (ss *SecurityService) CreateToken(params CreateTokenParams) (auth.CreateTokenResponseData, error) {
 	artifactoryUrl := ss.ArtDetails.GetUrl()
 	data := buildCreateTokenUrlValues(params)
 	httpClientsDetails := ss.getArtifactoryDetails().CreateHttpClientDetails()
 	resp, body, err := ss.client.SendPostForm(artifactoryUrl+tokenPath, data, &httpClientsDetails)
-	tokenInfo := CreateTokenResponseData{}
+	tokenInfo := auth.CreateTokenResponseData{}
 	if err != nil {
 		return tokenInfo, err
 	}
@@ -154,12 +154,12 @@ func (ss *SecurityService) GetUserTokens(username string) ([]string, error) {
 	return tokens, nil
 }
 
-func (ss *SecurityService) RefreshToken(params RefreshTokenParams) (CreateTokenResponseData, error) {
+func (ss *SecurityService) RefreshToken(params RefreshTokenParams) (auth.CreateTokenResponseData, error) {
 	artifactoryUrl := ss.ArtDetails.GetUrl()
 	data := buildRefreshTokenUrlValues(params)
 	httpClientsDetails := ss.getArtifactoryDetails().CreateHttpClientDetails()
 	resp, body, err := ss.client.SendPostForm(artifactoryUrl+tokenPath, data, &httpClientsDetails)
-	tokenInfo := CreateTokenResponseData{}
+	tokenInfo := auth.CreateTokenResponseData{}
 	if err != nil {
 		return tokenInfo, err
 	}
@@ -233,14 +233,6 @@ func buildRevokeTokenUrlValues(params RevokeTokenParams) url.Values {
 		data.Set("token_id", params.TokenId)
 	}
 	return data
-}
-
-type CreateTokenResponseData struct {
-	Scope        string `json:"scope,omitempty"`
-	AccessToken  string `json:"access_token,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
-	TokenType    string `json:"token_type,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 type GetTokensResponseData struct {

--- a/artifactory/services/users.go
+++ b/artifactory/services/users.go
@@ -3,15 +3,14 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
-	"net/http"
 )
-
-const InviteCliSourceName = "cli"
 
 type UserParams struct {
 	UserDetails     User
@@ -100,7 +99,6 @@ func (us *UserService) CreateUser(params UserParams) error {
 			return errorutils.CheckErrorf("user '%s' already exists", user.Name)
 		}
 	}
-
 	url, content, httpDetails, err := us.createOrUpdateUserRequest(params.UserDetails)
 	if err != nil {
 		return err

--- a/artifactory/services/users.go
+++ b/artifactory/services/users.go
@@ -3,16 +3,15 @@ package services
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
-	"net/http"
-	"strings"
-
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"net/http"
 )
+
+const InviteCliSourceName = "cli"
 
 type UserParams struct {
 	UserDetails     User
@@ -161,33 +160,4 @@ func (us *UserService) DeleteUser(name string) error {
 		return errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
 	}
 	return err
-}
-
-func (us *UserService) InviteUser(email string) error {
-	httpDetails := us.ArtDetails.CreateHttpClientDetails()
-	url := fmt.Sprintf("%saccess/api/v1/users/invite", strings.TrimSuffix(us.ArtDetails.GetUrl(), "artifactory/"))
-	data := InvitedUser{
-		InvitedEmail: email,
-	}
-	requestContent, err := json.Marshal(data)
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	utils.SetContentType("application/json", &httpDetails.Headers)
-	//utils.AddAuthHeaders()"application/json", &httpDetails.Headers)
-	resp, body, err := us.client.SendPost(url, requestContent, &httpDetails)
-	if err != nil {
-		return err
-	}
-	if resp == nil {
-		return errorutils.CheckErrorf("no response provided (including status code)")
-	}
-	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
-		return errorutils.CheckError(errorutils.GenerateResponseError(resp.Status, clientutils.IndentJson(body)))
-	}
-	return err
-}
-
-type InvitedUser struct {
-	InvitedEmail string `json:"invitedEmail,omitempty" csv:"invitedEmail,omitempty"`
 }

--- a/auth/authutils.go
+++ b/auth/authutils.go
@@ -8,6 +8,18 @@ import (
 	"time"
 )
 
+type CreateTokenResponseData struct {
+	CreateTokenData
+}
+
+type CreateTokenData struct {
+	Scope        string `json:"scope,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
 func extractPayloadFromAccessToken(token string) (TokenPayload, error) {
 	// Separate token parts.
 	tokenParts := strings.Split(token, ".")

--- a/tests/accessinvite_test.go
+++ b/tests/accessinvite_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccessInvite(t *testing.T) {
+	initAccessTest(t)
+	t.Run("invite", testInviteUser)
+}
+
+func testInviteUser(t *testing.T) {
+	randomMail := fmt.Sprintf("test%s@jfrog.com", timestampStr)
+	UserParams := getTestInvitedUserParams(false, randomMail)
+	err := testUserService.CreateUser(UserParams)
+	assert.NoError(t, err)
+
+	// TDO: why create user?
+	user, err := testUserService.GetUser(UserParams)
+	assert.NoError(t, err)
+	assert.Nil(t, user)
+	err = testsAccessInviteService.InviteUser(randomMail)
+	assert.NoError(t, err)
+	err = testsAccessInviteService.InviteUser(randomMail)
+	assert.Error(t, err)
+	err = testUserService.DeleteUser(UserParams.UserDetails.Name)
+	assert.NoError(t, err)
+}
+
+func getTestInvitedUserParams(replaceIfExists bool, email string) services.UserParams {
+	userDetails := services.User{
+		Name:                     email,
+		Email:                    email,
+		Password:                 "Password1!",
+		Admin:                    &trueValue,
+		Realm:                    "internal",
+		ProfileUpdatable:         &trueValue,
+		DisableUIAccess:          &falseValue,
+		InternalPasswordDisabled: &falseValue,
+		ShouldInvite:             &trueValue,
+		Source:                   services.InviteCliSourceName,
+	}
+	return services.UserParams{
+		UserDetails:     userDetails,
+		ReplaceIfExists: replaceIfExists,
+	}
+}

--- a/tests/accesstokens_test.go
+++ b/tests/accesstokens_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"github.com/jfrog/jfrog-client-go/access/services"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAccessTokens(t *testing.T) {
+	initAccessTest(t)
+	t.Run("invite", testCreateToken)
+}
+
+func testCreateToken(t *testing.T) {
+	tokenParams := services.TokenParams{}
+	tokenParams.ExpiresIn = 0
+	token, err := testsAccessTokensService.CreateAccessToken(tokenParams)
+	assert.NoError(t, err)
+	assert.NotEqual(t, "", token.AccessToken, "Access token is empty")
+	//TODO: check why
+	assert.Equal(t, 31536000, token.ExpiresIn)
+}

--- a/tests/accesstokens_test.go
+++ b/tests/accesstokens_test.go
@@ -17,6 +17,6 @@ func testCreateToken(t *testing.T) {
 	token, err := testsAccessTokensService.CreateAccessToken(tokenParams)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", token.AccessToken, "Access token is empty")
-	//TODO: check why
+	// TODO: check why 31536000
 	assert.Equal(t, 31536000, token.ExpiresIn)
 }

--- a/tests/artifactorysecurity_test.go
+++ b/tests/artifactorysecurity_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	accessauth "github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/stretchr/testify/assert"
@@ -255,7 +256,7 @@ func revokeToken(token string) (string, error) {
 }
 
 // Util function to create a token
-func createToken(username string) (services.CreateTokenResponseData, error) {
+func createToken(username string) (accessauth.CreateTokenResponseData, error) {
 	params := services.NewCreateTokenParams()
 	params.Username = username
 	params.Scope = "api:* member-of-groups:readers"

--- a/tests/jfrogclient_test.go
+++ b/tests/jfrogclient_test.go
@@ -69,6 +69,8 @@ func setupIntegrationTests() {
 	}
 	if *TestAccess {
 		createAccessProjectManager()
+		createAccessInviteManager()
+		createAccessTokensManager()
 	}
 	if err := createRepo(); err != nil {
 		log.Error(err.Error())

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -116,6 +116,8 @@ var (
 
 	// Access Services
 	testsAccessProjectService *accessServices.ProjectService
+	testsAccessInviteService  *accessServices.InviteService
+	testsAccessTokensService  *accessServices.TokenService
 
 	timestamp    = time.Now().Unix()
 	timestampStr = strconv.FormatInt(timestamp, 10)
@@ -1003,6 +1005,24 @@ func createAccessProjectManager() {
 	failOnHttpClientCreation(err)
 	testGroupService = services.NewGroupService(rtclient)
 	testGroupService.SetArtifactoryDetails(artDetails)
+}
+
+func createAccessInviteManager() {
+	accessDetails := GetAccessDetails()
+	client, err := createJfrogHttpClient(&accessDetails)
+	failOnHttpClientCreation(err)
+	testsAccessInviteService = accessServices.NewInviteService(client)
+	testsAccessInviteService.ServiceDetails = accessDetails
+	// To test "invite" flow we first have to create new "invited user" using ArtifactoryUserManager.
+	createArtifactoryUserManager()
+}
+
+func createAccessTokensManager() {
+	accessDetails := GetAccessDetails()
+	client, err := createJfrogHttpClient(&accessDetails)
+	failOnHttpClientCreation(err)
+	testsAccessTokensService = accessServices.NewTokenService(client)
+	testsAccessTokensService.ServiceDetails = accessDetails
 }
 
 func getUniqueField(prefix string) string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
* Add a new "invite" command - sending an invitation to the platform email.
* Add a new "createToken" command - sending a request to access API and generate a token to the platform.