### PR TITLE
Add other_component_ids to /graph/scan API

### DIFF
--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -183,8 +183,15 @@ type GraphNode struct {
 	Properties map[string]string `json:"properties,omitempty"`
 	// List of subcomponents.
 	Nodes []*GraphNode `json:"nodes,omitempty"`
+	// Other component IDs field is populated by the Xray indexer to get a better accuracy in '.deb' files.
+	OtherComponentIds []OtherComponentIds `json:"other_component_ids,omitempty"`
 	// Node parent (for internal use)
 	Parent *GraphNode `json:"-"`
+}
+
+type OtherComponentIds struct {
+	Id     string `json:"component_id,omitempty"`
+	Origin int    `json:"origin,omitempty"`
 }
 
 type RequestScanResponse struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add 'other_component_ids' populated by the Xray indexer in the `jf scan` command for Debian.