### PR TITLE
New AQL query for build-info json

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder_test.go
+++ b/artifactory/services/utils/aqlquerybuilder_test.go
@@ -220,3 +220,36 @@ func TestBuildKeyValQueryPart(t *testing.T) {
 		})
 	}
 }
+
+var encodeForBuildInfoRepositoryProvider = []struct {
+	value            string
+	expectedEncoding string
+}{
+	// Shouldn't encode
+	{"", ""},
+	{"a", "a"},
+	{"a b", "a b"},
+	{"a.b", "a.b"},
+	{"a&b", "a&b"},
+
+	// Should encode
+	{"a/b", "a%2Fb"},
+	{"a\\b", "a%5Cb"},
+	{"a:b", "a%3Ab"},
+	{"a|b", "a%7Cb"},
+	{"a*b", "a%2Ab"},
+	{"a?b", "a%3Fb"},
+	{"a  /  b", "a %20%2F%20 b"},
+
+	// Should convert whitespace to space
+	{"a\tb", "a b"},
+	{"a\nb", "a b"},
+}
+
+func TestEncodeForBuildInfoRepository(t *testing.T) {
+	for _, testCase := range encodeForBuildInfoRepositoryProvider {
+		t.Run(testCase.value, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedEncoding, encodeForBuildInfoRepository(testCase.value))
+		})
+	}
+}

--- a/tests/artifactoryaql_test.go
+++ b/tests/artifactoryaql_test.go
@@ -1,0 +1,45 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAqlQueryForBuildInfoJson(t *testing.T) {
+	initArtifactoryTest(t)
+
+	// Create a build
+	buildName := fmt.Sprintf("%s-%s", "a / \\ | \t * ? : ; \\ / %b", getRunId())
+	err := createDummyBuild(buildName)
+	assert.NoError(t, err)
+
+	// Run AQL to get the build from Artifactory
+	aqlQuery := utils.CreateAqlQueryForBuildInfoJson("", buildName, buildNumber, buildTimestamp)
+	stream, err := testsAqlService.ExecAql(aqlQuery)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	// Parse AQL results
+	aqlResults, err := io.ReadAll(stream)
+	assert.NoError(t, err)
+	parsedResult := new(utils.AqlSearchResult)
+	err = json.Unmarshal(aqlResults, parsedResult)
+	assert.NoError(t, err)
+	assert.Len(t, parsedResult.Results, 1)
+
+	// Verify build checksum exist
+	assert.NotEmpty(t, parsedResult.Results[0].Actual_Sha1)
+	assert.NotEmpty(t, parsedResult.Results[0].Actual_Md5)
+
+	// Delete build
+	encodedBuildName := strings.TrimSuffix(parsedResult.Results[0].Path, "-"+buildTimestamp+".json")
+	assert.NoError(t, deleteBuild(encodedBuildName))
+}

--- a/tests/jfrogclient_test.go
+++ b/tests/jfrogclient_test.go
@@ -55,6 +55,7 @@ func setupIntegrationTests() {
 		createArtifactoryFederationManager()
 		createArtifactorySystemManager()
 		createArtifactoryStorageManager()
+		createArtifactoryAqlManager()
 	}
 
 	if *TestDistribution {

--- a/tests/xraybinmgr_test.go
+++ b/tests/xraybinmgr_test.go
@@ -15,6 +15,7 @@ func TestXrayBinMgr(t *testing.T) {
 func addBuildsToIndexing(t *testing.T) {
 	buildName := fmt.Sprintf("%s-%s", "build1", getRunId())
 	defer func() {
+		assert.NoError(t, deleteBuildIndex(buildName))
 		assert.NoError(t, deleteBuild(buildName))
 	}()
 	// Create a build

--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -133,12 +133,14 @@ func testXrayWatchSelectedRepos(t *testing.T) {
 	err = createAndIndexBuild(t, build1Name)
 	assert.NoError(t, err)
 	defer func() {
+		assert.NoError(t, deleteBuildIndex(build1Name))
 		assert.NoError(t, deleteBuild(build1Name))
 	}()
 	build2Name := fmt.Sprintf("%s-%s", "build2", getRunId())
 	err = createAndIndexBuild(t, build2Name)
 	assert.NoError(t, err)
 	defer func() {
+		assert.NoError(t, deleteBuildIndex(build2Name))
 		assert.NoError(t, deleteBuild(build2Name))
 	}()
 	paramsSelectedRepos := utils.NewWatchParams()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Create CreateAqlQueryForBuildInfo, which retrieves build information and generates an AQL query to return the SHA1 and MD5 checksums of the build-info.json file.