### PR TITLE
Make DeactivateKeyEncryption return wasEncrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,7 +1161,7 @@ serviceId, err := servicesManager.GetConfigDescriptor()
 Notice: This API is enabled only on self-hosted Artifactory servers
 
 ```go
-serviceId, err := servicesManager.ActivateKeyEncryption()
+err := servicesManager.ActivateKeyEncryption()
 ```
 
 #### Deactivating Artifactory's Key Encryption
@@ -1169,7 +1169,7 @@ serviceId, err := servicesManager.ActivateKeyEncryption()
 Notice: This API is enabled only on self-hosted Artifactory servers
 
 ```go
-serviceId, err := servicesManager.DeactivateKeyEncryption()
+wasEncrypted, err := servicesManager.DeactivateKeyEncryption()
 ```
 
 #### Fetching Users Details

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -79,7 +79,7 @@ type ArtifactoryServicesManager interface {
 	GetServiceId() (string, error)
 	GetConfigDescriptor() (string, error)
 	ActivateKeyEncryption() error
-	DeactivateKeyEncryption() error
+	DeactivateKeyEncryption() (bool, error)
 	PromoteDocker(params services.DockerPromoteParams) error
 	Client() *jfroghttpclient.JfrogHttpClient
 	GetGroup(params services.GroupParams) (*services.Group, error)
@@ -350,7 +350,7 @@ func (esm *EmptyArtifactoryServicesManager) ActivateKeyEncryption() error {
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) DeactivateKeyEncryption() error {
+func (esm *EmptyArtifactoryServicesManager) DeactivateKeyEncryption() (bool, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -475,7 +475,7 @@ func (sm *ArtifactoryServicesManagerImp) ActivateKeyEncryption() error {
 	return systemService.ActivateKeyEncryption()
 }
 
-func (sm *ArtifactoryServicesManagerImp) DeactivateKeyEncryption() error {
+func (sm *ArtifactoryServicesManagerImp) DeactivateKeyEncryption() (bool, error) {
 	systemService := services.NewSystemService(sm.config.GetServiceDetails(), sm.client)
 	return systemService.DeactivateKeyEncryption()
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Make DeactivateKeyEncryption return (wasEncrypted bool, err error). This change is needed to know whether we should encrypt after decrypting during the `jf rt transfer-config` command.