### PR TITLE
Sync-deletes - The wrong folders are deleted when uploading files with uppercase names

### DIFF
--- a/artifactory/services/utils/deleteutils.go
+++ b/artifactory/services/utils/deleteutils.go
@@ -63,7 +63,7 @@ func WriteCandidateDirsToBeDeleted(candidateDirsReaders []*content.ContentReader
 			if candidateDirToBeDeleted.Name == "." {
 				continue
 			}
-			candidateDirToBeDeletedPath = strings.ToLower(candidateDirToBeDeleted.GetItemRelativePath())
+			candidateDirToBeDeletedPath = candidateDirToBeDeleted.GetItemRelativePath()
 		}
 		// Fetch the next 'artifactNotToBeDelete'.
 		if artifactNotToBeDeleted == nil {
@@ -74,7 +74,7 @@ func WriteCandidateDirsToBeDeleted(candidateDirsReaders []*content.ContentReader
 				writeRemainCandidate(resultWriter, dirsToBeDeletedReader)
 				break
 			}
-			itemNotToBeDeletedLocation = strings.ToLower(artifactNotToBeDeleted.GetItemRelativeLocation())
+			itemNotToBeDeletedLocation = artifactNotToBeDeleted.GetItemRelativeLocation()
 		}
 		// Found an 'artifact not to be deleted' in 'dir to be deleted', therefore skip writing the dir to the result file.
 		if strings.HasPrefix(itemNotToBeDeletedLocation, candidateDirToBeDeletedPath) {

--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -370,28 +370,16 @@ func (item ResultItem) GetItemRelativePath() string {
 	}
 
 	url := item.Repo
-	url = addSeparator(url, "/", item.Path)
-	url = addSeparator(url, "/", item.Name)
+	url = path.Join(url, item.Path, item.Name)
 	if item.Type == "folder" {
 		url = appendFolderSuffix(url)
 	}
 	return url
 }
 
-// Returns "item.Repo/item.Path/" lowercased.
+// Returns "item.Repo/item.Path/".
 func (item ResultItem) GetItemRelativeLocation() string {
-	return strings.ToLower(addSeparator(item.Repo, "/", item.Path) + "/")
-}
-
-func addSeparator(str1, separator, str2 string) string {
-	if str2 == "" {
-		return str1
-	}
-	if str1 == "" {
-		return str2
-	}
-
-	return str1 + separator + str2
+	return path.Join(item.Repo, item.Path) + "/"
 }
 
 func (item *ResultItem) ToArtifact() buildinfo.Artifact {

--- a/artifactory/services/utils/tests/testdata/candidate_dirs_to_be_deleted_results.json
+++ b/artifactory/services/utils/tests/testdata/candidate_dirs_to_be_deleted_results.json
@@ -2,6 +2,11 @@
   "results": [
     {
       "repo": "a",
+      "path": "b/c/d",
+      "type": "folder"
+    },
+    {
+      "repo": "a",
       "path": "e",
       "type": "folder"
     },


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Issue:`Sync-delete` logic fails to filter out folders that should not be deleted. As a result, folders that start with lowercase are being deleted.
Part of: https://github.com/jfrog/jfrog-cli/pull/1681