### PR TITLE
Unlabel safe to test automatically  

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,14 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
+      - name: Unlabel 'safe to test'
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{github.event_name != 'push' }}
+        with:
+          labels: 'safe to test'
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -39,8 +43,8 @@ jobs:
         run: go vet -v ./...
 
   JFrog-Client-Go-Artifactory-Tests:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: ${{ matrix.suite }} ${{ matrix.os }}
+    needs: Go-Lint
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +81,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.artifactory=true --rt.url='http://localhost:8081/artifactory/' --rt.user='admin' --rt.password='password' --ci.runId=${{ runner.os }}-${{ matrix.suite }}
 
   JFrog-Client-Go-Ds-Xr-Access-Tests:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
+    needs: Go-Lint
     name: ${{ matrix.suite }} ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -107,7 +111,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.suite }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ runner.os }}-${{ matrix.suite }}
 
   JFrog-Client-Go-Pipelines-Tests:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
+    needs: Go-Lint
     name: pipelines ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -132,7 +136,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKEN }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ runner.os }}-pipe
 
   JFrog-Client-Go-Repositories-Tests:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
+    needs: Go-Lint
     name: repositories ubuntu-latest
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,8 @@ concurrency:
   group: ${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
-  Go-Lint:
+  Pretest:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Unlabel 'safe to test'
@@ -44,7 +42,7 @@ jobs:
 
   JFrog-Client-Go-Artifactory-Tests:
     name: ${{ matrix.suite }} ${{ matrix.os }}
-    needs: Go-Lint
+    needs: Pretest
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +79,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.artifactory=true --rt.url='http://localhost:8081/artifactory/' --rt.user='admin' --rt.password='password' --ci.runId=${{ runner.os }}-${{ matrix.suite }}
 
   JFrog-Client-Go-Ds-Xr-Access-Tests:
-    needs: Go-Lint
+    needs: Pretest
     name: ${{ matrix.suite }} ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -111,7 +109,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.${{ matrix.suite }}=true --rt.url=${{ secrets.CLI_RT_URL }} --ds.url=${{ secrets.CLI_DIST_URL }} --xr.url=${{ secrets.CLI_XRAY_URL }} --access.url=${{ secrets.CLI_ACCESS_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --access.token=${{ secrets.CLI_ACCESS_TOKEN }} --ci.runId=${{ runner.os }}-${{ matrix.suite }}
 
   JFrog-Client-Go-Pipelines-Tests:
-    needs: Go-Lint
+    needs: Pretest
     name: pipelines ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -136,7 +134,7 @@ jobs:
         run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKEN }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ runner.os }}-pipe
 
   JFrog-Client-Go-Repositories-Tests:
-    needs: Go-Lint
+    needs: Pretest
     name: repositories ubuntu-latest
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
make all jobs depend on the Go-lint job so it is the only job
that needs to check for the 'safe to test' label and can now safely remove it.

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----