### PR TITLE
Return error on retry executor timeout

### DIFF
--- a/distribution/services/deleteremote.go
+++ b/distribution/services/deleteremote.go
@@ -112,7 +112,7 @@ func (dr *DeleteReleaseBundleService) waitForDeletion(name, version string) erro
 	if dr.MaxWaitMinutes >= 1 {
 		maxWaitMinutes = dr.MaxWaitMinutes
 	}
-	for timeElapsed := 0; timeElapsed < maxWaitMinutes*60; timeElapsed += defaultSyncSleepIntervalSeconds {
+	for timeElapsed := 0; timeElapsed < maxWaitMinutes*60; timeElapsed += DefaultDistributeSyncSleepIntervalSeconds {
 		if timeElapsed%60 == 0 {
 			log.Info(fmt.Sprintf("Performing sync deletion of release bundle %s/%s...", name, version))
 		}
@@ -127,7 +127,7 @@ func (dr *DeleteReleaseBundleService) waitForDeletion(name, version string) erro
 		if resp.StatusCode != http.StatusOK {
 			return errorutils.CheckErrorf("Error while waiting to deletion: status code " + fmt.Sprint(resp.StatusCode) + ".")
 		}
-		time.Sleep(time.Second * defaultSyncSleepIntervalSeconds)
+		time.Sleep(time.Second * DefaultDistributeSyncSleepIntervalSeconds)
 	}
 	return errorutils.CheckErrorf("Timeout for sync deletion. ")
 }

--- a/distribution/services/distribute.go
+++ b/distribution/services/distribute.go
@@ -14,8 +14,8 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-const defaultMaxWaitMinutes = 60           // 1 hour
-const defaultSyncSleepIntervalSeconds = 10 // 10 seconds
+const defaultMaxWaitMinutes = 60                     // 1 hour
+const DefaultDistributeSyncSleepIntervalSeconds = 10 // 10 seconds
 
 type DistributeReleaseBundleService struct {
 	client         *jfroghttpclient.JfrogHttpClient
@@ -81,7 +81,7 @@ func (dr *DistributeReleaseBundleService) execDistribute(name, version string, d
 	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK, http.StatusAccepted); err != nil {
 		return "", err
 	}
-	response := distributionResponseBody{}
+	response := DistributionResponseBody{}
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return "", errorutils.CheckError(err)
@@ -106,8 +106,8 @@ func (dr *DistributeReleaseBundleService) waitForDistribution(distributeParams *
 	}
 	distributingMessage := fmt.Sprintf("Sync: Distributing %s/%s...", distributeParams.Name, distributeParams.Version)
 	retryExecutor := &utils.RetryExecutor{
-		MaxRetries:               maxWaitMinutes * 60 / defaultMaxWaitMinutes,
-		RetriesIntervalMilliSecs: defaultSyncSleepIntervalSeconds * 1000,
+		MaxRetries:               maxWaitMinutes * 60 / DefaultDistributeSyncSleepIntervalSeconds,
+		RetriesIntervalMilliSecs: DefaultDistributeSyncSleepIntervalSeconds * 1000,
 		ErrorMessage:             "",
 		LogMsgPrefix:             distributingMessage,
 		ExecutionHandler: func() (bool, error) {
@@ -146,7 +146,7 @@ type DistributionRulesBody struct {
 	CountryCodes []string `json:"country_codes,omitempty"`
 }
 
-type distributionResponseBody struct {
+type DistributionResponseBody struct {
 	TrackerId json.Number `json:"id"`
 }
 

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -55,6 +55,11 @@ func (runner *RetryExecutor) Execute() error {
 			time.Sleep(time.Millisecond * time.Duration(runner.RetriesIntervalMilliSecs))
 		}
 	}
+	// If the error is not nil, return it and log the timeout message. Otherwise, generate new error.
+	if err != nil {
+		log.Info(runner.getTimeoutErrorMsg())
+		return err
+	}
 	return errorutils.CheckErrorf(runner.getTimeoutErrorMsg())
 }
 

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"time"
 
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -54,8 +55,11 @@ func (runner *RetryExecutor) Execute() error {
 			time.Sleep(time.Millisecond * time.Duration(runner.RetriesIntervalMilliSecs))
 		}
 	}
-	log.Info(fmt.Sprintf("%s executor timeout after %v attempts with %v milliseconds wait intervals", runner.LogMsgPrefix, runner.MaxRetries, runner.RetriesIntervalMilliSecs))
-	return err
+	return errorutils.CheckErrorf(runner.getTimeoutErrorMsg())
+}
+
+func (runner *RetryExecutor) getTimeoutErrorMsg() string {
+	return fmt.Sprintf("%s executor timeout after %v attempts with %v milliseconds wait intervals", runner.LogMsgPrefix, runner.MaxRetries, runner.RetriesIntervalMilliSecs)
 }
 
 func (runner *RetryExecutor) LogRetry(attemptNumber int, err error) {

--- a/utils/retryexecutor.go
+++ b/utils/retryexecutor.go
@@ -39,7 +39,7 @@ func (runner *RetryExecutor) Execute() error {
 		// Run ExecutionHandler
 		shouldRetry, err = runner.ExecutionHandler()
 
-		// If should not retry, return
+		// If we should not retry, return.
 		if !shouldRetry {
 			return err
 		}
@@ -60,7 +60,16 @@ func (runner *RetryExecutor) Execute() error {
 		log.Info(runner.getTimeoutErrorMsg())
 		return err
 	}
-	return errorutils.CheckErrorf(runner.getTimeoutErrorMsg())
+	return errorutils.CheckError(RetryExecutorTimeoutError{runner.getTimeoutErrorMsg()})
+}
+
+// Error of this type will be returned if the executor reaches timeout and no other error is returned by the execution handler.
+type RetryExecutorTimeoutError struct {
+	errMsg string
+}
+
+func (retryErr RetryExecutorTimeoutError) Error() string {
+	return retryErr.errMsg
 }
 
 func (runner *RetryExecutor) getTimeoutErrorMsg() string {

--- a/utils/retryexecutor_test.go
+++ b/utils/retryexecutor_test.go
@@ -33,7 +33,7 @@ func TestRetryExecutorSuccess(t *testing.T) {
 	}
 }
 
-func TestRetryExecutorFail(t *testing.T) {
+func TestRetryExecutorTimeout(t *testing.T) {
 	retriesToPerform := 5
 	runCount := 0
 
@@ -47,7 +47,7 @@ func TestRetryExecutorFail(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, executor.Execute())
+	assert.EqualError(t, executor.Execute(), executor.getTimeoutErrorMsg())
 	if runCount != retriesToPerform+1 {
 		t.Error(fmt.Errorf("expected, %d, got: %d", retriesToPerform, runCount))
 	}

--- a/utils/retryexecutor_test.go
+++ b/utils/retryexecutor_test.go
@@ -45,7 +45,7 @@ func TestRetryExecutorTimeoutWithDefaultError(t *testing.T) {
 		},
 	}
 
-	assert.EqualError(t, executor.Execute(), executor.getTimeoutErrorMsg())
+	assert.Equal(t, executor.Execute(), RetryExecutorTimeoutError{executor.getTimeoutErrorMsg()})
 	assert.Equal(t, retriesToPerform+1, runCount)
 }
 
@@ -53,7 +53,7 @@ func TestRetryExecutorTimeoutWithCustomError(t *testing.T) {
 	retriesToPerform := 5
 	runCount := 0
 
-	errorMsg := "Retry failed due to reason"
+	executionHandler := errors.New("retry failed due to reason")
 
 	executor := RetryExecutor{
 		MaxRetries:               retriesToPerform,
@@ -61,11 +61,11 @@ func TestRetryExecutorTimeoutWithCustomError(t *testing.T) {
 		ErrorMessage:             "Testing RetryExecutor",
 		ExecutionHandler: func() (bool, error) {
 			runCount++
-			return true, errors.New(errorMsg)
+			return true, executionHandler
 		},
 	}
 
-	assert.EqualError(t, executor.Execute(), errorMsg)
+	assert.Equal(t, executor.Execute(), executionHandler)
 	assert.Equal(t, retriesToPerform+1, runCount)
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
In addition, fix distribute sync retries calculation.