### PR TITLE
Artifactory Release Lifecycle Management - Modify release bundle promotion properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -2396,13 +2396,12 @@ lifecycleManager, err := lifecycle.New(serviceConfig)
 
 ```go
 rbDetails := ReleaseBundleDetails{"rbName", "rbVersion"}
-params := CreateOrPromoteReleaseBundleParams{}
-// The GPG/RSA key-pair name given in Artifactory.
-params.SigningKeyName = "key-pair"
-// Optional:
-params.ProjectKey = "project"
-params.Async = true
+queryParams := CommonOptionalQueryParams{}
+queryParams.ProjectKey = "project"
+queryParams.Async = true
 
+// The GPG/RSA key-pair name given in Artifactory.
+signingKeyName = "key-pair"
 
 source := CreateFromBuildsSource{Builds: []BuildSource{
     {
@@ -2412,19 +2411,19 @@ source := CreateFromBuildsSource{Builds: []BuildSource{
         BuildRepository: "artifactory-build-info",
     },
 }}
-serviceManager.CreateReleaseBundleFromBuilds(rbDetails, params, source)
+serviceManager.CreateReleaseBundleFromBuilds(rbDetails, queryParams, signingKeyName, source)
 ```
 
 #### Creating a Release Bundle From Release Bundles
 
 ```go
 rbDetails := ReleaseBundleDetails{"rbName", "rbVersion"}
-params := CreateOrPromoteReleaseBundleParams{}
+queryParams := CommonOptionalQueryParams{}
+queryParams.ProjectKey = "project"
+queryParams.Async = true
+
 // The GPG/RSA key-pair name given in Artifactory.
-params.SigningKeyName = "key-pair"
-// Optional:
-params.ProjectKey = "project"
-params.Async = true
+signingKeyName = "key-pair"
 
 source := CreateFromReleaseBundlesSource{ReleaseBundles: []ReleaseBundleSource{
     {
@@ -2433,23 +2432,25 @@ source := CreateFromReleaseBundlesSource{ReleaseBundles: []ReleaseBundleSource{
        ProjectKey:           "default",
     },
 }}
-serviceManager.CreateReleaseBundleFromBundles(rbDetails, params, source)
+serviceManager.CreateReleaseBundleFromBundles(rbDetails, params, signingKeyName, source)
 ```
 
 #### Promoting a Release Bundle
 
 ```go
 rbDetails := ReleaseBundleDetails{"rbName", "rbVersion"}
-params := CreateOrPromoteReleaseBundleParams{}
-// The GPG/RSA key-pair name given in Artifactory.
-params.SigningKeyName = "key-pair"
-// Optional:
-params.ProjectKey = "project"
-params.Async = true
+queryParams := CommonOptionalQueryParams{}
+queryParams.ProjectKey = "project"
+queryParams.Async = true
 
-environment := "target-env"
-overwrite:=true
-resp, err := serviceManager.PromoteReleaseBundle(rbDetails, params, environment, overwrite)
+// The GPG/RSA key-pair name given in Artifactory.
+signingKeyName = "key-pair"
+
+promotionParams := RbPromotionParams{}
+promotionParams.Environment := "target-env"
+promotionParams.IncludedRepositoryKeys := []string{"generic-local"}
+
+resp, err := serviceManager.PromoteReleaseBundle(rbDetails, queryParams, signingKeyName, promotionParams)
 ```
 
 #### Get Release Bundle Creation Status
@@ -2498,14 +2499,11 @@ resp, err := serviceManager.DistributeReleaseBundle(params, autoCreateRepo, path
 
 ```go
 rbDetails := ReleaseBundleDetails{"rbName", "rbVersion"}
-params := CreateOrPromoteReleaseBundleParams{}
-// The GPG/RSA key-pair name given in Artifactory.
-params.SigningKeyName = "key-pair"
-// Optional:
-params.ProjectKey = "project"
-params.Async = true
+queryParams := CommonOptionalQueryParams{}
+queryParams.ProjectKey = "project"
+queryParams.Async = true
 
-resp, err := serviceManager.DeleteReleaseBundle(rbDetails, params)
+resp, err := serviceManager.DeleteReleaseBundle(rbDetails, queryParams)
 ```
 
 #### Remote Delete Release Bundle

--- a/lifecycle/manager.go
+++ b/lifecycle/manager.go
@@ -37,20 +37,20 @@ func (lcs *LifecycleServicesManager) Client() *jfroghttpclient.JfrogHttpClient {
 }
 
 func (lcs *LifecycleServicesManager) CreateReleaseBundleFromBuilds(rbDetails lifecycle.ReleaseBundleDetails,
-	params lifecycle.CreateOrPromoteReleaseBundleParams, sourceBuilds lifecycle.CreateFromBuildsSource) error {
+	queryParams lifecycle.CommonOptionalQueryParams, signingKeyName string, sourceBuilds lifecycle.CreateFromBuildsSource) error {
 	rbService := lifecycle.NewReleaseBundlesService(lcs.config.GetServiceDetails(), lcs.client)
-	return rbService.CreateFromBuilds(rbDetails, params, sourceBuilds)
+	return rbService.CreateFromBuilds(rbDetails, queryParams, signingKeyName, sourceBuilds)
 }
 
 func (lcs *LifecycleServicesManager) CreateReleaseBundleFromBundles(rbDetails lifecycle.ReleaseBundleDetails,
-	params lifecycle.CreateOrPromoteReleaseBundleParams, sourceReleaseBundles lifecycle.CreateFromReleaseBundlesSource) error {
+	queryParams lifecycle.CommonOptionalQueryParams, signingKeyName string, sourceReleaseBundles lifecycle.CreateFromReleaseBundlesSource) error {
 	rbService := lifecycle.NewReleaseBundlesService(lcs.config.GetServiceDetails(), lcs.client)
-	return rbService.CreateFromBundles(rbDetails, params, sourceReleaseBundles)
+	return rbService.CreateFromBundles(rbDetails, queryParams, signingKeyName, sourceReleaseBundles)
 }
 
-func (lcs *LifecycleServicesManager) PromoteReleaseBundle(rbDetails lifecycle.ReleaseBundleDetails, params lifecycle.CreateOrPromoteReleaseBundleParams, environment string, overwrite bool) (lifecycle.RbPromotionResp, error) {
+func (lcs *LifecycleServicesManager) PromoteReleaseBundle(rbDetails lifecycle.ReleaseBundleDetails, queryParams lifecycle.CommonOptionalQueryParams, signingKeyName string, promotionParams lifecycle.RbPromotionParams) (lifecycle.RbPromotionResp, error) {
 	rbService := lifecycle.NewReleaseBundlesService(lcs.config.GetServiceDetails(), lcs.client)
-	return rbService.Promote(rbDetails, params, environment, overwrite)
+	return rbService.Promote(rbDetails, queryParams, signingKeyName, promotionParams)
 }
 
 func (lcs *LifecycleServicesManager) GetReleaseBundleCreationStatus(rbDetails lifecycle.ReleaseBundleDetails, projectKey string, sync bool) (lifecycle.ReleaseBundleStatusResponse, error) {
@@ -63,9 +63,9 @@ func (lcs *LifecycleServicesManager) GetReleaseBundlePromotionStatus(rbDetails l
 	return rbService.GetReleaseBundlePromotionStatus(rbDetails, projectKey, createdMillis, sync)
 }
 
-func (lcs *LifecycleServicesManager) DeleteReleaseBundle(rbDetails lifecycle.ReleaseBundleDetails, params lifecycle.ReleaseBundleQueryParams) error {
+func (lcs *LifecycleServicesManager) DeleteReleaseBundle(rbDetails lifecycle.ReleaseBundleDetails, queryParams lifecycle.CommonOptionalQueryParams) error {
 	rbService := lifecycle.NewReleaseBundlesService(lcs.config.GetServiceDetails(), lcs.client)
-	return rbService.DeleteReleaseBundle(rbDetails, params)
+	return rbService.DeleteReleaseBundle(rbDetails, queryParams)
 }
 
 func (lcs *LifecycleServicesManager) DistributeReleaseBundle(params distribution.DistributionParams, autoCreateRepo bool, pathMapping lifecycle.PathMapping) error {

--- a/lifecycle/services/create.go
+++ b/lifecycle/services/create.go
@@ -12,8 +12,9 @@ const (
 )
 
 type createOperation struct {
-	reqBody RbCreationBody
-	params  CreateOrPromoteReleaseBundleParams
+	reqBody        RbCreationBody
+	params         CommonOptionalQueryParams
+	signingKeyName string
 }
 
 func (c *createOperation) getOperationRestApi() string {
@@ -28,29 +29,35 @@ func (c *createOperation) getOperationSuccessfulMsg() string {
 	return "Release Bundle successfully created"
 }
 
-func (c *createOperation) getOperationParams() CreateOrPromoteReleaseBundleParams {
+func (c *createOperation) getOperationParams() CommonOptionalQueryParams {
 	return c.params
 }
 
-func (rbs *ReleaseBundlesService) CreateFromBuilds(rbDetails ReleaseBundleDetails, params CreateOrPromoteReleaseBundleParams, sourceBuilds CreateFromBuildsSource) error {
+func (c *createOperation) getSigningKeyName() string {
+	return c.signingKeyName
+}
+
+func (rbs *ReleaseBundlesService) CreateFromBuilds(rbDetails ReleaseBundleDetails, params CommonOptionalQueryParams, signingKeyName string, sourceBuilds CreateFromBuildsSource) error {
 	operation := createOperation{
 		reqBody: RbCreationBody{
 			ReleaseBundleDetails: rbDetails,
 			SourceType:           builds,
 			Source:               sourceBuilds},
-		params: params,
+		params:         params,
+		signingKeyName: signingKeyName,
 	}
 	_, err := rbs.doOperation(&operation)
 	return err
 }
 
-func (rbs *ReleaseBundlesService) CreateFromBundles(rbDetails ReleaseBundleDetails, params CreateOrPromoteReleaseBundleParams, sourceReleaseBundles CreateFromReleaseBundlesSource) error {
+func (rbs *ReleaseBundlesService) CreateFromBundles(rbDetails ReleaseBundleDetails, params CommonOptionalQueryParams, signingKeyName string, sourceReleaseBundles CreateFromReleaseBundlesSource) error {
 	operation := createOperation{
 		reqBody: RbCreationBody{
 			ReleaseBundleDetails: rbDetails,
 			SourceType:           releaseBundles,
 			Source:               sourceReleaseBundles},
-		params: params,
+		params:         params,
+		signingKeyName: signingKeyName,
 	}
 	_, err := rbs.doOperation(&operation)
 	return err

--- a/lifecycle/services/delete.go
+++ b/lifecycle/services/delete.go
@@ -15,7 +15,7 @@ const (
 	remoteDeleteEndpoint = "remote_delete"
 )
 
-func (rbs *ReleaseBundlesService) DeleteReleaseBundle(rbDetails ReleaseBundleDetails, params ReleaseBundleQueryParams) error {
+func (rbs *ReleaseBundlesService) DeleteReleaseBundle(rbDetails ReleaseBundleDetails, params CommonOptionalQueryParams) error {
 	queryParams := getProjectQueryParam(params.ProjectKey)
 	queryParams[async] = strconv.FormatBool(params.Async)
 	restApi := path.Join(releaseBundleBaseApi, records, rbDetails.ReleaseBundleName, rbDetails.ReleaseBundleVersion)

--- a/lifecycle/services/operation.go
+++ b/lifecycle/services/operation.go
@@ -31,7 +31,8 @@ type ReleaseBundleOperation interface {
 	getOperationRestApi() string
 	getRequestBody() any
 	getOperationSuccessfulMsg() string
-	getOperationParams() CreateOrPromoteReleaseBundleParams
+	getOperationParams() CommonOptionalQueryParams
+	getSigningKeyName() string
 }
 
 func (rbs *ReleaseBundlesService) doOperation(operation ReleaseBundleOperation) ([]byte, error) {
@@ -43,7 +44,7 @@ func (rbs *ReleaseBundlesService) doOperation(operation ReleaseBundleOperation) 
 	}
 
 	httpClientDetails := rbs.GetLifecycleDetails().CreateHttpClientDetails()
-	rtUtils.AddSigningKeyNameHeader(operation.getOperationParams().SigningKeyName, &httpClientDetails.Headers)
+	rtUtils.AddSigningKeyNameHeader(operation.getSigningKeyName(), &httpClientDetails.Headers)
 	rtUtils.SetContentType("application/json", &httpClientDetails.Headers)
 
 	content, err := json.Marshal(operation.getRequestBody())
@@ -79,13 +80,7 @@ type ReleaseBundleDetails struct {
 	ReleaseBundleVersion string `json:"release_bundle_version,omitempty"`
 }
 
-type CreateOrPromoteReleaseBundleParams struct {
-	ReleaseBundleQueryParams
-	// Header:
-	SigningKeyName string
-}
-
-type ReleaseBundleQueryParams struct {
+type CommonOptionalQueryParams struct {
 	ProjectKey string
 	Async      bool
 }

--- a/lifecycle/services/promote.go
+++ b/lifecycle/services/promote.go
@@ -12,9 +12,10 @@ const (
 )
 
 type promoteOperation struct {
-	reqBody   RbPromotionBody
-	rbDetails ReleaseBundleDetails
-	params    CreateOrPromoteReleaseBundleParams
+	reqBody        RbPromotionBody
+	rbDetails      ReleaseBundleDetails
+	queryParams    CommonOptionalQueryParams
+	signingKeyName string
 }
 
 func (p *promoteOperation) getOperationRestApi() string {
@@ -29,18 +30,24 @@ func (p *promoteOperation) getOperationSuccessfulMsg() string {
 	return "Release Bundle successfully promoted"
 }
 
-func (p *promoteOperation) getOperationParams() CreateOrPromoteReleaseBundleParams {
-	return p.params
+func (p *promoteOperation) getOperationParams() CommonOptionalQueryParams {
+	return p.queryParams
 }
 
-func (rbs *ReleaseBundlesService) Promote(rbDetails ReleaseBundleDetails, params CreateOrPromoteReleaseBundleParams, environment string, overwrite bool) (RbPromotionResp, error) {
+func (p *promoteOperation) getSigningKeyName() string {
+	return p.signingKeyName
+}
+
+func (rbs *ReleaseBundlesService) Promote(rbDetails ReleaseBundleDetails, queryParams CommonOptionalQueryParams, signingKeyName string, promotionParams RbPromotionParams) (RbPromotionResp, error) {
 	operation := promoteOperation{
 		reqBody: RbPromotionBody{
-			Environment: environment,
-			Overwrite:   overwrite,
+			Environment:            promotionParams.Environment,
+			IncludedRepositoryKeys: promotionParams.IncludedRepositoryKeys,
+			ExcludedRepositoryKeys: promotionParams.ExcludedRepositoryKeys,
 		},
-		rbDetails: rbDetails,
-		params:    params,
+		rbDetails:      rbDetails,
+		queryParams:    queryParams,
+		signingKeyName: signingKeyName,
 	}
 	respBody, err := rbs.doOperation(&operation)
 	if err != nil {
@@ -51,9 +58,14 @@ func (rbs *ReleaseBundlesService) Promote(rbDetails ReleaseBundleDetails, params
 	return promotionResp, errorutils.CheckError(err)
 }
 
+type RbPromotionParams struct {
+	Environment            string
+	IncludedRepositoryKeys []string
+	ExcludedRepositoryKeys []string
+}
+
 type RbPromotionBody struct {
 	Environment            string   `json:"environment,omitempty"`
-	Overwrite              bool     `json:"overwrite_existing_artifacts,omitempty"`
 	IncludedRepositoryKeys []string `json:"included_repository_keys,omitempty"`
 	ExcludedRepositoryKeys []string `json:"excluded_repository_keys,omitempty"`
 }

--- a/lifecycle/services/promote.go
+++ b/lifecycle/services/promote.go
@@ -40,11 +40,7 @@ func (p *promoteOperation) getSigningKeyName() string {
 
 func (rbs *ReleaseBundlesService) Promote(rbDetails ReleaseBundleDetails, queryParams CommonOptionalQueryParams, signingKeyName string, promotionParams RbPromotionParams) (RbPromotionResp, error) {
 	operation := promoteOperation{
-		reqBody: RbPromotionBody{
-			Environment:            promotionParams.Environment,
-			IncludedRepositoryKeys: promotionParams.IncludedRepositoryKeys,
-			ExcludedRepositoryKeys: promotionParams.ExcludedRepositoryKeys,
-		},
+		reqBody:        RbPromotionBody(promotionParams),
 		rbDetails:      rbDetails,
 		queryParams:    queryParams,
 		signingKeyName: signingKeyName,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Breaking changes:
- Changed signature of creation and promotion services.
- Removed the `overwrite_existing_artifacts` promotion option that has been decommissioned as of 7.75.0 (both from UI and API).

Improvement:
- Support for include/exclude repositories in release bundle promotion.