### PR TITLE
Add GetRunningNodes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
       - [Removing a Permission Target](#removing-a-permission-target)
       - [Fetching a Permission Target](#fetching-a-permission-target)
       - [Fetching Artifactory's Version](#fetching-artifactorys-version)
+      - [Fetching Running Artifactory Nodes in a Cluster](#fetching-running-artifactory-nodes-in-a-cluster)
       - [Fetching Artifactory's Service ID](#fetching-artifactorys-service-id)
       - [Fetching Artifactory's Config Descriptor](#fetching-artifactorys-config-descriptor)
       - [Activating Artifactory's Key Encryption](#activating-artifactorys-key-encryption)
@@ -1103,6 +1104,12 @@ If the requested permission target does not exist, a nil value is returned for t
 
 ```go
 version, err := servicesManager.GetVersion()
+```
+
+#### Fetching Running Artifactory Nodes in a Cluster
+
+```go
+runningNodes, err := servicesManager.GetRunningNodes()
 ```
 
 #### Fetching Artifactory's Service ID

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -75,6 +75,7 @@ type ArtifactoryServicesManager interface {
 	DeleteReplication(repoKey string) error
 	GetReplication(repoKey string) ([]utils.ReplicationParams, error)
 	GetVersion() (string, error)
+	GetRunningNodes() ([]string, error)
 	GetServiceId() (string, error)
 	GetConfigDescriptor() (string, error)
 	ActivateKeyEncryption() error
@@ -326,6 +327,10 @@ func (esm *EmptyArtifactoryServicesManager) GetReplication(repoKey string) ([]ut
 }
 
 func (esm *EmptyArtifactoryServicesManager) GetVersion() (string, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) GetRunningNodes() ([]string, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -459,6 +459,11 @@ func (sm *ArtifactoryServicesManagerImp) GetServiceId() (string, error) {
 	return systemService.GetServiceId()
 }
 
+func (sm *ArtifactoryServicesManagerImp) GetRunningNodes() ([]string, error) {
+	systemService := services.NewSystemService(sm.config.GetServiceDetails(), sm.client)
+	return systemService.GetRunningNodes()
+}
+
 func (sm *ArtifactoryServicesManagerImp) GetConfigDescriptor() (string, error) {
 	systemService := services.NewSystemService(sm.config.GetServiceDetails(), sm.client)
 	return systemService.GetConfigDescriptor()

--- a/tests/artifactorysystem_test.go
+++ b/tests/artifactorysystem_test.go
@@ -15,6 +15,7 @@ func TestSystem(t *testing.T) {
 	initArtifactoryTest(t)
 	t.Run("getVersion", testGetVersion)
 	t.Run("getServiceId", testGetServiceId)
+	t.Run("getRunningNodes", testGetRunningNodes)
 	t.Run("getConfigDescriptor", testGetConfigDescriptor)
 	t.Run("activateKeyEncryption", testActivateKeyEncryption)
 	t.Run("deactivateKeyEncryption", testDeactivateKeyEncryption)
@@ -30,6 +31,12 @@ func testGetServiceId(t *testing.T) {
 	serviceId, err := testsSystemService.GetServiceId()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, serviceId)
+}
+
+func testGetRunningNodes(t *testing.T) {
+	runningNodes, err := testsSystemService.GetRunningNodes()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, runningNodes)
 }
 
 func testGetConfigDescriptor(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add GetRunningNodes API to retrieve all running nodes' names in a cluster.