### PR TITLE
Retry HTTP requests when receiving 429

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -131,8 +131,8 @@ func (jc *HttpClient) Send(method, url string, content []byte, followRedirect, c
 			if resp == nil {
 				return false, errorutils.CheckErrorf("%sReceived empty response from server", logMsgPrefix)
 			}
-			// If response-code < 500, should not retry
-			if resp.StatusCode < 500 {
+			// If response-code < 500 and it is not 429, should not retry
+			if resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
 				return false, nil
 			}
 			// Perform retry


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

HTTP responses might come back with a 429 error code, indicating "Too many requests." To help the client handle these errors better, we could enable retries.