### PR TITLE
Generate Vulnerabilities Report - correct the location of key "include_path_pattern"

### DIFF
--- a/xray/services/report.go
+++ b/xray/services/report.go
@@ -102,12 +102,12 @@ type CvssScore struct {
 }
 
 type Resource struct {
-	IncludePathPatterns []string     `json:"include_path_patterns,omitempty"`
 	Repositories        []Repository `json:"repositories,omitempty"`
 }
 
 type Repository struct {
-	Name string `json:"name,omitempty"`
+	Name                string       `json:"name,omitempty"`
+	IncludePathPatterns []string     `json:"include_path_patterns,omitempty"`
 }
 
 // ReportResponse defines a report request response


### PR DESCRIPTION
The current incorrect location creates a xray report that includes all the artifacts in a repo. See https://www.jfrog.com/confluence/display/JFROG/Xray+REST+API#XrayRESTAPI-GenerateVulnerabilitiesReport for reference

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----