### PR TITLE
Add storage services

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -52,6 +52,7 @@ type ArtifactoryServicesManager interface {
 	Aql(aql string) (io.ReadCloser, error)
 	SetProps(params services.PropsParams) (int, error)
 	DeleteProps(params services.PropsParams) (int, error)
+	GetItemProps(relativePath string) (*utils.ItemProperties, error)
 	UploadFilesWithSummary(params ...services.UploadParams) (operationSummary *utils.OperationSummary, err error)
 	UploadFiles(params ...services.UploadParams) (totalUploaded, totalFailed int, err error)
 	Copy(params ...services.MoveCopyParams) (successCount, failedCount int, err error)
@@ -89,6 +90,9 @@ type ArtifactoryServicesManager interface {
 	TriggerFederatedRepositoryFullSyncAll(repoKey string) error
 	TriggerFederatedRepositoryFullSyncMirror(repoKey string, mirrorUrl string) error
 	Export(params services.ExportParams) error
+	FolderInfo(relativePath string) (*utils.FolderInfo, error)
+	FileList(relativePath string) (*utils.FileList, error)
+	StorageInfo() (*utils.StorageInfo, error)
 }
 
 // By using this struct, you have the option of overriding only some of the ArtifactoryServicesManager
@@ -230,6 +234,10 @@ func (esm *EmptyArtifactoryServicesManager) SetProps(params services.PropsParams
 }
 
 func (esm *EmptyArtifactoryServicesManager) DeleteProps(params services.PropsParams) (int, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) GetItemProps(relativePath string) (*utils.ItemProperties, error) {
 	panic("Failed: Method is not implemented")
 }
 
@@ -386,6 +394,18 @@ func (esm *EmptyArtifactoryServicesManager) TriggerFederatedRepositoryFullSyncMi
 }
 
 func (esm *EmptyArtifactoryServicesManager) Export(params services.ExportParams) error {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) FolderInfo(relativePath string) (*utils.FolderInfo, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) FileList(relativePath string) (*utils.FileList, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) StorageInfo() (*utils.StorageInfo, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -294,6 +294,13 @@ func (sm *ArtifactoryServicesManagerImp) DeleteProps(params services.PropsParams
 	setPropsService.Threads = sm.config.GetThreads()
 	return setPropsService.DeleteProps(params)
 }
+
+func (sm *ArtifactoryServicesManagerImp) GetItemProps(relativePath string) (*utils.ItemProperties, error) {
+	setPropsService := services.NewPropsService(sm.client)
+	setPropsService.ArtDetails = sm.config.GetServiceDetails()
+	return setPropsService.GetItemProperties(relativePath)
+}
+
 func (sm *ArtifactoryServicesManagerImp) initUploadService() *services.UploadService {
 	uploadService := services.NewUploadService(sm.client)
 	uploadService.Threads = sm.config.GetThreads()
@@ -518,4 +525,19 @@ func (sm *ArtifactoryServicesManagerImp) Export(params services.ExportParams) er
 
 func (sm *ArtifactoryServicesManagerImp) Client() *jfroghttpclient.JfrogHttpClient {
 	return sm.client
+}
+
+func (sm *ArtifactoryServicesManagerImp) FolderInfo(relativePath string) (*utils.FolderInfo, error) {
+	storageService := services.NewStorageService(sm.config.GetServiceDetails(), sm.client)
+	return storageService.FolderInfo(relativePath)
+}
+
+func (sm *ArtifactoryServicesManagerImp) FileList(relativePath string) (*utils.FileList, error) {
+	storageService := services.NewStorageService(sm.config.GetServiceDetails(), sm.client)
+	return storageService.FileList(relativePath)
+}
+
+func (sm *ArtifactoryServicesManagerImp) StorageInfo() (*utils.StorageInfo, error) {
+	storageService := services.NewStorageService(sm.config.GetServiceDetails(), sm.client)
+	return storageService.StorageInfo()
 }

--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -1,23 +1,13 @@
 package services
 
 import (
-	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"sort"
-
-	biutils "github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/gofrog/version"
-
 	"github.com/jfrog/build-info-go/entities"
-
-	"github.com/jfrog/jfrog-client-go/http/httpclient"
-
+	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/parallel"
+	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
-
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -25,6 +15,11 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
 )
 
 type DownloadService struct {
@@ -366,7 +361,7 @@ func createDownloadFileDetails(downloadPath, localPath, localFileName string, do
 	return
 }
 
-func (ds *DownloadService) downloadFile(downloadFileDetails *httpclient.DownloadFileDetails, logMsgPrefix string, downloadParams DownloadParams) error {
+func (ds *DownloadService) DownloadFile(downloadFileDetails *httpclient.DownloadFileDetails, logMsgPrefix string, downloadParams DownloadParams) error {
 	httpClientsDetails := ds.GetArtifactoryDetails().CreateHttpClientDetails()
 	bulkDownload := downloadParams.SplitCount == 0 || downloadParams.MinSplitSize < 0 || downloadParams.MinSplitSize*1000 > downloadFileDetails.Size
 	if !bulkDownload {
@@ -549,7 +544,7 @@ func (ds *DownloadService) downloadFileIfNeeded(downloadPath, localPath, localFi
 		return e
 	}
 	downloadFileDetails := createDownloadFileDetails(downloadPath, localPath, localFileName, downloadData)
-	return ds.downloadFile(downloadFileDetails, logMsgPrefix, downloadParams)
+	return ds.DownloadFile(downloadFileDetails, logMsgPrefix, downloadParams)
 }
 
 func createDir(localPath, localFileName, logMsgPrefix string) error {

--- a/artifactory/services/movecopy.go
+++ b/artifactory/services/movecopy.go
@@ -125,7 +125,7 @@ func (mc *MoveCopyService) getPathsToMove(moveSpec MoveCopyParams) (resultItems 
 			}
 		}()
 
-		resultItems, err = reduceMovePaths(utils.ResultItem{}, tempResultItems, moveSpec.IsFlat(), clientutils.PlaceholdersUserd(moveSpec.Pattern, moveSpec.Target))
+		resultItems, err = reduceMovePaths(utils.ResultItem{}, tempResultItems, moveSpec.IsFlat(), clientutils.ArePlaceholdersUsed(moveSpec.Pattern, moveSpec.Target))
 		if err != nil {
 			return
 		}

--- a/artifactory/services/storage.go
+++ b/artifactory/services/storage.go
@@ -1,0 +1,95 @@
+package services
+
+import (
+	"encoding/json"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/http"
+	"path"
+)
+
+type StorageService struct {
+	client     *jfroghttpclient.JfrogHttpClient
+	artDetails *auth.ServiceDetails
+}
+
+func NewStorageService(artDetails auth.ServiceDetails, client *jfroghttpclient.JfrogHttpClient) *StorageService {
+	return &StorageService{artDetails: &artDetails, client: client}
+}
+
+func (s *StorageService) GetArtifactoryDetails() auth.ServiceDetails {
+	return *s.artDetails
+}
+
+func (s *StorageService) GetJfrogHttpClient() *jfroghttpclient.JfrogHttpClient {
+	return s.client
+}
+
+func (s *StorageService) FolderInfo(relativePath string) (*utils.FolderInfo, error) {
+	client := s.GetJfrogHttpClient()
+	restAPI := path.Join("api", "storage", relativePath)
+	folderUrl, err := utils.BuildArtifactoryUrl(s.GetArtifactoryDetails().GetUrl(), restAPI, make(map[string]string))
+	if err != nil {
+		return nil, err
+	}
+
+	httpClientsDetails := s.GetArtifactoryDetails().CreateHttpClientDetails()
+	resp, body, _, err := client.SendGet(folderUrl, true, &httpClientsDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+
+	result := &utils.FolderInfo{}
+	err = json.Unmarshal(body, result)
+	return result, errorutils.CheckError(err)
+}
+
+func (s *StorageService) FileList(relativePath string) (*utils.FileList, error) {
+	client := s.GetJfrogHttpClient()
+	restAPI := path.Join("api", "storage", relativePath)
+	folderUrl, err := utils.BuildArtifactoryUrl(s.GetArtifactoryDetails().GetUrl(), restAPI, make(map[string]string))
+	if err != nil {
+		return nil, err
+	}
+	folderUrl += "?list&listFolders=1"
+
+	httpClientsDetails := s.GetArtifactoryDetails().CreateHttpClientDetails()
+	resp, body, _, err := client.SendGet(folderUrl, true, &httpClientsDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+
+	result := &utils.FileList{}
+	err = json.Unmarshal(body, result)
+	return result, errorutils.CheckError(err)
+}
+
+func (s *StorageService) StorageInfo() (*utils.StorageInfo, error) {
+	client := s.GetJfrogHttpClient()
+	url := s.GetArtifactoryDetails().GetUrl() + "api/storageinfo"
+
+	httpClientsDetails := s.GetArtifactoryDetails().CreateHttpClientDetails()
+	resp, body, _, err := client.SendGet(url, true, &httpClientsDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	log.Debug("Artifactory response: ", resp.Status)
+
+	result := &utils.StorageInfo{}
+	err = json.Unmarshal(body, result)
+	return result, errorutils.CheckError(err)
+}

--- a/artifactory/services/upload_test.go
+++ b/artifactory/services/upload_test.go
@@ -47,7 +47,7 @@ func TestBuildUploadUrls(t *testing.T) {
 	for _, v := range testsParams {
 		targetProps, e := utils.ParseProperties(v.targetProps)
 		assert.NoError(t, e)
-		_, actualTargetPathWithProps, e := buildUploadUrls("http://localhost:8881/artifactory/", v.targetPath, v.buildProps, "", targetProps)
+		_, actualTargetPathWithProps, e := BuildUploadUrls("http://localhost:8881/artifactory/", v.targetPath, v.buildProps, "", targetProps)
 		assert.NoError(t, e)
 		assert.Equal(t, v.expectedTargetPathWithProps, actualTargetPathWithProps)
 	}

--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -172,3 +172,8 @@ func MergeProperties(properties []*Properties) *Properties {
 	mergedProps.removeDuplicateValues()
 	return mergedProps
 }
+
+type ItemProperties struct {
+	Properties map[string][]string `json:"properties,omitempty"`
+	Uri        string              `json:"uri,omitempty"`
+}

--- a/artifactory/services/utils/storageutils.go
+++ b/artifactory/services/utils/storageutils.go
@@ -1,0 +1,66 @@
+package utils
+
+import "encoding/json"
+
+type FolderInfo struct {
+	Uri          string               `json:"uri,omitempty"`
+	Repo         string               `json:"repo,omitempty"`
+	Path         string               `json:"path,omitempty"`
+	Created      string               `json:"created,omitempty"`
+	CreatedBy    string               `json:"createdBy,omitempty"`
+	LastModified string               `json:"lastModified,omitempty"`
+	ModifiedBy   string               `json:"modifiedBy,omitempty"`
+	LastUpdated  string               `json:"lastUpdated,omitempty"`
+	Children     []FolderInfoChildren `json:"children,omitempty"`
+}
+
+type FolderInfoChildren struct {
+	Uri    string `json:"uri,omitempty"`
+	Folder bool   `json:"folder,omitempty"`
+}
+
+type FileList struct {
+	Uri     string         `json:"uri,omitempty"`
+	Created string         `json:"created,omitempty"`
+	Files   []FileListFile `json:"files,omitempty"`
+}
+
+type FileListFile struct {
+	Uri          string      `json:"uri,omitempty"`
+	Size         json.Number `json:"size,omitempty"`
+	LastModified string      `json:"lastModified,omitempty"`
+	Folder       bool        `json:"folder,omitempty"`
+}
+
+type StorageInfo struct {
+	BinariesSummary         `json:"binariesSummary,omitempty"`
+	RepositoriesSummaryList []RepositorySummary `json:"repositoriesSummaryList,omitempty"`
+	FileStoreSummary        `json:"fileStoreSummary,omitempty"`
+}
+
+type BinariesSummary struct {
+	BinariesCount  string `json:"binariesCount,omitempty"`
+	BinariesSize   string `json:"binariesSize,omitempty"`
+	ArtifactsSize  string `json:"artifactsSize,omitempty"`
+	Optimization   string `json:"optimization,omitempty"`
+	ItemsCount     string `json:"itemsCount,omitempty"`
+	ArtifactsCount string `json:"artifactsCount,omitempty"`
+}
+
+type RepositorySummary struct {
+	RepoKey          string      `json:"repoKey,omitempty"`
+	RepoType         string      `json:"repoType,omitempty"`
+	FoldersCount     json.Number `json:"foldersCount,omitempty"`
+	FilesCount       json.Number `json:"filesCount,omitempty"`
+	UsedSpace        string      `json:"usedSpace,omitempty"`
+	UsedSpaceInBytes json.Number `json:"usedSpaceInBytes,omitempty"`
+	ItemsCount       json.Number `json:"itemsCount,omitempty"`
+}
+
+type FileStoreSummary struct {
+	StorageType      string `json:"storageType,omitempty"`
+	StorageDirectory string `json:"storageDirectory,omitempty"`
+	TotalSpace       string `json:"totalSpace,omitempty"`
+	UsedSpace        string `json:"usedSpace,omitempty"`
+	FreeSpace        string `json:"freeSpace,omitempty"`
+}

--- a/utils/parenthesesutils.go
+++ b/utils/parenthesesutils.go
@@ -36,7 +36,7 @@ func (p *ParenthesesSlice) IsPresent(index int) bool {
 }
 
 // Return true if at least one of the {i} in 'target' has corresponding parentheses in 'pattern'.
-func PlaceholdersUserd(pattern, target string) bool {
+func ArePlaceholdersUsed(pattern, target string) bool {
 	removedParenthesesTarget := RemovePlaceholderParentheses(pattern, target)
 	return removedParenthesesTarget != target
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

1. Added services to support a few storage REST APIs:
i. Get Item Props
ii. Folder Info
iii. File List
iiii. Storage Info
2. Added AQL result fields: Updated, CreatedBy, ModifiedBy, Stats
3. Made a few functions public to support the transfer command of the CLI.