### PR TITLE
Flush the Content Writer before closing

### DIFF
--- a/utils/io/content/contentwriter.go
+++ b/utils/io/content/contentwriter.go
@@ -3,6 +3,7 @@ package content
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -107,8 +108,7 @@ func (rw *ContentWriter) run() {
 	var err error
 	if !rw.useStdout {
 		defer func() {
-			err = rw.outputFile.Close()
-			if err != nil {
+			if err = errors.Join(rw.outputFile.Sync(), rw.outputFile.Close()); err != nil {
 				rw.errorsQueue.AddError(errorutils.CheckError(err))
 			}
 		}()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

To enable immediate reading of the generated file, it is advisable to flush the Content Writer before closing it. This can be achieved by invoking the Sync() method on the Content Writer file. Once the content is flushed, the writer can be closed using the close() method. Performing these actions in sequence ensures that any buffered content is immediately written to the file, allowing for seamless reading or subsequent operations on the file, such as moving it.

For example, in the following code snippet, we close the Content Writer and then promptly move the file:
https://github.com/jfrog/jfrog-cli-core/blob/v2.35.0/artifactory/commands/transferfiles/errorshandler.go#L244
