### PR TITLE
Add multi_scan_id to scan params for sca scan flow

### DIFF
--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -46,6 +46,8 @@ const (
 
 	XscGraphAPI = "api/v1/sca/scan/graph"
 
+	multiScanIdParam = "multi_scan_id="
+
 	scanTechQueryParam = "tech="
 
 	XscVersionAPI = "api/v1/system/version"
@@ -83,6 +85,7 @@ func createScanGraphQueryParams(scanParams XrayGraphScanParams) string {
 	}
 
 	if scanParams.XscVersion != "" {
+		params = append(params, multiScanIdParam+scanParams.MultiScanId)
 		gitInfoContext := scanParams.XscGitInfoContext
 		if gitInfoContext != nil {
 			if len(gitInfoContext.Technologies) > 0 {
@@ -108,6 +111,7 @@ func (ss *ScanService) ScanGraph(scanParams XrayGraphScanParams) (string, error)
 		if err != nil {
 			return "", fmt.Errorf("failed sending Git Info to XSC service, error: %s ", err.Error())
 		}
+		scanParams.MultiScanId = multiScanId
 		if err = os.Setenv("JF_MSI", multiScanId); err != nil {
 			// Not a fatal error, if not set the scan will not be shown at the XSC UI, should not fail the scan.
 			log.Debug(fmt.Sprintf("failed setting MSI as environment variable. Cause: %s", err.Error()))
@@ -281,6 +285,7 @@ type XrayGraphScanParams struct {
 	IncludeLicenses        bool
 	XscGitInfoContext      *XscGitInfoContext
 	XscVersion             string
+	MultiScanId            string
 }
 
 type RequestScanResponse struct {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Adding back multi_scan_id to scan params for sca scan flow (xsc is expecting the multi_scan_id as query param).
PR for jfrog-cli-security for test purposes:
https://github.com/jfrog/jfrog-cli-security/pull/15 