### PR TITLE
Separate storage info calc and get

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
             - [Getting Info of a Folder in Artifactory](#getting-info-of-a-folder-in-artifactory)
             - [Getting a listing of files and folders within a folder in Artifactory](#getting-a-listing-of-files-and-folders-within-a-folder-in-artifactory)
             - [Getting Storage Summary Info of Artifactory](#getting-storage-summary-info-of-artifactory)
+            - [Triggerring Storage Info Recalculation in Artifactory](#triggerring-storage-info-recalculation-in-artifactory)
     - [Access APIs](#access-apis)
         - [Creating Access Service Manager](#creating-access-service-manager)
             - [Creating Access Details](#creating-access-details)
@@ -1299,8 +1300,13 @@ serviceManager.FileList("repo/path/", optionalParams)
 #### Getting Storage Summary Info of Artifactory
 
 ```go
-forceRefresh := true
-serviceManager.StorageInfo(forceRefresh)
+storageInfo, err := serviceManager.GetStorageInfo()
+```
+
+#### Triggerring Storage Info Recalculation in Artifactory
+
+```go
+err := serviceManager.CalculateStorageInfo()
 ```
 
 ## Access APIs

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -97,7 +97,8 @@ type ArtifactoryServicesManager interface {
 	Export(params services.ExportParams) error
 	FolderInfo(relativePath string) (*utils.FolderInfo, error)
 	FileList(relativePath string, optionalParams utils.FileListParams) (*utils.FileListResponse, error)
-	StorageInfo(refresh bool) (*utils.StorageInfo, error)
+	GetStorageInfo() (*utils.StorageInfo, error)
+	CalculateStorageInfo() error
 }
 
 // By using this struct, you have the option of overriding only some of the ArtifactoryServicesManager
@@ -426,7 +427,11 @@ func (esm *EmptyArtifactoryServicesManager) FileList(relativePath string, option
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) StorageInfo(refresh bool) (*utils.StorageInfo, error) {
+func (esm *EmptyArtifactoryServicesManager) GetStorageInfo() (*utils.StorageInfo, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) CalculateStorageInfo() error {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -1,8 +1,9 @@
 package artifactory
 
 import (
-	"github.com/jfrog/jfrog-client-go/auth"
 	"io"
+
+	"github.com/jfrog/jfrog-client-go/auth"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
 
@@ -557,14 +558,12 @@ func (sm *ArtifactoryServicesManagerImp) FileList(relativePath string, optionalP
 	return storageService.FileList(relativePath, optionalParams)
 }
 
-func (sm *ArtifactoryServicesManagerImp) StorageInfo(refresh bool) (*utils.StorageInfo, error) {
+func (sm *ArtifactoryServicesManagerImp) GetStorageInfo() (*utils.StorageInfo, error) {
 	storageService := services.NewStorageService(sm.config.GetServiceDetails(), sm.client)
-	// If refresh flag was provided - Send a refresh request to Artifactory before getting the storage info.
-	if refresh {
-		err := storageService.StorageInfoRefresh()
-		if err != nil {
-			return nil, err
-		}
-	}
 	return storageService.StorageInfo()
+}
+
+func (sm *ArtifactoryServicesManagerImp) CalculateStorageInfo() error {
+	storageService := services.NewStorageService(sm.config.GetServiceDetails(), sm.client)
+	return storageService.StorageInfoRefresh()
 }

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -2,12 +2,12 @@ package utils
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"strconv"
 	"strings"
 
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 
+	buildInfoUtils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils"
 )
 
@@ -318,7 +318,7 @@ func includePropertiesInAqlForSpec(specFile *CommonParams) bool {
 
 func appendMissingFields(fields []string, defaultFields []string) []string {
 	for _, field := range fields {
-		if !fileutils.IsStringInSlice(field, defaultFields) {
+		if !buildInfoUtils.IsStringInSlice(field, defaultFields) {
 			defaultFields = append(defaultFields, field)
 		}
 	}

--- a/auth/cert/sslutils_default.go
+++ b/auth/cert/sslutils_default.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cert

--- a/auth/cert/sslutils_windows.go
+++ b/auth/cert/sslutils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cert

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,6 @@ exclude (
 	golang.org/x/text v0.3.4
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.1-0.20220620130614-83dda95caddf
+replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220628060849-fcdbffb153da

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,6 @@ exclude (
 	golang.org/x/text v0.3.4
 )
 
-replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220628060849-fcdbffb153da

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23 h1:l9+nTmOPKOvEFh0ONZ3Xzm6pKvraNdB03M22lUg+WaY=
+github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
@@ -747,8 +749,6 @@ github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHg
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
-github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990 h1:RiPZ2a3E5m5sfwmZzmyo4xOjcUL2vqyJSXhidNLBWaY=
-github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/yeya24/promlinter v0.1.1-0.20210918184747-d757024714a1/go.mod h1:rs5vtZzeBHqqMwXqFScncpCF6u06lezhZepno9AB1Oc=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.4.0 h1:1O+zvovje/JC4ja8XeVp1pGByIIxWKW6kjdj8eW9yyI=
-github.com/jfrog/build-info-go v1.4.0/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
@@ -749,6 +747,8 @@ github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHg
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
+github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990 h1:RiPZ2a3E5m5sfwmZzmyo4xOjcUL2vqyJSXhidNLBWaY=
+github.com/yahavi/build-info-go v0.1.2-0.20220811130923-7bd0866ef990/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/yeya24/promlinter v0.1.1-0.20210918184747-d757024714a1/go.mod h1:rs5vtZzeBHqqMwXqFScncpCF6u06lezhZepno9AB1Oc=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=

--- a/tests/artifactorystorage_test.go
+++ b/tests/artifactorystorage_test.go
@@ -91,9 +91,6 @@ func storageInfoTest(t *testing.T) {
 	assert.NotEmpty(t, info.ArtifactsCount)
 	assert.NotEmpty(t, info.StorageType)
 	assert.NotEmpty(t, info.StorageDirectory)
-	assert.NotEmpty(t, info.TotalSpace)
-	assert.NotEmpty(t, info.UsedSpace)
-	assert.NotEmpty(t, info.FreeSpace)
 
 	for _, repoSummary := range info.RepositoriesSummaryList {
 		if repoSummary.RepoKey == getRtTargetRepoKey() {

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -5,9 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/jfrog/build-info-go/entities"
-	biutils "github.com/jfrog/build-info-go/utils"
-	gofrog "github.com/jfrog/gofrog/io"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -16,6 +13,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/jfrog/build-info-go/entities"
+	biutils "github.com/jfrog/build-info-go/utils"
+	gofrog "github.com/jfrog/gofrog/io"
 
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 )
@@ -471,7 +472,7 @@ func CopyDir(fromPath, toPath string, includeDirs bool, excludeNames []string) e
 
 	for _, v := range files {
 		// Skip if excluded
-		if IsStringInSlice(filepath.Base(v), excludeNames) {
+		if biutils.IsStringInSlice(filepath.Base(v), excludeNames) {
 			continue
 		}
 
@@ -494,15 +495,6 @@ func CopyDir(fromPath, toPath string, includeDirs bool, excludeNames []string) e
 		}
 	}
 	return err
-}
-
-func IsStringInSlice(string string, strings []string) bool {
-	for _, v := range strings {
-		if v == string {
-			return true
-		}
-	}
-	return false
 }
 
 // Removing the provided path from the filesystem


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on: https://github.com/jfrog/build-info-go/pull/93

* Currently, the get storage info API gets a "refresh" boolean. Triggering a refresh is an asynchronous operation and therefore there is no reason to trigger it right before the "get".
* Since we already break the API, I changed StorageInfo -> GetStorageInfo
* Fix storageInfoTest to allow it to run on SaaS environment.
* Remove IsStringInSlice and use the one in the build-info-go