### PR TITLE
Encode properties in predictable order

### DIFF
--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"net/url"
+	"sort"
 	"strings"
 )
 
@@ -95,9 +96,20 @@ func (props *Properties) AddProperty(key, value string) {
 // If concatValues is true, then the values of each property are concatenated together separated by a comma. For example: key=val1,val2,...
 // Otherwise, each value of the property will be written with its key separately. For example: key=val1;key=val2;...
 func (props *Properties) ToEncodedString(concatValues bool) string {
+	// Sort the keys to create a predictable order
+	keys := make([]string, 0, len(props.properties))
+	for k := range props.properties {
+		keys = append(keys, k)
+	}
+
+	// sort the slice by keys
+	sort.Strings(keys)
+
 	encodedProps := ""
-	for key, values := range props.properties {
+	for _, key := range keys {
 		var jointProp string
+
+		values := props.properties[key]
 
 		if concatValues {
 			jointProp = fmt.Sprintf("%s=", url.QueryEscape(key))

--- a/artifactory/services/utils/properties.go
+++ b/artifactory/services/utils/properties.go
@@ -54,6 +54,20 @@ func (props *Properties) ParseAndAddProperties(propStr string) error {
 	return nil
 }
 
+// Creates an array containing the keys sorted in increasing order.
+func (props *Properties) getSortedKeys() []string {
+	// Sort the keys to create a predictable order
+	keys := make([]string, 0, len(props.properties))
+	for k := range props.properties {
+		keys = append(keys, k)
+	}
+
+	// sort the slice by keys
+	sort.Strings(keys)
+
+	return keys
+}
+
 // Searches for the first "=" instance, and split str into 2 substrings.
 // Returns error for invalid property format.
 func splitPropToKeyAndValue(str string) (key, value string, err error) {
@@ -96,17 +110,8 @@ func (props *Properties) AddProperty(key, value string) {
 // If concatValues is true, then the values of each property are concatenated together separated by a comma. For example: key=val1,val2,...
 // Otherwise, each value of the property will be written with its key separately. For example: key=val1;key=val2;...
 func (props *Properties) ToEncodedString(concatValues bool) string {
-	// Sort the keys to create a predictable order
-	keys := make([]string, 0, len(props.properties))
-	for k := range props.properties {
-		keys = append(keys, k)
-	}
-
-	// sort the slice by keys
-	sort.Strings(keys)
-
 	encodedProps := ""
-	for _, key := range keys {
+	for _, key := range props.getSortedKeys() {
 		var jointProp string
 
 		values := props.properties[key]

--- a/artifactory/services/utils/properties_test.go
+++ b/artifactory/services/utils/properties_test.go
@@ -67,3 +67,37 @@ func TestMergeProperties(t *testing.T) {
 		t.Error("Failed to marge Properties. expected:", expected, "actual:", mergedProps)
 	}
 }
+
+func TestPropertiesAreEncodedInAPredictableOrderWhenConcatenated(t *testing.T) {
+	tests := []struct {
+		properties   Properties
+		concatValues bool
+		expected     string
+	}{
+		{
+			Properties{properties: map[string][]string{"c": {"x"}, "a": {"y"}, "b": {"z"}}},
+			true,
+			"a=y;b=z;c=x",
+		},
+		{
+			Properties{properties: map[string][]string{"c": {"x", "f"}, "a": {"y"}, "b": {"z"}}},
+			true,
+			"a=y;b=z;c=x%2Cf",
+		},
+		{
+			Properties{properties: map[string][]string{"c": {"x"}, "a": {"y"}, "b": {"z"}}},
+			false,
+			"a=y;b=z;c=x",
+		},
+		{
+			Properties{properties: map[string][]string{"c": {"x", "f"}, "a": {"y"}, "b": {"z"}}},
+			false,
+			"a=y;b=z;c=x;c=f",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.expected, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.properties.ToEncodedString(test.concatValues))
+		})
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

When testing, it is useful to be able to have some predictability in the
way that properties are encoded to a string. Since the properties struct
is currently backed by a map, the order that it is rendered to a string
is not predictable.

This change sorts the keys before rendering to a string. The items in
the arrays (the values in the map) are considered to be ordered and
hence are not sorted.

Feature Request: https://github.com/jfrog/jfrog-client-go/issues/549