### PR TITLE
Add util to extract the subject from JWT tokens

### DIFF
--- a/auth/authutils.go
+++ b/auth/authutils.go
@@ -3,10 +3,11 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"strings"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type CreateTokenResponseData struct {
@@ -127,6 +128,15 @@ func GetTokenMinutesLeft(token string) (int64, error) {
 		return 0, nil
 	}
 	return left / 60, nil
+}
+
+// Extracts the subject from an access token
+func ExtractSubjectFromAccessToken(token string) (string, error) {
+	tokenPayload, err := extractPayloadFromAccessToken(token)
+	if err != nil {
+		return "", err
+	}
+	return tokenPayload.Subject, nil
 }
 
 type TokenPayload struct {

--- a/auth/authutils_test.go
+++ b/auth/authutils_test.go
@@ -1,8 +1,9 @@
 package auth
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /* #nosec G101 -- Dummy tokens for tests. */
@@ -25,10 +26,10 @@ func TestExtractUsernameFromAccessToken(t *testing.T) {
 		{"tempuser", token4, false},
 	}
 
-	for index, test := range testCases {
-		username := ExtractUsernameFromAccessToken(test.inputToken)
-		assert.Equal(t, username == "", test.shouldError)
-		assert.Equal(t, username, testCases[index].expectedUsername)
+	for _, testCase := range testCases {
+		username := ExtractUsernameFromAccessToken(testCase.inputToken)
+		assert.Equal(t, testCase.shouldError, username == "")
+		assert.Equal(t, testCase.expectedUsername, username)
 	}
 }
 
@@ -51,6 +52,6 @@ func TestExtractSubjectFromAccessToken(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
-		assert.Equal(t, subject, testCase.expectedSubject)
+		assert.Equal(t, testCase.expectedSubject, subject)
 	}
 }

--- a/auth/authutils_test.go
+++ b/auth/authutils_test.go
@@ -13,11 +13,11 @@ var (
 	token4 = "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJsS0NYXzFvaTBQbTZGdF9XRklkejZLZ1g4U0FULUdOY0lJWXRjTC1KM084In0.eyJzdWIiOiJqZmZlQDAwMFwvdXNlcnNcL3RlbXB1c2VyIiwic2NwIjoiYXBwbGllZC1wZXJtaXNzaW9uc1wvYWRtaW4gYXBpOioiLCJhdWQiOlsiamZydEAqIiwiamZtZEAqIiwiamZldnRAKiIsImpmYWNAKiJdLCJpc3MiOiJqZmZlQDAwMCIsImV4cCI6MTYxNjQ4OTU4NSwiaWF0IjoxNjE2NDg1OTg1LCJqdGkiOiI0OTBlYWEzOS1mMzYxLTQxYjAtOTA5Ni1kNjg5NmQ0ZWQ3YjEifQ.J5P8Pu5tqEjgnLFLEoCdh1LJHWiMmEHht95v0EFuixwO-osq7sfXua_UCGBkKbmqVSGKew9kl_LTcbq_uMe281_5q2yYxT74iqc2wQ1K0uovEUeIU6E65oi70JwUWUwcF3sNJ2gFatnvgSu-2Kv6m-DtSIW36WS3Mh8uMZQ19ob4fmueVmMFyQsp0EEG6xFYeOK6SB8OUd0gAd_XvXiSRuF0eLabhKmXM2pVBLYfd2KIMlkFckEOGGOzeglvA62xmP4Ik7UsF487NAo0LeS_Pd79owr0jtgTYkCTrLlFhUzUMDVmD_LsCMyf_S4CJxhwkCRhhy9SYSs1WPgknL3--w"
 )
 
-func TestExtractSubjectFromAccessToken(t *testing.T) {
-	tests := []struct {
-		expectedSubject string
-		inputToken      string
-		shouldError     bool
+func TestExtractUsernameFromAccessToken(t *testing.T) {
+	testCases := []struct {
+		expectedUsername string
+		inputToken       string
+		shouldError      bool
 	}{
 		{"admin", token1, false},
 		{"", token2, true},
@@ -25,9 +25,32 @@ func TestExtractSubjectFromAccessToken(t *testing.T) {
 		{"tempuser", token4, false},
 	}
 
-	for index, test := range tests {
+	for index, test := range testCases {
 		username := ExtractUsernameFromAccessToken(test.inputToken)
 		assert.Equal(t, username == "", test.shouldError)
-		assert.Equal(t, username, tests[index].expectedSubject)
+		assert.Equal(t, username, testCases[index].expectedUsername)
+	}
+}
+
+func TestExtractSubjectFromAccessToken(t *testing.T) {
+	testCases := []struct {
+		expectedSubject string
+		inputToken      string
+		shouldError     bool
+	}{
+		{"jfrt@01c3gffhg2e8w6149e3a2q0w97/users/admin", token1, false},
+		{"jfrt@001c3gffhg2e8w6149e3a2q0w97", token2, false},
+		{"", token3, true},
+		{"jffe@000/users/tempuser", token4, false},
+	}
+
+	for _, testCase := range testCases {
+		subject, err := ExtractSubjectFromAccessToken(testCase.inputToken)
+		if testCase.shouldError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, subject, testCase.expectedSubject)
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----