### PR TITLE
fix: summary typo in error message

### DIFF
--- a/xray/services/summary.go
+++ b/xray/services/summary.go
@@ -78,7 +78,7 @@ func (ss *SummaryService) GetArtifactSummary(params ArtifactSummaryParams) (*Art
 		return nil, errorutils.CheckError(err)
 	}
 	if response.Errors != nil && len(response.Errors) > 0 {
-		return nil, errorutils.CheckErrorf("Getting artifact-summery for artifact: %s failed with error: %s", response.Errors[0].Identifier, response.Errors[0].Error)
+		return nil, errorutils.CheckErrorf("Getting artifact-summary for artifact: %s failed with error: %s", response.Errors[0].Identifier, response.Errors[0].Error)
 	}
 	return &response, nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request. (go 1.18 has two small changes to unrelated files `auth/cert/sslutils_[default|windows].go`, I did not push those).
-----

Fixes spelling of summary (not summ**e**ry)

Releated issue: https://github.com/jfrog/jfrog-client-go/issues/47