### PR TITLE
Fix flaky StorageInfo test

### DIFF
--- a/artifactory/services/utils/storageutils.go
+++ b/artifactory/services/utils/storageutils.go
@@ -1,6 +1,9 @@
 package utils
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 type FolderInfo struct {
 	Uri          string               `json:"uri,omitempty"`
@@ -55,6 +58,16 @@ type StorageInfo struct {
 	BinariesSummary         `json:"binariesSummary,omitempty"`
 	RepositoriesSummaryList []RepositorySummary `json:"repositoriesSummaryList,omitempty"`
 	FileStoreSummary        `json:"fileStoreSummary,omitempty"`
+}
+
+func (si *StorageInfo) FindRepositoryWithKey(key string) (*RepositorySummary, error) {
+	for _, rs := range si.RepositoriesSummaryList {
+		if rs.RepoKey == key {
+			return &rs, nil
+		}
+	}
+
+	return nil, errors.New("Failed to locate repository with key: " + key)
 }
 
 type BinariesSummary struct {

--- a/artifactory/services/utils/storageutils_test.go
+++ b/artifactory/services/utils/storageutils_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFindRepositoryThatExists(t *testing.T) {
+	si := buildFakeStorageInfo()
+
+	result, err := si.FindRepositoryWithKey("repository-one")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "repository-one", result.RepoKey)
+}
+
+func TestFindRepositoryThatDoesNotExist(t *testing.T) {
+	si := buildFakeStorageInfo()
+
+	result, err := si.FindRepositoryWithKey("repository-three")
+
+	assert.Error(t, err, "Failed to locate repository with key: repository-three")
+	assert.Nil(t, result)
+}
+
+func buildFakeStorageInfo() StorageInfo {
+	repositoryOne := RepositorySummary{RepoKey: "repository-one"}
+	repositoryTwo := RepositorySummary{RepoKey: "repository-two"}
+
+	return StorageInfo{
+		BinariesSummary:         BinariesSummary{},
+		RepositoriesSummaryList: []RepositorySummary{repositoryOne, repositoryTwo},
+		FileStoreSummary:        FileStoreSummary{},
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The storage info test fails occasionally because of a race between the
refresh and the subsequent call to fetch the storage information. In
some cases, the storage refresh has not completed before the request to
fetch the storage information occurs.

This change adds a loop with a timeout to the test to wait until the
repository is listed in the storage information before continuing to
assert the test statements.
