### PR TITLE
Multipart upload - Set the the checksum deploy token

### DIFF
--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -624,11 +624,13 @@ func (us *UploadService) doUpload(artifact UploadData, targetUrlWithProps, logMs
 		return
 	}
 	if shouldTryMultipart {
-		if err = us.MultipartUpload.UploadFileConcurrently(artifact.Artifact.LocalPath, artifact.Artifact.TargetPath,
+		var checksumToken string
+		if checksumToken, err = us.MultipartUpload.UploadFileConcurrently(artifact.Artifact.LocalPath, artifact.Artifact.TargetPath,
 			fileInfo.Size(), details.Checksum.Sha1, us.Progress, uploadParams.SplitCount, uploadParams.ChunkSize); err != nil {
 			return
 		}
 		// Once the file is uploaded to the storage, we finalize the multipart upload by performing a checksum deployment to save the file in Artifactory.
+		utils.AddChecksumTokenHeader(httpClientsDetails.Headers, checksumToken)
 		resp, body, err = us.doChecksumDeploy(details, targetUrlWithProps, httpClientsDetails, us.client)
 		return
 	}

--- a/artifactory/services/utils/artifactoryutils.go
+++ b/artifactory/services/utils/artifactoryutils.go
@@ -68,6 +68,12 @@ func AddChecksumHeaders(headers map[string]string, fileDetails *fileutils.FileDe
 	}
 }
 
+// Add the checksum token header to the headers map.
+// This header enables Artifactory to accept the Checksum Deployment of a file uploaded via multipart upload.
+func AddChecksumTokenHeader(headers map[string]string, checksumToken string) {
+	AddHeader("X-Checksum-Deploy-Token", checksumToken, &headers)
+}
+
 func AddAuthHeaders(headers map[string]string, artifactoryDetails auth.ServiceDetails) {
 	if headers == nil {
 		headers = make(map[string]string)

--- a/artifactory/services/utils/multipartupload_test.go
+++ b/artifactory/services/utils/multipartupload_test.go
@@ -20,17 +20,18 @@ import (
 )
 
 const (
-	localPath  = "localPath"
-	repoKey    = "repoKey"
-	repoPath   = "repoPath"
-	partSize   = SizeGiB
-	partSizeMB = 1024
-	partNumber = 2
-	splitCount = 3
-	token      = "token"
-	partUrl    = "http://dummy-url-part"
-	sha1       = "sha1"
-	nodeId     = "nodeId"
+	localPath     = "localPath"
+	repoKey       = "repoKey"
+	repoPath      = "repoPath"
+	partSize      = SizeGiB
+	partSizeMB    = 1024
+	partNumber    = 2
+	splitCount    = 3
+	token         = "token"
+	partUrl       = "http://dummy-url-part"
+	sha1          = "sha1"
+	nodeId        = "nodeId"
+	checksumToken = "checksumToken"
 )
 
 func TestIsSupported(t *testing.T) {
@@ -209,7 +210,7 @@ func TestStatus(t *testing.T) {
 
 		// Send response 200 OK
 		w.WriteHeader(http.StatusOK)
-		response, err := json.Marshal(statusResponse{Status: finished, Progress: utils.Pointer(100)})
+		response, err := json.Marshal(statusResponse{Status: finished, Progress: utils.Pointer(100), ChecksumToken: checksumToken})
 		assert.NoError(t, err)
 		_, err = w.Write(response)
 		assert.NoError(t, err)
@@ -222,7 +223,7 @@ func TestStatus(t *testing.T) {
 	// Execute status
 	status, err := multipartUpload.status("", &httputils.HttpClientDetails{})
 	assert.NoError(t, err)
-	assert.Equal(t, statusResponse{Status: finished, Progress: utils.Pointer(100)}, status)
+	assert.Equal(t, statusResponse{Status: finished, Progress: utils.Pointer(100), ChecksumToken: checksumToken}, status)
 }
 
 func TestStatusServiceUnavailable(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add the `X-Checksum-Deploy-Token` header to the checksum deploy request after a multipart upload.