### PR TITLE
Support for Distribution path mapping with AQL

### DIFF
--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -18,8 +18,14 @@ type Aql struct {
 	ItemsFind string `json:"items.find"`
 }
 
+type PathMapping struct {
+	Input  string `json:"input"`
+	Output string `json:"output"`
+}
+
 type CommonParams struct {
 	Aql              Aql
+	PathMapping      PathMapping
 	Pattern          string
 	Exclusions       []string
 	Target           string

--- a/distribution/services/utils/distributionutils.go
+++ b/distribution/services/utils/distributionutils.go
@@ -34,16 +34,22 @@ func NewReleaseBundleParams(name, version string) ReleaseBundleParams {
 
 func CreateBundleBody(releaseBundleParams ReleaseBundleParams, dryRun bool) (*ReleaseBundleBody, error) {
 	var bundleQueries []BundleQuery
+	var pathMappings []rtUtils.PathMapping
+
 	// Create release bundle queries
 	for _, specFile := range releaseBundleParams.SpecFiles {
+		// Create path mapping
+		if specFile.GetSpecType() == rtUtils.AQL {
+			pathMappings = distribution.CreatePathMappings(specFile.PathMapping.Input, specFile.PathMapping.Output)
+		} else {
+			pathMappings = distribution.CreatePathMappingsFromPatternAndTarget(specFile.Pattern, specFile.Target)
+		}
+
 		// Create AQL
 		aql, err := createAql(specFile)
 		if err != nil {
 			return nil, err
 		}
-
-		// Create path mapping
-		pathMappings := distribution.CreatePathMappings(specFile.Pattern, specFile.Target)
 
 		// Create added properties
 		addedProps := createAddedProps(specFile)

--- a/distribution/services/utils/releasebundlebody.go
+++ b/distribution/services/utils/releasebundlebody.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/jfrog/jfrog-client-go/utils/distribution"
+import (
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+)
 
 // REST body for create and update a release bundle
 type ReleaseBundleBody struct {
@@ -22,10 +24,10 @@ type BundleSpec struct {
 }
 
 type BundleQuery struct {
-	QueryName    string                     `json:"query_name,omitempty"`
-	Aql          string                     `json:"aql,omitempty"`
-	PathMappings []distribution.PathMapping `json:"mappings,omitempty"`
-	AddedProps   []AddedProps               `json:"added_props,omitempty"`
+	QueryName    string              `json:"query_name,omitempty"`
+	Aql          string              `json:"aql,omitempty"`
+	PathMappings []utils.PathMapping `json:"mappings,omitempty"`
+	AddedProps   []AddedProps        `json:"added_props,omitempty"`
 }
 
 type AddedProps struct {

--- a/lifecycle/services/distribute.go
+++ b/lifecycle/services/distribute.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/jfrog/jfrog-client-go/utils/distribution"
@@ -62,7 +63,7 @@ func (dr *DistributeReleaseBundleService) createDistributeBody() ReleaseBundleDi
 	return ReleaseBundleDistributeBody{
 		ReleaseBundleDistributeV1Body: distribution.CreateDistributeV1Body(dr.DistributeParams, dr.DryRun, dr.AutoCreateRepo),
 		Modifications: Modifications{
-			PathMappings: distribution.CreatePathMappings(dr.Pattern, dr.Target),
+			PathMappings: distribution.CreatePathMappingsFromPatternAndTarget(dr.Pattern, dr.Target),
 		},
 	}
 }
@@ -73,7 +74,7 @@ type ReleaseBundleDistributeBody struct {
 }
 
 type Modifications struct {
-	PathMappings []distribution.PathMapping `json:"mappings"`
+	PathMappings []utils.PathMapping `json:"mappings"`
 }
 
 type PathMapping struct {

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -52,7 +53,9 @@ func TestDistributionServices(t *testing.T) {
 	t.Run("createSignDistributeDelete", createSignDistributeDelete)
 	t.Run("createSignSyncDistributeDelete", createSignSyncDistributeDelete)
 	t.Run("createDistributeMapping", createDistributeMapping)
-	t.Run("createDistributeMappingPlaceholder", createDistributeMappingPlaceholder)
+	t.Run("createDistributeMappingFromPatternAndTarget", createDistributeMappingFromPatternAndTarget)
+	t.Run("createDistributeMappingWithPlaceholder", createDistributeMappingWithPlaceholder)
+	t.Run("createDistributeMappingFromPatternAndTargetWithPlaceholder", createDistributeMappingFromPatternAndTargetWithPlaceholder)
 
 	artifactoryCleanup(t)
 	deleteGpgKeys(t)
@@ -123,6 +126,9 @@ func createUpdate(t *testing.T) {
 	// Verify was not created.
 	getLocalBundle(t, bundleName, false)
 
+	// Redefine specFiles to create params from scratch
+	createBundleParams.SpecFiles[0] = &utils.CommonParams{Pattern: getRtTargetRepo() + "b.in"}
+
 	// Create unsigned release bundle
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
 	if !assert.NoError(t, err) {
@@ -146,6 +152,9 @@ func createUpdate(t *testing.T) {
 	}
 	// Verify the release bundle was not updated.
 	assertCreatedLocalBundle(t, bundleName, createBundleParams)
+
+	// Redefine specFiles to create params from scratch
+	updateBundleParams.SpecFiles[0] = &utils.CommonParams{Pattern: getRtTargetRepo() + "test/a.in"}
 
 	summary, err = testsBundleUpdateService.UpdateReleaseBundle(updateBundleParams)
 	if !assert.NoError(t, err) {
@@ -357,6 +366,52 @@ func createDistributeMapping(t *testing.T) {
 
 	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out
 	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
+	createBundleParams.SpecFiles = []*utils.CommonParams{
+		{
+			Aql: utils.Aql{
+				ItemsFind: "{\"$or\":[{\"$and\":[{\"repo\":{\"$match\": \"" + strings.TrimSuffix(getRtTargetRepo(), "/") + "\"},\"name\":{\"$match\":\"b.in\"}}]}]}",
+			},
+			PathMapping: utils.PathMapping{
+				Input:  getRtTargetRepo() + "b.in",
+				Output: getRtTargetRepo() + "b.out",
+			},
+		},
+	}
+	createBundleParams.SignImmediately = true
+	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer deleteRemoteAndLocalBundle(t, bundleName)
+	assert.NotNil(t, summary)
+	verifyValidSha256(t, summary.GetSha256())
+
+	// Distribute release bundle
+	distributeBundleParams := distribution.NewDistributeReleaseBundleParams(bundleName, bundleVersion)
+	distributeBundleParams.DistributionRules = []*distribution.DistributionCommonParams{{SiteName: "*"}}
+	testsBundleDistributeService.Sync = true
+	// On distribution with path mapping, the target repository cannot be auto-created
+	testsBundleDistributeService.AutoCreateRepo = false
+	testsBundleDistributeService.DistributeParams = distributeBundleParams
+	err = testsBundleDistributeService.Distribute()
+	assert.NoError(t, err)
+
+	// Make sure <RtTargetRepo>/b.out does exist in Artifactory
+	searchParams := artifactoryServices.NewSearchParams()
+	searchParams.Pattern = getRtTargetRepo() + "b.out"
+	reader, err := testsSearchService.Search(searchParams)
+	assert.NoError(t, err)
+	readerCloseAndAssert(t, reader)
+	length, err := reader.Length()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, length)
+}
+
+func createDistributeMappingFromPatternAndTarget(t *testing.T) {
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
+
+	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out
+	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
 	createBundleParams.SpecFiles = []*utils.CommonParams{{Pattern: getRtTargetRepo() + "b.in", Target: getRtTargetRepo() + "b.out"}}
 	createBundleParams.SignImmediately = true
 	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
@@ -388,7 +443,54 @@ func createDistributeMapping(t *testing.T) {
 	assert.Equal(t, 1, length)
 }
 
-func createDistributeMappingPlaceholder(t *testing.T) {
+func createDistributeMappingWithPlaceholder(t *testing.T) {
+	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
+
+	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out
+	createBundleParams := services.NewCreateReleaseBundleParams(bundleName, bundleVersion)
+	createBundleParams.SpecFiles = []*utils.CommonParams{
+		{
+			Aql: utils.Aql{
+				ItemsFind: "{\"$or\":[{\"$and\":[{\"repo\":{\"$match\": \"" + strings.TrimSuffix(getRtTargetRepo(), "/") + "\"},\"name\":{\"$match\":\"*.in\"}}]}]}",
+			},
+			PathMapping: utils.PathMapping{
+				Input:  "(" + getRtTargetRepo() + ")" + "(.*).in",
+				Output: "$1$2.out",
+			},
+		},
+	}
+
+	createBundleParams.SignImmediately = true
+	summary, err := testsBundleCreateService.CreateReleaseBundle(createBundleParams)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer deleteRemoteAndLocalBundle(t, bundleName)
+	assert.NotNil(t, summary)
+	verifyValidSha256(t, summary.GetSha256())
+
+	// Distribute release bundle
+	distributeBundleParams := distribution.NewDistributeReleaseBundleParams(bundleName, bundleVersion)
+	distributeBundleParams.DistributionRules = []*distribution.DistributionCommonParams{{SiteName: "*"}}
+	testsBundleDistributeService.Sync = true
+	// On distribution with path mapping, the target repository cannot be auto-created
+	testsBundleDistributeService.AutoCreateRepo = false
+	testsBundleDistributeService.DistributeParams = distributeBundleParams
+	err = testsBundleDistributeService.Distribute()
+	assert.NoError(t, err)
+
+	// Make sure <RtTargetRepo>/b.out does exist in Artifactory
+	searchParams := artifactoryServices.NewSearchParams()
+	searchParams.Pattern = getRtTargetRepo() + "b.out"
+	reader, err := testsSearchService.Search(searchParams)
+	assert.NoError(t, err)
+	readerCloseAndAssert(t, reader)
+	length, err := reader.Length()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, length)
+}
+
+func createDistributeMappingFromPatternAndTargetWithPlaceholder(t *testing.T) {
 	bundleName := initRemoteDistributionTest(t, "client-test-bundle-"+getRunId())
 
 	// Create release bundle with path mapping from <RtTargetRepo>/b.in to <RtTargetRepo>/b.out

--- a/tests/distribution_test.go
+++ b/tests/distribution_test.go
@@ -45,17 +45,17 @@ func TestDistributionServices(t *testing.T) {
 	sendGpgKeys(t)
 
 	// Local release bundle tests
-	//t.Run("createDelete", createDelete)
-	//t.Run("createUpdate", createUpdate)
-	//t.Run("createWithProps", createWithProps)
+	t.Run("createDelete", createDelete)
+	t.Run("createUpdate", createUpdate)
+	t.Run("createWithProps", createWithProps)
 
 	// Remote release bundle tests
-	//t.Run("createSignDistributeDelete", createSignDistributeDelete)
-	//t.Run("createSignSyncDistributeDelete", createSignSyncDistributeDelete)
+	t.Run("createSignDistributeDelete", createSignDistributeDelete)
+	t.Run("createSignSyncDistributeDelete", createSignSyncDistributeDelete)
 	t.Run("createDistributeMapping", createDistributeMapping)
-	//t.Run("createDistributeMappingFromPatternAndTarget", createDistributeMappingFromPatternAndTarget)
-	//t.Run("createDistributeMappingWithPlaceholder", createDistributeMappingWithPlaceholder)
-	//t.Run("createDistributeMappingFromPatternAndTargetWithPlaceholder", createDistributeMappingFromPatternAndTargetWithPlaceholder)
+	t.Run("createDistributeMappingFromPatternAndTarget", createDistributeMappingFromPatternAndTarget)
+	t.Run("createDistributeMappingWithPlaceholder", createDistributeMappingWithPlaceholder)
+	t.Run("createDistributeMappingFromPatternAndTargetWithPlaceholder", createDistributeMappingFromPatternAndTargetWithPlaceholder)
 
 	artifactoryCleanup(t)
 	deleteGpgKeys(t)

--- a/utils/distribution/utils.go
+++ b/utils/distribution/utils.go
@@ -2,19 +2,20 @@ package distribution
 
 import (
 	"github.com/jfrog/gofrog/stringutils"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"regexp"
 )
 
 var fileSpecCaptureGroup = regexp.MustCompile(`({\d})`)
 
-// Create the path mapping from the input spec
-func CreatePathMappings(pattern, target string) []PathMapping {
+// Create the path mapping from the input spec which includes pattern and target
+func CreatePathMappingsFromPatternAndTarget(pattern, target string) []utils.PathMapping {
 	if len(target) == 0 {
-		return []PathMapping{}
+		return []utils.PathMapping{}
 	}
 
 	// Convert the file spec pattern and target to match the path mapping input and output specifications, respectfully.
-	return []PathMapping{{
+	return []utils.PathMapping{{
 		// The file spec pattern is wildcard based. Convert it to Regex:
 		Input: stringutils.WildcardPatternToRegExp(pattern),
 		// The file spec target contain placeholders-style matching groups, like {1}.
@@ -26,7 +27,14 @@ func CreatePathMappings(pattern, target string) []PathMapping {
 	}}
 }
 
-type PathMapping struct {
-	Input  string `json:"input"`
-	Output string `json:"output"`
+// Create the path mapping from the input spec
+func CreatePathMappings(input, output string) []utils.PathMapping {
+	if len(input) == 0 || len(output) == 0 {
+		return []utils.PathMapping{}
+	}
+
+	return []utils.PathMapping{{
+		Input:  input,
+		Output: output,
+	}}
 }

--- a/utils/distribution/utils_test.go
+++ b/utils/distribution/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCreatePathMappings(t *testing.T) {
+func TestCreatePathMappingsFromPatternAndTarget(t *testing.T) {
 	tests := []struct {
 		specPattern           string
 		specTarget            string
@@ -27,7 +27,41 @@ func TestCreatePathMappings(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.specPattern, func(t *testing.T) {
 			specFile := &utils.CommonParams{Pattern: test.specPattern, Target: test.specTarget}
-			pathMappings := CreatePathMappings(specFile.Pattern, specFile.Target)
+			pathMappings := CreatePathMappingsFromPatternAndTarget(specFile.Pattern, specFile.Target)
+			if test.expectedMappingInput == "" {
+				assert.Empty(t, pathMappings)
+				return
+			}
+			assert.Len(t, pathMappings, 1)
+			actualPathMapping := pathMappings[0]
+			assert.Equal(t, test.expectedMappingInput, actualPathMapping.Input)
+			assert.Equal(t, test.expectedMappingOutput, actualPathMapping.Output)
+		})
+	}
+}
+
+func TestCreatePathMappings(t *testing.T) {
+	tests := []struct {
+		specInput             string
+		specOutput            string
+		expectedMappingInput  string
+		expectedMappingOutput string
+	}{
+		{"", "", "", ""},
+		{"repo/path/file.in", "", "", ""},
+		{"", "repo/path/file.out", "", ""},
+		{"a/b/c", "a/b/x", "a/b/c", "a/b/x"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.specInput, func(t *testing.T) {
+			specFile := &utils.CommonParams{
+				PathMapping: utils.PathMapping{
+					Input:  test.specInput,
+					Output: test.specOutput,
+				},
+			}
+			pathMappings := CreatePathMappings(specFile.PathMapping.Input, specFile.PathMapping.Output)
 			if test.expectedMappingInput == "" {
 				assert.Empty(t, pathMappings)
 				return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Added support of "mappings" property to file spec in order to have the ability to control where to distribute the artifacts that are being added dynamically when using AQL in the release bundle that is being created.

When looking for docker artifacts using AQL, the release bundle also includes, in the distribution server backend, all the layers for a manifest.json and all of the manifest.json files and their layers if its a list.manifest.json

From now on the "mappings" will take affect on those none specified added manifests and layers and will allow the users a native way of creating the file spec for distribution commands.

FYI This couldn't be achieved using "target" for the list.manifest.json example.