### PR TITLE
Tweak multipart upload polling

### DIFF
--- a/artifactory/services/utils/multipartupload.go
+++ b/artifactory/services/utils/multipartupload.go
@@ -49,8 +49,8 @@ const (
 	aborted           completionStatus = "ABORTED"
 
 	// API constants
-	uploadsApi              = "/api/v1/uploads/"
-	artifactoryNodeIdHeader = "X-Artifactory-Node-Id"
+	uploadsApi    = "/api/v1/uploads/"
+	routeToHeader = "X-JFrog-Route-To"
 
 	// Sizes and limits constants
 	MaxMultipartUploadFileSize       = SizeTiB * 5
@@ -312,7 +312,7 @@ func (mu *MultipartUpload) completeAndPollForStatus(logMsgPrefix string, complet
 
 func (mu *MultipartUpload) pollCompletionStatus(logMsgPrefix string, completionAttemptsLeft uint, sha1, nodeId string, multipartUploadClient *httputils.HttpClientDetails, progressReader ioutils.Progress) error {
 	multipartUploadClientWithNodeId := multipartUploadClient.Clone()
-	multipartUploadClientWithNodeId.Headers = map[string]string{artifactoryNodeIdHeader: nodeId}
+	multipartUploadClientWithNodeId.Headers = map[string]string{routeToHeader: nodeId}
 
 	lastMergeLog := time.Now()
 	pollingExecutor := &utils.RetryExecutor{
@@ -363,7 +363,7 @@ func (mu *MultipartUpload) completeMultipartUpload(logMsgPrefix, sha1 string, mu
 		return "", err
 	}
 	log.Debug("Artifactory response:", string(body), resp.Status)
-	return resp.Header.Get(artifactoryNodeIdHeader), errorutils.CheckResponseStatusWithBody(resp, body, http.StatusAccepted)
+	return resp.Header.Get(routeToHeader), errorutils.CheckResponseStatusWithBody(resp, body, http.StatusAccepted)
 }
 
 func (mu *MultipartUpload) status(logMsgPrefix string, multipartUploadClientWithNodeId *httputils.HttpClientDetails) (status statusResponse, err error) {

--- a/artifactory/services/utils/multipartupload_test.go
+++ b/artifactory/services/utils/multipartupload_test.go
@@ -186,8 +186,8 @@ func TestCompleteMultipartUpload(t *testing.T) {
 		assert.Equal(t, "/api/v1/uploads/complete", r.URL.Path)
 		assert.Equal(t, fmt.Sprintf("sha1=%s", sha1), r.URL.RawQuery)
 
-		// Add the "X-Artifactory-Node-Id" header to the response
-		w.Header().Add(artifactoryNodeIdHeader, nodeId)
+		// Add the "X-JFrog-Route-To" header to the response
+		w.Header().Add(routeToHeader, nodeId)
 
 		// Send response 202 Accepted
 		w.WriteHeader(http.StatusAccepted)
@@ -211,8 +211,8 @@ func TestStatus(t *testing.T) {
 		// Check URL
 		assert.Equal(t, "/api/v1/uploads/status", r.URL.Path)
 
-		// Check "X-Artifactory-Node-Id" header
-		assert.Equal(t, nodeId, r.Header.Get(artifactoryNodeIdHeader))
+		// Check "X-JFrog-Route-To" header
+		assert.Equal(t, nodeId, r.Header.Get(routeToHeader))
 
 		// Send response 200 OK
 		w.WriteHeader(http.StatusOK)
@@ -227,7 +227,7 @@ func TestStatus(t *testing.T) {
 	defer cleanUp()
 
 	// Execute status
-	clientDetails := &httputils.HttpClientDetails{Headers: map[string]string{artifactoryNodeIdHeader: nodeId}}
+	clientDetails := &httputils.HttpClientDetails{Headers: map[string]string{routeToHeader: nodeId}}
 	status, err := multipartUpload.status("", clientDetails)
 	assert.NoError(t, err)
 	assert.Equal(t, statusResponse{Status: finished, Progress: utils.Pointer(100)}, status)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Use `X-JFrog-Route-To` header instead of `X-Artifactory-Node-Id`.
* If the system receives a "service unavailable" error (status code 503) when checking the upload status using the API call `GET /api/v1/uploads/status`, the completion process will be retried on a different node.