### PR TITLE
Bugfix: Upload with target-prop's value contain special characters

### DIFF
--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	propsSeparator  = ";"
-	valuesSeparator = ","
+	propsSeparator       = ";"
+	keyValuesSeparator   = "="
+	multiValuesSeparator = ","
 )
 
 type Properties struct {
@@ -35,31 +36,51 @@ func ParseProperties(propStr string) (*Properties, error) {
 }
 
 func (props *Properties) ParseAndAddProperties(propStr string) error {
-	propList := strings.Split(propStr, propsSeparator)
+	propList := splitWhileIgnoringBackslashPrefixSeparators(propStr, propsSeparator)
 	for _, prop := range propList {
 		if prop == "" {
 			continue
 		}
 
-		parts := strings.Split(prop, "=")
-		if len(parts) != 2 {
-			return errorutils.CheckError(errors.New(fmt.Sprintf("Invalid property format: %s - format should be key=val1,val2,...", prop)))
+		key, value, err := splitPropToKeyAndValue(prop)
+		if err != nil {
+			return err
 		}
 
-		key := parts[0]
-		values := strings.Split(parts[1], valuesSeparator)
-		for i, val := range values {
-			// If "\" is found, then it means that the original string contains the "\," which indicates this "," is part of the value
-			// and not a separator
-			if strings.HasSuffix(val, "\\") && i+1 < len(values) {
-				values[i+1] = val[:len(val)-1] + valuesSeparator + values[i+1]
-			} else {
-				props.properties[key] = append(props.properties[key], val)
-			}
+		splitValues := splitWhileIgnoringBackslashPrefixSeparators(value, multiValuesSeparator)
+		for _, val := range splitValues {
+			props.properties[key] = append(props.properties[key], val)
 		}
 	}
 	props.removeDuplicateValues()
 	return nil
+}
+
+// Searches for the first "=" instance, and split str into 2 substrings.
+// Returns error for invalid property format.
+func splitPropToKeyAndValue(str string) (key, value string, err error) {
+	index := strings.Index(str, keyValuesSeparator)
+	if index == -1 || index-1 < 0 || index+1 >= len(str) {
+		return "", "", errorutils.CheckError(errors.New(fmt.Sprintf("Invalid property format: %s - format should be key=val1,val2,...", str)))
+	}
+	key = str[0:index]
+	value = str[index+1:]
+	err = nil
+	return
+}
+
+// Returns a slice created by splitting the sent string s into substrings, using the sent separator.
+// A backslash prefix escapes the separator.
+func splitWhileIgnoringBackslashPrefixSeparators(str, separator string) (splitArray []string) {
+	values := strings.Split(str, separator)
+	for i, val := range values {
+		if strings.HasSuffix(val, "\\") && i+1 < len(values) {
+			values[i+1] = val[:len(val)-1] + separator + values[i+1]
+		} else {
+			splitArray = append(splitArray, val)
+		}
+	}
+	return
 }
 
 func (props *Properties) AddProperty(key, value string) {
@@ -86,15 +107,15 @@ func (props *Properties) ToEncodedString(concatValues bool) string {
 		}
 		for _, value := range values {
 			if concatValues {
-				propValue := strings.Replace(value, valuesSeparator, fmt.Sprintf("\\%s", valuesSeparator), -1)
-				jointProp = fmt.Sprintf("%s%s%s", jointProp, url.QueryEscape(propValue), url.QueryEscape(valuesSeparator))
+				propValue := strings.Replace(value, multiValuesSeparator, fmt.Sprintf("\\%s", multiValuesSeparator), -1)
+				jointProp = fmt.Sprintf("%s%s%s", jointProp, url.QueryEscape(propValue), url.QueryEscape(multiValuesSeparator))
 			} else {
 				jointProp = fmt.Sprintf("%s%s=%s%s", jointProp, url.QueryEscape(key), url.QueryEscape(value), propsSeparator)
 			}
 		}
 		// Trim the last comma/semicolon
 		if concatValues {
-			jointProp = strings.TrimSuffix(jointProp, url.QueryEscape(valuesSeparator))
+			jointProp = strings.TrimSuffix(jointProp, url.QueryEscape(multiValuesSeparator))
 		} else {
 			jointProp = strings.TrimSuffix(jointProp, propsSeparator)
 		}
@@ -108,7 +129,7 @@ func (props *Properties) ToEncodedString(concatValues bool) string {
 func (props *Properties) ToHeadersMap() map[string]string {
 	headers := map[string]string{}
 	for key, values := range props.properties {
-		headers[key] = base64.StdEncoding.EncodeToString([]byte(strings.Join(values, valuesSeparator)))
+		headers[key] = base64.StdEncoding.EncodeToString([]byte(strings.Join(values, multiValuesSeparator)))
 	}
 	return headers
 }

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -41,6 +41,9 @@ func TestParseProperties(t *testing.T) {
 		{"y=a,b\\,c\\,d\\,e", Properties{properties: map[string][]string{"y": {"a", "b,c,d,e"}}}},
 		{"y=\\,a b", Properties{properties: map[string][]string{"y": {",a b"}}}},
 		{"y=a,b;x=i;y=a;x=j", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i", "j"}}}},
+		{"y=a=a,b;x=i;y=a=a;x=j=", Properties{properties: map[string][]string{"y": {"a=a", "b"}, "x": {"i", "j="}}}},
+		{"y=a,b;x=i\\;;y=a;x=j\\;\\;", Properties{properties: map[string][]string{"y": {"a", "b"}, "x": {"i;", "j;;"}}}},
+		{"y=a,b;x=\\i;y=a\\;;x=j\\;=\\,", Properties{properties: map[string][]string{"y": {"a", "b", "a;"}, "x": {"\\i", "j;=,"}}}},
 	}
 	for _, test := range tests {
 		t.Run(test.propsString, func(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixes https://github.com/jfrog/jfrog-cli/issues/1587
Properties value can now contain characters '=' and ';' .
In case of ';' character in the value - user should use a backslash prefix and write ';' .