### PR TITLE
Fix CLI_PIPE_ACCESS_TOKE typo on github secrets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: pipelines tests
-      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKE }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ runner.os }}-pipe
+      run: go test -v github.com/jfrog/jfrog-client-go/tests --timeout 0 --test.pipelines=true --rt.url=${{ secrets.CLI_RT_URL }} --pipe.url=${{ secrets.CLI_PIPE_URL }} --rt.user=${{ secrets.CLI_RT_USER }} --rt.password=${{ secrets.CLI_RT_PASSWORD }} --pipe.accessToken=${{ secrets.CLI_PIPE_ACCESS_TOKEN }} --pipe.vcsToken=${{ secrets.CLI_PIPE_VCS_TOKEN }} --pipe.vcsRepo=${{ secrets.CLI_PIPE_VCS_REPO }} --pipe.vcsBranch=${{ secrets.CLI_PIPE_VCS_BRANCH }} --ci.runId=${{ runner.os }}-pipe
 
   JFrog-Client-Go-Repositories-Tests:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----