### PR TITLE
Fix git execution function wrong path assignment

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -38,7 +38,6 @@ func (m *GitManager) ExecGit(args ...string) (string, string, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := exec.Command("git", args...)
-	cmd.Dir = m.path
 	cmd.Stdin = nil
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
On the git execution function, the `Dir` field, which indicates where the execution is running, was assigned mistakenly as the `.git` path.
This caused the git execution calls to run inside the` .git` folder and not the project folder.