### PR TITLE
Upload - Add timezones to each zip file before uploading

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -871,6 +871,7 @@ func (us *UploadService) addFileToZip(artifact *clientutils.Artifact, progressPr
 		header.Name = artifact.TargetPathInArchive
 	}
 	header.Method = zip.Deflate
+	header.Modified = info.ModTime()
 
 	// If this is a directory, add it to the writer with a trailing slash.
 	if info.IsDir() {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

By uploading files with archive as zip, the timezone offset is not saved.
This PR adds a timezone offset to each file before uploading.

Dependent on: