### PR TITLE
Update SearchFiles example to use utils.ResultItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1532,7 +1532,7 @@ defer func() {
 }()
 
 // Iterate over the results.
-for currentResult := new(ResultItem); reader.NextRecord(currentResult) == nil; currentResult = new(ResultItem)  {
+for currentResult := new(utils.ResultItem); reader.NextRecord(currentResult) == nil; currentResult = new(utils.ResultItem)  {
     fmt.Printf("Found artifact: %s of type: %s\n", currentResult.Name, currentResult.Type)
 }
 if err := resultReader.GetError(); err != nil {
@@ -1543,7 +1543,7 @@ if err := resultReader.GetError(); err != nil {
 reader.Reset()
 ````
 
-- `reader.NextRecord(currentResult)` reads the next record from the reader into `currentResult` of type `ResultItem`.
+- `reader.NextRecord(currentResult)` reads the next record from the reader into `currentResult` of type `utils.ResultItem`.
 
 - `reader.Close()` removes the file used by the reader after it is used (preferably using `defer`).
 


### PR DESCRIPTION
Adding the proper package to the utils.ResultItem type reference makes the code snippet work when copied into client code

This is a docs-only PR.