### PR TITLE
Clean relative paths in storage APIs

### DIFF
--- a/artifactory/services/props.go
+++ b/artifactory/services/props.go
@@ -165,7 +165,7 @@ func NewPropsParams() PropsParams {
 }
 
 func (ps *PropsService) GetItemProperties(relativePath string) (*utils.ItemProperties, error) {
-	restAPI := path.Join("api", "storage", relativePath)
+	restAPI := path.Join("api", "storage", path.Clean(relativePath))
 	propertiesURL, err := utils.BuildArtifactoryUrl(ps.GetArtifactoryDetails().GetUrl(), restAPI, make(map[string]string))
 	if err != nil {
 		return nil, err

--- a/artifactory/services/storage.go
+++ b/artifactory/services/storage.go
@@ -33,7 +33,7 @@ func (s *StorageService) GetJfrogHttpClient() *jfroghttpclient.JfrogHttpClient {
 
 func (s *StorageService) FolderInfo(relativePath string) (*utils.FolderInfo, error) {
 	client := s.GetJfrogHttpClient()
-	restAPI := path.Join(StorageRestApi, relativePath)
+	restAPI := path.Join(StorageRestApi, path.Clean(relativePath))
 	folderUrl, err := utils.BuildArtifactoryUrl(s.GetArtifactoryDetails().GetUrl(), restAPI, make(map[string]string))
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (s *StorageService) FolderInfo(relativePath string) (*utils.FolderInfo, err
 
 func (s *StorageService) FileList(relativePath string, optionalParams utils.FileListParams) (*utils.FileListResponse, error) {
 	client := s.GetJfrogHttpClient()
-	restAPI := path.Join(StorageRestApi, relativePath)
+	restAPI := path.Join(StorageRestApi, path.Clean(relativePath))
 
 	// Convert params to map:
 	params := make(map[string]string)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Cleaning relative paths (removing dot-dots) before joining them to Artifactory storage API URL.