### PR TITLE
Allow stopping retry executor

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -98,6 +98,7 @@ func (jc *HttpClient) newRequest(method, url string, body io.Reader) (req *http.
 
 func (jc *HttpClient) Send(method, url string, content []byte, followRedirect, closeBody bool, httpClientsDetails httputils.HttpClientDetails, logMsgPrefix string) (resp *http.Response, respBody []byte, redirectUrl string, err error) {
 	retryExecutor := utils.RetryExecutor{
+		Context:                  jc.ctx,
 		MaxRetries:               jc.retries,
 		RetriesIntervalMilliSecs: jc.retryWaitMilliSecs,
 		LogMsgPrefix:             logMsgPrefix,

--- a/utils/retryexecutor_test.go
+++ b/utils/retryexecutor_test.go
@@ -57,9 +57,9 @@ func TestRetryExecutorCancel(t *testing.T) {
 	retriesToPerform := 5
 	runCount := 0
 
-	context, cancelFunc := context.WithCancel(context.Background())
+	retryContext, cancelFunc := context.WithCancel(context.Background())
 	executor := RetryExecutor{
-		Context:                  context,
+		Context:                  retryContext,
 		MaxRetries:               retriesToPerform,
 		RetriesIntervalMilliSecs: 0,
 		ErrorMessage:             "Testing RetryExecutor",
@@ -70,7 +70,7 @@ func TestRetryExecutorCancel(t *testing.T) {
 	}
 
 	cancelFunc()
-	assert.NoError(t, executor.Execute())
+	assert.EqualError(t, executor.Execute(), context.Canceled.Error())
 	if runCount != 1 {
 		t.Error(fmt.Errorf("expected, %d, got: %d", retriesToPerform, runCount))
 	}

--- a/utils/retryexecutor_test.go
+++ b/utils/retryexecutor_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"context"
 	"fmt"
+	"testing"
+
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRetryExecutorSuccess(t *testing.T) {
@@ -47,6 +49,29 @@ func TestRetryExecutorFail(t *testing.T) {
 
 	assert.NoError(t, executor.Execute())
 	if runCount != retriesToPerform+1 {
+		t.Error(fmt.Errorf("expected, %d, got: %d", retriesToPerform, runCount))
+	}
+}
+
+func TestRetryExecutorCancel(t *testing.T) {
+	retriesToPerform := 5
+	runCount := 0
+
+	context, cancelFunc := context.WithCancel(context.Background())
+	executor := RetryExecutor{
+		Context:                  context,
+		MaxRetries:               retriesToPerform,
+		RetriesIntervalMilliSecs: 0,
+		ErrorMessage:             "Testing RetryExecutor",
+		ExecutionHandler: func() (bool, error) {
+			runCount++
+			return true, nil
+		},
+	}
+
+	cancelFunc()
+	assert.NoError(t, executor.Execute())
+	if runCount != 1 {
 		t.Error(fmt.Errorf("expected, %d, got: %d", retriesToPerform, runCount))
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Allow providing the context to the retry executor to allow canceling.