### PR TITLE
Fix to close response body before status check

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -331,14 +331,14 @@ func (jc *HttpClient) UploadFileFromReader(reader io.Reader, url string, httpCli
 	if errorutils.CheckError(err) != nil || resp == nil {
 		return
 	}
-	if err = errorutils.CheckResponseStatus(resp, http.StatusCreated, http.StatusOK, http.StatusAccepted); err != nil {
-		return
-	}
 	defer func() {
 		if resp != nil && resp.Body != nil {
 			err = errors.Join(err, errorutils.CheckError(resp.Body.Close()))
 		}
 	}()
+	if err = errorutils.CheckResponseStatus(resp, http.StatusCreated, http.StatusOK, http.StatusAccepted); err != nil {
+		return
+	}
 	body, err = io.ReadAll(resp.Body)
 	err = errorutils.CheckError(err)
 	return


### PR DESCRIPTION
`httpclient.HttpClient.UploadFileFromReader()` used to not to close the HTTP response body when the status code is unexpected. The defer block for this should be appended right after the HTTP call is made.

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----