### PR TITLE
Remove ecosystem usage report retry

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -46,6 +46,10 @@ func (jc *HttpClient) GetRetries() int {
 	return jc.retries
 }
 
+func (jc *HttpClient) GetClient() *http.Client {
+	return jc.client
+}
+
 func (jc *HttpClient) GetRetryWaitTime() int {
 	return jc.retryWaitMilliSecs
 }

--- a/utils/usage/reportusage.go
+++ b/utils/usage/reportusage.go
@@ -1,14 +1,16 @@
 package usage
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 const (
@@ -51,11 +53,37 @@ func CreateUsageData(productId, accountId, clientId string, features ...string) 
 }
 
 func sendRequestToEcosystemService(content []byte) (resp *http.Response, respBody []byte, err error) {
+	client, req, err := createEcosystemRequestInfo(content)
+	if err != nil {
+		return
+	}
+	log.Debug(fmt.Sprintf("Sending HTTP %s request to: %s", req.Method, req.URL))
+	resp, err = client.Do(req)
+	err = errorutils.CheckError(err)
+	if err != nil {
+		return
+	}
+	if resp == nil {
+		err = errorutils.CheckErrorf("Ecosystem-Usage Received empty response from server")
+		return
+	}
+	defer func() {
+		if resp.Body != nil {
+			err = errors.Join(err, errorutils.CheckError(resp.Body.Close()))
+		}
+	}()
+	respBody, _ = io.ReadAll(resp.Body)
+	return
+}
+
+func createEcosystemRequestInfo(content []byte) (c *http.Client, req *http.Request, err error) {
 	var client *httpclient.HttpClient
 	if client, err = httpclient.ClientBuilder().Build(); err != nil {
 		return
 	}
-	details := httputils.HttpClientDetails{}
-	utils.AddHeader("Content-Type", "application/json", &details.Headers)
-	return client.SendPost(ecosystemUsageApiPath, content, details, "Ecosystem-Usage")
+	if req, err = http.NewRequest("POST", ecosystemUsageApiPath, bytes.NewBuffer(content)); err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.GetClient(), req, errorutils.CheckError(err)
 }

--- a/utils/usage/reportusage.go
+++ b/utils/usage/reportusage.go
@@ -81,7 +81,7 @@ func createEcosystemRequestInfo(content []byte) (c *http.Client, req *http.Reque
 	if client, err = httpclient.ClientBuilder().Build(); err != nil {
 		return
 	}
-	if req, err = http.NewRequest("POST", ecosystemUsageApiPath, bytes.NewBuffer(content)); err != nil {
+	if req, err = http.NewRequest(http.MethodPost, ecosystemUsageApiPath, bytes.NewBuffer(content)); err != nil {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Try to send usage reports to ecosystem service only once.