### PR TITLE
Fix typo when using an API key as access token

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -744,7 +744,7 @@ func setAuthentication(req *http.Request, httpClientsDetails httputils.HttpClien
 	if httpClientsDetails.AccessToken != "" {
 		if IsApiKey(httpClientsDetails.AccessToken) {
 			log.Warn("The provided Access Token is an API key and will be used as a password in username/password authentication.\n" +
-				"To avoid this message in the future please use it a a password.")
+				"To avoid this message in the future please use it as a password.")
 			req.SetBasicAuth(httpClientsDetails.User, httpClientsDetails.AccessToken)
 		} else {
 			req.Header.Set("Authorization", "Bearer "+httpClientsDetails.AccessToken)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----