### PR TITLE
Support overall request timeout in all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 | Branch |                                                                                                                                                                              Status                                                                                                                                                                              |
-|:------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| :----: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | master | [![Build status](https://github.com/jfrog/jfrog-client-go/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/jfrog/jfrog-client-go/actions) [![Static Analysis](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml/badge.svg?branch=master)](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) |
 |  dev   |    [![Build status](https://github.com/jfrog/jfrog-client-go/actions/workflows/tests.yml/badge.svg?branch=dev)](https://github.com/jfrog/jfrog-client-go/actions) [![Static Analysis](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml/badge.svg?branch=dev)](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml)    |
 
@@ -251,7 +251,7 @@ content of this repository is deleted.
 #### Test Types
 
 | Type                 | Description        | Prerequisites                 |
-|----------------------|--------------------|-------------------------------|
+| -------------------- | ------------------ | ----------------------------- |
 | `-test.artifactory`  | Artifactory tests  | Artifactory Pro               |
 | `-test.distribution` | Distribution tests | Artifactory with Distribution |
 | `-test.xray`         | Xray tests         | Artifactory with Xray         |
@@ -262,7 +262,7 @@ content of this repository is deleted.
 #### Connection Details
 
 | Flag                | Description                                                                                            |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | `-rt.url`           | [Default: http://localhost:8081/artifactory] Artifactory URL.                                          |
 | `-ds.url`           | [Optional] JFrog Distribution URL.                                                                     |
 | `-xr.url`           | [Optional] JFrog Xray URL.                                                                             |
@@ -357,8 +357,10 @@ serviceConfig, err := config.NewConfigBuilder().
     SetDryRun(false).
     // Add [Context](https://golang.org/pkg/context/)
     SetContext(ctx).
-    // Optionally overwrite the default HTTP timeout, which is set to 30 seconds.
-    SetHttpTimeout(180 * time.Second).
+    // Optionally overwrite the default dial timeout, which is set to 30 seconds.
+    SetDialTimeout(180 * time.Second).
+    // Optionally set the total HTTP request timeout.
+    SetOverallRequestTimeout(10 * time.Minute).
     // Optionally overwrite the default HTTP retries, which is set to 3.
     SetHttpRetries(8).
     Build()
@@ -1965,7 +1967,7 @@ vulnerabilitiesReportRequest := services.VulnerabilitiesReportRequestParams{
     Severity: []string{
         "High",
         "Medium"
-      },	
+      },
     CvssScore: services.CvssScore {
         MinScore: float64(6.3),
         MaxScore: float64(9)
@@ -2020,6 +2022,7 @@ reportContent, err := xrayManager.ReportContent(reportContentRequest)
 // The reportId argument value is returned as part of the xrayManager.GenerateVulnerabilitiesReport API response.
 err := xrayManager.DeleteReport(reportId)
 ```
+
 #### Generate Licences Report
 
 ```go
@@ -2119,7 +2122,7 @@ violationsReportRequest := services.ViolationsReportRequestParams{
       Severity: []string{
           "High",
           "Medium"
-        },	
+        },
       CvssScore: services.CvssScore {
           MinScore: float64(6.3),
           MaxScore: float64(9)
@@ -2132,7 +2135,7 @@ violationsReportRequest := services.ViolationsReportRequestParams{
           Start: "2020-06-29T12:22:16Z",
           End: "2020-06-29T12:22:16Z"
       },
-      SummaryContains: "kernel", 
+      SummaryContains: "kernel",
       HasRemediation: &falseValue,
     },
     LicenseFilters: services.LicensesFilter {

--- a/access/manager.go
+++ b/access/manager.go
@@ -23,6 +23,8 @@ func New(config config.Config) (*AccessServicesManager, error) {
 		SetClientCertKeyPath(details.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
 		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetRetries(config.GetHttpRetries()).
 		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
 		Build()

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -37,7 +37,8 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 		SetCertificatesPath(config.GetCertificatesPath()).
 		SetInsecureTls(config.IsInsecureTls()).
 		SetContext(config.GetContext()).
-		SetTimeout(config.GetHttpTimeout()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetClientCertPath(artDetails.GetClientCertPath()).
 		SetClientCertKeyPath(artDetails.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(artDetails.RunPreRequestFunctions).

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"context"
-	"github.com/jfrog/jfrog-client-go/auth"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"net/http"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type Config interface {
@@ -16,7 +17,8 @@ type Config interface {
 	GetLogger() log.Log
 	IsInsecureTls() bool
 	GetContext() context.Context
-	GetHttpTimeout() time.Duration
+	GetDialTimeout() time.Duration
+	GetOverallRequestTimeout() time.Duration
 	GetHttpRetries() int
 	GetHttpRetryWaitMilliSecs() int
 	GetHttpClient() *http.Client
@@ -30,7 +32,8 @@ type servicesConfig struct {
 	logger                 log.Log
 	insecureTls            bool
 	ctx                    context.Context
-	httpTimeout            time.Duration
+	dialTimeout            time.Duration
+	overallRequestTimeout  time.Duration
 	httpRetries            int
 	httpRetryWaitMilliSecs int
 	httpClient             *http.Client
@@ -64,8 +67,12 @@ func (config *servicesConfig) GetContext() context.Context {
 	return config.ctx
 }
 
-func (config *servicesConfig) GetHttpTimeout() time.Duration {
-	return config.httpTimeout
+func (config *servicesConfig) GetDialTimeout() time.Duration {
+	return config.dialTimeout
+}
+
+func (config *servicesConfig) GetOverallRequestTimeout() time.Duration {
+	return config.overallRequestTimeout
 }
 
 func (config *servicesConfig) GetHttpRetries() int {

--- a/config/configbuilder.go
+++ b/config/configbuilder.go
@@ -63,12 +63,6 @@ func (builder *servicesConfigBuilder) SetContext(ctx context.Context) *servicesC
 	return builder
 }
 
-// Deprecated
-func (builder *servicesConfigBuilder) SetHttpTimeout(dialTimeout time.Duration) *servicesConfigBuilder {
-	log.Warn("SetHttpTimeout is deprecated. Use SetDialTimeout instead.")
-	return builder.SetDialTimeout(dialTimeout)
-}
-
 func (builder *servicesConfigBuilder) SetDialTimeout(dialTimeout time.Duration) *servicesConfigBuilder {
 	builder.dialTimeout = dialTimeout
 	return builder

--- a/config/configbuilder.go
+++ b/config/configbuilder.go
@@ -2,16 +2,18 @@ package config
 
 import (
 	"context"
-	"github.com/jfrog/jfrog-client-go/auth"
-	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"net/http"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 func NewConfigBuilder() *servicesConfigBuilder {
 	configBuilder := &servicesConfigBuilder{}
 	configBuilder.threads = 3
-	configBuilder.httpTimeout = httpclient.DefaultHttpTimeout
+	configBuilder.dialTimeout = httpclient.DefaultDialTimeout
 	configBuilder.httpRetries = 3
 	configBuilder.httpRetryWaitMilliSecs = 0
 	return configBuilder
@@ -24,7 +26,8 @@ type servicesConfigBuilder struct {
 	isDryRun               bool
 	insecureTls            bool
 	ctx                    context.Context
-	httpTimeout            time.Duration
+	dialTimeout            time.Duration
+	overallRequestTimeout  time.Duration
 	httpRetries            int
 	httpRetryWaitMilliSecs int
 	httpClient             *http.Client
@@ -60,8 +63,19 @@ func (builder *servicesConfigBuilder) SetContext(ctx context.Context) *servicesC
 	return builder
 }
 
-func (builder *servicesConfigBuilder) SetHttpTimeout(httpTimeout time.Duration) *servicesConfigBuilder {
-	builder.httpTimeout = httpTimeout
+// Deprecated
+func (builder *servicesConfigBuilder) SetHttpTimeout(dialTimeout time.Duration) *servicesConfigBuilder {
+	log.Warn("SetHttpTimeout is deprecated. Use SetDialTimeout instead.")
+	return builder.SetDialTimeout(dialTimeout)
+}
+
+func (builder *servicesConfigBuilder) SetDialTimeout(dialTimeout time.Duration) *servicesConfigBuilder {
+	builder.dialTimeout = dialTimeout
+	return builder
+}
+
+func (builder *servicesConfigBuilder) SetOverallRequestTimeout(overallRequestTimeout time.Duration) *servicesConfigBuilder {
+	builder.overallRequestTimeout = overallRequestTimeout
 	return builder
 }
 
@@ -88,7 +102,8 @@ func (builder *servicesConfigBuilder) Build() (Config, error) {
 	c.dryRun = builder.isDryRun
 	c.insecureTls = builder.insecureTls
 	c.ctx = builder.ctx
-	c.httpTimeout = builder.httpTimeout
+	c.dialTimeout = builder.dialTimeout
+	c.overallRequestTimeout = builder.overallRequestTimeout
 	c.httpRetries = builder.httpRetries
 	c.httpRetryWaitMilliSecs = builder.httpRetryWaitMilliSecs
 	c.httpClient = builder.httpClient

--- a/config/configbuilder.go
+++ b/config/configbuilder.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 func NewConfigBuilder() *servicesConfigBuilder {

--- a/distribution/manager.go
+++ b/distribution/manager.go
@@ -21,7 +21,8 @@ func New(config config.Config) (*DistributionServicesManager, error) {
 		SetCertificatesPath(config.GetCertificatesPath()).
 		SetInsecureTls(config.IsInsecureTls()).
 		SetContext(config.GetContext()).
-		SetTimeout(config.GetHttpTimeout()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetClientCertPath(details.GetClientCertPath()).
 		SetClientCertKeyPath(details.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(details.RunPreRequestFunctions).

--- a/http/jfroghttpclient/clientbuilder.go
+++ b/http/jfroghttpclient/clientbuilder.go
@@ -2,14 +2,15 @@ package jfroghttpclient
 
 import (
 	"context"
-	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"net/http"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
 )
 
 func JfrogClientBuilder() *jfrogHttpClientBuilder {
 	builder := &jfrogHttpClientBuilder{}
-	builder.SetTimeout(httpclient.DefaultHttpTimeout)
+	builder.SetDialTimeout(httpclient.DefaultDialTimeout)
 	return builder
 }
 
@@ -22,7 +23,8 @@ type jfrogHttpClientBuilder struct {
 	preRequestInterceptors []PreRequestInterceptorFunc
 	clientCertPath         string
 	clientCertKeyPath      string
-	timeout                time.Duration
+	dialTimeout            time.Duration
+	overallRequestTimeout  time.Duration
 	httpClient             *http.Client
 }
 
@@ -66,8 +68,13 @@ func (builder *jfrogHttpClientBuilder) AppendPreRequestInterceptor(interceptor P
 	return builder
 }
 
-func (builder *jfrogHttpClientBuilder) SetTimeout(timeout time.Duration) *jfrogHttpClientBuilder {
-	builder.timeout = timeout
+func (builder *jfrogHttpClientBuilder) SetDialTimeout(dialTimeout time.Duration) *jfrogHttpClientBuilder {
+	builder.dialTimeout = dialTimeout
+	return builder
+}
+
+func (builder *jfrogHttpClientBuilder) SetOverallRequestTimeout(overallRequestTimeout time.Duration) *jfrogHttpClientBuilder {
+	builder.overallRequestTimeout = overallRequestTimeout
 	return builder
 }
 
@@ -84,7 +91,8 @@ func (builder *jfrogHttpClientBuilder) Build() (rtHttpClient *JfrogHttpClient, e
 		SetClientCertPath(builder.clientCertPath).
 		SetClientCertKeyPath(builder.clientCertKeyPath).
 		SetContext(builder.ctx).
-		SetTimeout(builder.timeout).
+		SetDialTimeout(builder.dialTimeout).
+		SetOverallRequestTimeout(builder.overallRequestTimeout).
 		SetRetries(builder.retries).
 		SetRetryWaitMilliSecs(builder.retryWaitTimMilliSecs).
 		SetHttpClient(builder.httpClient).

--- a/lifecycle/manager.go
+++ b/lifecycle/manager.go
@@ -23,6 +23,8 @@ func New(config config.Config) (*LifecycleServicesManager, error) {
 		SetClientCertKeyPath(details.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
 		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetRetries(config.GetHttpRetries()).
 		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
 		Build()

--- a/pipelines/manager.go
+++ b/pipelines/manager.go
@@ -22,6 +22,8 @@ func New(config config.Config) (*PipelinesServicesManager, error) {
 		SetClientCertKeyPath(details.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
 		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetRetries(config.GetHttpRetries()).
 		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
 		Build()

--- a/tests/timeout_test.go
+++ b/tests/timeout_test.go
@@ -1,0 +1,160 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/access"
+	accessAuth "github.com/jfrog/jfrog-client-go/access/auth"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/jfrog/jfrog-client-go/distribution"
+	"github.com/jfrog/jfrog-client-go/lifecycle"
+	"github.com/jfrog/jfrog-client-go/pipelines"
+
+	distributionAuth "github.com/jfrog/jfrog-client-go/distribution/auth"
+	distributionServices "github.com/jfrog/jfrog-client-go/distribution/services"
+	lifecycleAuth "github.com/jfrog/jfrog-client-go/lifecycle/auth"
+	lifecycleServices "github.com/jfrog/jfrog-client-go/lifecycle/services"
+	pipelinesAuth "github.com/jfrog/jfrog-client-go/pipelines/auth"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/utils/tests"
+	"github.com/jfrog/jfrog-client-go/xray"
+	xrayAuth "github.com/jfrog/jfrog-client-go/xray/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	overallRequestTimeout = time.Millisecond * 50
+	handlerTimeout        = time.Millisecond * 100
+)
+
+func TestTimeout(t *testing.T) {
+	previousLog := tests.RedirectLogOutputToNil()
+	defer func() {
+		log.SetLogger(previousLog)
+	}()
+	t.Run("testAccessTimeout", testAccessTimeout)
+	t.Run("testArtifactoryTimeout", testArtifactoryTimeout)
+	t.Run("testDistributionTimeout", testDistributionTimeout)
+	t.Run("testLifecycleTimeout", testLifecycleTimeout)
+	t.Run("testPipelinesTimeout", testPipelinesTimeout)
+	t.Run("testXrayTimeout", testXrayTimeout)
+}
+
+func testAccessTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := accessAuth.NewAccessDetails()
+	details.SetUrl(url)
+	servicesManager, err := access.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetAllProjects()
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func testArtifactoryTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := artifactoryAuth.NewArtifactoryDetails()
+	details.SetUrl(url)
+	servicesManager, err := artifactory.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetVersion()
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func testDistributionTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := distributionAuth.NewDistributionDetails()
+	details.SetUrl(url)
+	servicesManager, err := distribution.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetDistributionStatus(distributionServices.DistributionStatusParams{})
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func testLifecycleTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := lifecycleAuth.NewLifecycleDetails()
+	details.SetUrl(url)
+	servicesManager, err := lifecycle.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetReleaseBundleCreationStatus(lifecycleServices.ReleaseBundleDetails{}, "", false)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func testPipelinesTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := pipelinesAuth.NewPipelinesDetails()
+	details.SetUrl(url)
+	servicesManager, err := pipelines.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetSystemInfo()
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func testXrayTimeout(t *testing.T) {
+	// Create mock server
+	url, cleanup := createSleepyRequestServer()
+	defer cleanup()
+
+	// Create services manager configuring to work with the mock server
+	details := xrayAuth.NewXrayDetails()
+	details.SetUrl(url)
+	servicesManager, err := xray.New(createServiceConfigWithTimeout(t, details))
+	assert.NoError(t, err)
+
+	// Expect timeout
+	_, err = servicesManager.GetVersion()
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func createServiceConfigWithTimeout(t *testing.T, serverDetails auth.ServiceDetails) config.Config {
+	serviceConfig, err := config.NewConfigBuilder().SetOverallRequestTimeout(overallRequestTimeout).SetServiceDetails(serverDetails).Build()
+	assert.NoError(t, err)
+	return serviceConfig
+}
+
+// Create a mock HTTP server that sleeps before responding to requests
+func createSleepyRequestServer() (url string, cleanup func()) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		time.Sleep(handlerTimeout)
+	})
+	server := httptest.NewServer(handler)
+	url = server.URL + "/"
+	cleanup = server.Close
+	return
+}

--- a/utils/io/httputils/httpclient.go
+++ b/utils/io/httputils/httpclient.go
@@ -1,28 +1,38 @@
 package httputils
 
 import (
-	"github.com/jfrog/jfrog-client-go/utils"
 	"net/http"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils"
 )
 
 type HttpClientDetails struct {
-	User        string
-	Password    string
-	ApiKey      string
-	AccessToken string
-	Headers     map[string]string
-	Transport   *http.Transport
-	HttpTimeout time.Duration
+	User                  string
+	Password              string
+	ApiKey                string
+	AccessToken           string
+	Headers               map[string]string
+	Transport             *http.Transport
+	DialTimeout           time.Duration
+	OverallRequestTimeout time.Duration
 }
 
 func (httpClientDetails HttpClientDetails) Clone() *HttpClientDetails {
 	headers := make(map[string]string)
 	utils.MergeMaps(httpClientDetails.Headers, headers)
+	var transport *http.Transport
+	if httpClientDetails.Transport != nil {
+		transport = httpClientDetails.Transport.Clone()
+	}
 	return &HttpClientDetails{
-		User:        httpClientDetails.User,
-		Password:    httpClientDetails.Password,
-		ApiKey:      httpClientDetails.ApiKey,
-		AccessToken: httpClientDetails.AccessToken,
-		Headers:     headers}
+		User:                  httpClientDetails.User,
+		Password:              httpClientDetails.Password,
+		ApiKey:                httpClientDetails.ApiKey,
+		AccessToken:           httpClientDetails.AccessToken,
+		Headers:               headers,
+		Transport:             transport,
+		DialTimeout:           httpClientDetails.DialTimeout,
+		OverallRequestTimeout: httpClientDetails.OverallRequestTimeout,
+	}
 }

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -3,10 +3,7 @@ package tests
 import (
 	"bufio"
 	"errors"
-	biutils "github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
-	"github.com/stretchr/testify/assert"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	biutils "github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/stretchr/testify/assert"
 )
 
 type HttpServerHandlers map[string]func(w http.ResponseWriter, r *http.Request)
@@ -183,4 +185,15 @@ func GetLocalArtifactoryTokenIfNeeded(url string) (adminToken string) {
 		adminToken = os.Getenv("JFROG_TESTS_LOCAL_ACCESS_TOKEN")
 	}
 	return
+}
+
+// Set new logger with output redirection to a null logger. This is useful for negative tests.
+// Caller is responsible to set the old log back.
+func RedirectLogOutputToNil() (previousLog log.Log) {
+	previousLog = log.Logger
+	newLog := log.NewLogger(log.INFO, nil)
+	newLog.SetOutputWriter(io.Discard)
+	newLog.SetLogsWriter(io.Discard, 0)
+	log.SetLogger(newLog)
+	return previousLog
 }

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -22,7 +22,8 @@ func New(config config.Config) (*XrayServicesManager, error) {
 		SetCertificatesPath(config.GetCertificatesPath()).
 		SetInsecureTls(config.IsInsecureTls()).
 		SetContext(config.GetContext()).
-		SetTimeout(config.GetHttpTimeout()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
 		SetClientCertPath(details.GetClientCertPath()).
 		SetClientCertKeyPath(details.GetClientCertKeyPath()).
 		AppendPreRequestInterceptor(details.RunPreRequestFunctions).


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Rename HttpTimeout -> DialTimeout.
* Allow configuring "OverallRequestTimeout" to all requests. This timeout is the total time between the request and the response. It has no timeout by default.