### PR TITLE
Fix flatten graph to cover node twice when needed.

### DIFF
--- a/xray/services/scan_test.go
+++ b/xray/services/scan_test.go
@@ -58,13 +58,17 @@ func TestFlattenGraph(t *testing.T) {
 	nodeD := &xrayUtils.GraphNode{Id: "D"}
 	nodeE := &xrayUtils.GraphNode{Id: "E"}
 	nodeF := &xrayUtils.GraphNode{Id: "F"}
+	nodeG := &xrayUtils.GraphNode{Id: "G"}
+	nodeGNoChildren := &xrayUtils.GraphNode{Id: "G"}
+	nodeH := &xrayUtils.GraphNode{Id: "H"}
 
 	// Set dependencies
 	nodeA.Nodes = []*xrayUtils.GraphNode{nodeB, nodeC}
 	nodeB.Nodes = []*xrayUtils.GraphNode{nodeC, nodeD}
 	nodeC.Nodes = []*xrayUtils.GraphNode{nodeD}
 	nodeD.Nodes = []*xrayUtils.GraphNode{nodeE, nodeF}
-	nodeF.Nodes = []*xrayUtils.GraphNode{nodeA, nodeB, nodeC}
+	nodeF.Nodes = []*xrayUtils.GraphNode{nodeGNoChildren, nodeA, nodeB, nodeC, nodeG}
+	nodeG.Nodes = []*xrayUtils.GraphNode{nodeH}
 
 	// Create graph
 	graph := []*xrayUtils.GraphNode{nodeA, nodeB, nodeC}
@@ -72,7 +76,7 @@ func TestFlattenGraph(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that the graph has been flattened correctly
-	assert.Equal(t, len(flatGraph[0].Nodes), 6)
+	assert.Equal(t, len(flatGraph[0].Nodes), 8)
 	set := datastructures.MakeSet[string]()
 	for _, node := range flatGraph[0].Nodes {
 		assert.Len(t, node.Nodes, 0)

--- a/xray/services/utils/graph.go
+++ b/xray/services/utils/graph.go
@@ -24,6 +24,9 @@ type GraphNode struct {
 	OtherComponentIds []OtherComponentIds `json:"other_component_ids,omitempty"`
 	// Node parent (for internal use)
 	Parent *GraphNode `json:"-"`
+	// Node Can appear in some cases without children. When adding node to flatten graph,
+	// we want to process node again if it was processed without children.
+	ChildrenExist bool `json:"-"`
 }
 
 type OtherComponentIds struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----