### PR TITLE
Fix AQL for excluded properties and ? wildcards

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -214,7 +214,11 @@ func buildKeyAllValQueryPart(key string, propValues []string) string {
 }
 
 func buildExcludedKeyValQueryPart(key string, value string) string {
-	return fmt.Sprintf(`"@%s":{"$ne":%s}`, key, getAqlValue(value))
+	operator := `$ne`
+	if strings.Contains(value, "*") || strings.Contains(value, "?") {
+		operator = `$nmatch`
+	}
+	return fmt.Sprintf(`"@%s":{"%s":"%s"}`, key, operator, value)
 }
 
 func buildItemTypeQueryPart(params *CommonParams) string {
@@ -398,7 +402,7 @@ func buildIncludeQueryPart(fieldsToInclude []string) string {
 // Optimization - If value is a wildcard pattern, return `{"$match":"value"}`. Otherwise, return `"value"`.
 func getAqlValue(val string) string {
 	var aqlValuePattern string
-	if strings.Contains(val, "*") {
+	if strings.Contains(val, "*") || strings.Contains(val, "?") {
 		aqlValuePattern = `{"$match":"%s"}`
 	} else {
 		aqlValuePattern = `"%s"`


### PR DESCRIPTION
1. Fixes AQL property exclusion query part
2. Handles `?` wildcard in AQL query values by using the `$match` or `$nmatch` operator

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
