### PR TITLE
Correct segfault in example permission target code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,24 +1081,27 @@ Creating a new permission target :
 ```go
 params := services.NewPermissionTargetParams()
 params.Name = "java-developers"
+params.Repo = &services.PermissionTargetSection{}
 params.Repo.Repositories = []string{"ANY REMOTE", "local-repo1", "local-repo2"}
 params.Repo.ExcludePatterns = []string{"dir/*"}
-params.Repo.Actions.Users = map[string][]string {
-	"user1" : {"read", "write"},
-    "user2" : {"write","annotate", "read"},
+params.Repo.Actions = &services.Actions{}
+params.Repo.Actions.Users = map[string][]string{
+    "user1": {"read", "write"},
+    "user2": {"write", "annotate", "read"},
 }
-params.Repo.Actions.Groups = map[string][]string {
-	"group1" : {"manage","read","annotate"},
+params.Repo.Actions.Groups = map[string][]string{
+    "group1": {"manage", "read", "annotate"},
 }
 // This is the default value that cannot be changed
+params.Build = &services.PermissionTargetSection{}
 params.Build.Repositories = []string{"artifactory-build-info"}
-params.Build.Actions.Groups = map[string][]string {
-	"group1" : {"manage","read","write","annotate","delete"},
-	"group2" : {"read"},
-
+params.Build.Actions = &services.Actions{}
+params.Build.Actions.Groups = map[string][]string{
+    "group1": {"manage", "read", "write", "annotate", "delete"},
+    "group2": {"read"},
 }
 
-err = servicesManager.CreatePermissionTarget(params)
+err := testsPermissionTargetService.Create(params)
 ```
 
 Updating an existing permission target :

--- a/tests/artifactorypermissiontarget_test.go
+++ b/tests/artifactorypermissiontarget_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"crypto/rand"
 	"fmt"
 	"testing"
 
@@ -91,4 +92,137 @@ func TestPermissionTargetEmptyFields(t *testing.T) {
 	validatePermissionTarget(t, params)
 	err := testsPermissionTargetService.Delete(params.Name)
 	assert.NoError(t, err)
+}
+
+// This test directly copies the example in the documentation:
+// - Creating and Updating Permission Targets
+func TestDocumentationExampleCreateUpdateAndDeletePermissionTarget(t *testing.T) {
+	initArtifactoryTest(t)
+
+	// Preamble to get dependent entities setup
+	user1 := createRandomUser(t)
+	defer deleteUserAndAssert(t, user1)
+
+	user2 := createRandomUser(t)
+	defer deleteUserAndAssert(t, user2)
+
+	localRepo1 := createRandomRepo(t)
+	defer deleteRepo(t, localRepo1)
+
+	localRepo2 := createRandomRepo(t)
+	defer deleteRepo(t, localRepo2)
+
+	group1 := createRandomGroup(t)
+	defer deleteGroupAndAssert(t, group1)
+
+	group2 := createRandomGroup(t)
+	defer deleteGroupAndAssert(t, group2)
+
+	// Example code from Documentation
+	params := services.NewPermissionTargetParams()
+	params.Name = "java-developers"
+	params.Repo = &services.PermissionTargetSection{}
+	params.Repo.Repositories = []string{"ANY REMOTE", localRepo1, localRepo2}
+	params.Repo.ExcludePatterns = []string{"dir/*"}
+	params.Repo.Actions = &services.Actions{}
+	params.Repo.Actions.Users = map[string][]string{
+		user1: {"read", "write"},
+		user2: {"write", "annotate", "read"},
+	}
+	params.Repo.Actions.Groups = map[string][]string{
+		group1: {"manage", "read", "annotate"},
+	}
+	// This is the default value that cannot be changed
+	params.Build = &services.PermissionTargetSection{}
+	params.Build.Repositories = []string{"artifactory-build-info"}
+	params.Build.Actions = &services.Actions{}
+	params.Build.Actions.Groups = map[string][]string{
+		group1: {"manage", "read", "write", "annotate", "delete"},
+		group2: {"read"},
+	}
+
+	// Creating the Permission Target
+	err := testsPermissionTargetService.Create(params)
+	assert.NoError(t, err)
+
+	// Update the permission target
+	err = testsPermissionTargetService.Update(params)
+	assert.NoError(t, err)
+
+	// Fetch a permission target
+	_, err = testsPermissionTargetService.Get("java-developers")
+	assert.NoError(t, err)
+
+	// Delete the permission target
+	err = testsPermissionTargetService.Delete("java-developers")
+	assert.NoError(t, err)
+}
+
+func createRandomUser(t *testing.T) string {
+	name := fmt.Sprintf("test-%s-%s", timestampStr, randomString(16))
+	userDetails := services.User{
+		Name:                     name,
+		Email:                    name + "@jfrog.com",
+		Password:                 "Password1*",
+		Admin:                    &falseValue,
+		Realm:                    "internal",
+		ShouldInvite:             &falseValue,
+		ProfileUpdatable:         &trueValue,
+		DisableUIAccess:          &falseValue,
+		InternalPasswordDisabled: &falseValue,
+		WatchManager:             &falseValue,
+		ReportsManager:           &falseValue,
+		PolicyManager:            &falseValue,
+	}
+
+	err := testUserService.CreateUser(services.UserParams{
+		UserDetails:     userDetails,
+		ReplaceIfExists: true,
+	})
+
+	assert.NoError(t, err)
+
+	return name
+}
+
+func createRandomRepo(t *testing.T) string {
+	repoKey := fmt.Sprintf("test-%s-%s", timestampStr, randomString(16))
+	glp := services.NewGenericLocalRepositoryParams()
+	glp.Key = repoKey
+	setLocalRepositoryBaseParams(&glp.LocalRepositoryBaseParams, false)
+
+	err := testsCreateLocalRepositoryService.Generic(glp)
+
+	assert.NoError(t, err)
+
+	return repoKey
+}
+
+func createRandomGroup(t *testing.T) string {
+	name := fmt.Sprintf("test-%s-%s", timestampStr, randomString(16))
+
+	groupDetails := services.Group{
+		Name:            name,
+		Description:     "hello",
+		AutoJoin:        &falseValue,
+		AdminPrivileges: &falseValue,
+		Realm:           "internal",
+		RealmAttributes: "",
+	}
+
+	groupParams := services.GroupParams{
+		GroupDetails: groupDetails,
+		IncludeUsers: false,
+	}
+
+	err := testGroupService.CreateGroup(groupParams)
+	assert.NoError(t, err)
+
+	return name
+}
+
+func randomString(length int) string {
+	b := make([]byte, length)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)[:length]
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The example for creating a permission target in the documentation
creates a segfault when executed. This change corrects the example code
and introduces a test which executes what the example would do.

Fixes: https://github.com/jfrog/jfrog-client-go/issues/543