### PR TITLE
Add and use a new IsPathAccessible API before accessing the .git dir

### DIFF
--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	biutils "github.com/jfrog/build-info-go/utils"
 	"io"
 	"net/url"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	biutils "github.com/jfrog/build-info-go/utils"
 
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/gofrog/crypto"
@@ -36,7 +37,7 @@ func GetFileSeparator() string {
 // function will return `true` regardless of the symlink target
 func IsPathExists(path string, preserveSymLink bool) bool {
 	_, err := GetFileInfo(path, preserveSymLink)
-	return !os.IsNotExist(err)
+	return err != nil
 }
 
 // Check if path points at a file.

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -43,7 +43,7 @@ func IsPathExists(path string, preserveSymLink bool) bool {
 // Checks if the path is accessible.
 func IsPathAccessible(path string) bool {
 	_, err := GetFileInfo(path, true)
-	return err != nil
+	return err == nil
 }
 
 // Check if path points at a file.

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -32,11 +32,17 @@ func GetFileSeparator() string {
 	return string(os.PathSeparator)
 }
 
-// Check if path exists.
+// Checks if the path exists.
 // If path points at a symlink and `preserveSymLink == true`,
 // function will return `true` regardless of the symlink target
 func IsPathExists(path string, preserveSymLink bool) bool {
 	_, err := GetFileInfo(path, preserveSymLink)
+	return !os.IsNotExist(err)
+}
+
+// Checks if the path is accessible.
+func IsPathAccessible(path string) bool {
+	_, err := GetFileInfo(path, true)
 	return err != nil
 }
 

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -15,10 +15,16 @@ import (
 )
 
 func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
+	var symlinkPath string
+	symlinkCreated := false
+
 	// Create a temporary file
 	tempFile, err := os.CreateTemp("", "testfile")
 	assert.NoError(t, err)
 	defer func() {
+		if symlinkCreated {
+			assert.NoError(t, os.Remove(symlinkPath))
+		}
 		assert.NoError(t, os.Remove(tempFile.Name()))
 	}()
 
@@ -45,12 +51,10 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	assert.False(t, IsPathAccessible(tempDir+"_nonexistent"))
 
 	// Create a symlink and test with preserveSymLink true and false
-	symlinkPath := tempFile.Name() + "_symlink"
+	symlinkPath = tempFile.Name() + "_symlink"
 	err = os.Symlink(tempFile.Name(), symlinkPath)
 	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.Remove(symlinkPath))
-	}()
+	symlinkCreated = true
 
 	assert.True(t, IsPathExists(symlinkPath, true))
 	assert.True(t, IsPathExists(symlinkPath, false))

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -70,12 +70,13 @@ func TestIsPathAccessible(t *testing.T) {
 		assert.NoError(t, os.Chmod(tempFile.Name(), 0644))
 	}()
 
-	// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the file.
-	// Therefore, we'll try to open the file explicitly to confirm inaccessibility.
-	_, err = os.Open(tempFile.Name())
-	assert.Error(t, err, "Expected error when trying to open a file with 0000 permissions")
 	if io.IsWindows() {
 		assert.False(t, IsPathAccessible(tempFile.Name()), "IsPathAccessible should return false for a file with 0000 permissions")
+	} else {
+		// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the file.
+		// Therefore, we'll try to open the file explicitly to confirm inaccessibility.
+		_, err = os.Open(tempFile.Name())
+		assert.Error(t, err, "Expected error when trying to open a file with 0000 permissions")
 	}
 
 	// Create a temporary directory
@@ -95,11 +96,13 @@ func TestIsPathAccessible(t *testing.T) {
 	}()
 
 	// Try to read the directory to confirm inaccessibility
-	_, err = os.ReadDir(tempDir)
-	assert.Error(t, err, "Expected error when trying to read a directory with 0000 permissions")
-	// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the directory.
 	if io.IsWindows() {
 		assert.False(t, IsPathAccessible(tempDir), "IsPathAccessible should return false for a directory with 0000 permissions")
+	} else {
+		// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the directory.
+		// Therefore, we'll try to access the directory explicitly to confirm inaccessibility.
+		_, err = os.ReadDir(tempDir)
+		assert.Error(t, err, "Expected error when trying to read a directory with 0000 permissions")
 	}
 }
 

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -26,6 +26,7 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	assert.NoError(t, tempFile.Close())
 
 	defer func() {
+		// Close the symlink before closing the file it references.
 		if symlinkCreated {
 			assert.NoError(t, os.Remove(symlinkPath))
 		}
@@ -58,6 +59,9 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	symlinkPath = tempFile.Name() + "_symlink"
 	err = os.Symlink(tempFile.Name(), symlinkPath)
 	assert.NoError(t, err)
+	// It is best to close the symlink before closing the file it
+	// references. We use this variable to flag to the defer function
+	// to close the symlink.
 	symlinkCreated = true
 
 	assert.True(t, IsPathExists(symlinkPath, true))

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -55,9 +55,9 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	symlinkPath = tempFile.Name() + "_symlink"
 	err = os.Symlink(tempFile.Name(), symlinkPath)
 	assert.NoError(t, err)
-	// It is best to close the symlink before closing the file it
+	// It is best to remove the symlink before removing the file it
 	// references. We use this variable to flag to the defer function
-	// to close the symlink.
+	// to remove the symlink.
 	symlinkCreated = true
 
 	assert.True(t, IsPathExists(symlinkPath, true))

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -1,8 +1,6 @@
 package fileutils
 
 import (
-	biutils "github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/jfrog-client-go/utils/io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,8 +8,90 @@ import (
 	"strings"
 	"testing"
 
+	biutils "github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIsPathExists(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "testfile")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Remove(tempFile.Name()))
+	}()
+
+	// Test for an existing file
+	assert.True(t, IsPathExists(tempFile.Name(), false))
+
+	// Test for a non-existing file
+	assert.False(t, IsPathExists(tempFile.Name()+"_nonexistent", false))
+
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "testdir")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	// Test for an existing directory
+	assert.True(t, IsPathExists(tempDir, false))
+
+	// Test for a non-existing directory
+	assert.False(t, IsPathExists(tempDir+"_nonexistent", false))
+
+	// Create a symlink and test with preserveSymLink true and false
+	symlinkPath := tempFile.Name() + "_symlink"
+	err = os.Symlink(tempFile.Name(), symlinkPath)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Remove(symlinkPath))
+	}()
+
+	assert.True(t, IsPathExists(symlinkPath, true))
+	assert.True(t, IsPathExists(symlinkPath, false))
+}
+
+func TestIsPathAccessible(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "testfile")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Remove(tempFile.Name()))
+	}()
+
+	// Test for an accessible file
+	assert.True(t, IsPathAccessible(tempFile.Name()))
+
+	// Change the file permissions to make it inaccessible
+	assert.NoError(t, os.Chmod(tempFile.Name(), 0000))
+	defer func() {
+		assert.NoError(t, os.Chmod(tempFile.Name(), 0644))
+	}()
+
+	// Test for an inaccessible file
+	assert.False(t, IsPathAccessible(tempFile.Name()))
+
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "testdir")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	// Test for an accessible directory
+	assert.True(t, IsPathAccessible(tempDir))
+
+	// Change the directory permissions to make it inaccessible
+	assert.NoError(t, os.Chmod(tempDir, 0000))
+	defer func() {
+		assert.NoError(t, os.Chmod(tempDir, 0755))
+	}()
+
+	// Test for an inaccessible directory
+	assert.False(t, IsPathAccessible(tempDir))
+}
 
 func TestIsSsh(t *testing.T) {
 	testRuns := []struct {

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -70,11 +70,13 @@ func TestIsPathAccessible(t *testing.T) {
 		assert.NoError(t, os.Chmod(tempFile.Name(), 0644))
 	}()
 
-	// On Linux, even with chmod 0000, the owner may still be able to access the file.
+	// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the file.
 	// Therefore, we'll try to open the file explicitly to confirm inaccessibility.
 	_, err = os.Open(tempFile.Name())
 	assert.Error(t, err, "Expected error when trying to open a file with 0000 permissions")
-	assert.False(t, IsPathAccessible(tempFile.Name()), "IsPathAccessible should return false for a file with 0000 permissions")
+	if io.IsWindows() {
+		assert.False(t, IsPathAccessible(tempFile.Name()), "IsPathAccessible should return false for a file with 0000 permissions")
+	}
 
 	// Create a temporary directory
 	tempDir, err := os.MkdirTemp("", "testdir")
@@ -95,7 +97,10 @@ func TestIsPathAccessible(t *testing.T) {
 	// Try to read the directory to confirm inaccessibility
 	_, err = os.ReadDir(tempDir)
 	assert.Error(t, err, "Expected error when trying to read a directory with 0000 permissions")
-	assert.False(t, IsPathAccessible(tempDir), "IsPathAccessible should return false for a directory with 0000 permissions")
+	// On Linux and Mac, unlike Windows, even with chmod 0000, the owner may still be able to access the directory.
+	if io.IsWindows() {
+		assert.False(t, IsPathAccessible(tempDir), "IsPathAccessible should return false for a directory with 0000 permissions")
+	}
 }
 
 func TestIsSsh(t *testing.T) {

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -10,6 +10,7 @@ import (
 
 	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +23,8 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	tempFile, err := os.CreateTemp("", "testfile")
 	assert.NoError(t, err)
 	defer func() {
+		log.Info("*********")
+		log.Info(symlinkCreated)
 		if symlinkCreated {
 			assert.NoError(t, os.Remove(symlinkPath))
 		}

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -26,7 +26,7 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	assert.NoError(t, tempFile.Close())
 
 	defer func() {
-		// Close the symlink before closing the file it references.
+		// Remove the symlink before removing the file it references.
 		if symlinkCreated {
 			assert.NoError(t, os.Remove(symlinkPath))
 		}
@@ -41,11 +41,7 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	assert.False(t, IsPathExists(tempFile.Name()+"_nonexistent", false))
 
 	// Create a temporary directory
-	tempDir, err := os.MkdirTemp("", "testdir")
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	// Test for an existing directory
 	assert.True(t, IsPathExists(tempDir, false))

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -10,7 +10,6 @@ import (
 
 	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,9 +21,11 @@ func TestIsPathExistsAndIsPathAccessible(t *testing.T) {
 	// Create a temporary file
 	tempFile, err := os.CreateTemp("", "testfile")
 	assert.NoError(t, err)
+
+	// Close the file immediately after creation to ensure it is not locked
+	assert.NoError(t, tempFile.Close())
+
 	defer func() {
-		log.Info("*********")
-		log.Info(symlinkCreated)
 		if symlinkCreated {
 			assert.NoError(t, os.Remove(symlinkPath))
 		}

--- a/utils/vcsdetails.go
+++ b/utils/vcsdetails.go
@@ -42,9 +42,10 @@ func (vc *VcsCache) getCacheSize() int32 {
 	return atomic.LoadInt32(vc.vcsDirSize)
 }
 
-// Search for '.git' directory inside 'path', incase there is one, extract the details and add a new entry to the cache(key:path in the file system ,value: git revision & url).
-// otherwise, search in the parent folder and try:
-// 1. search for .git, and save the details for the current dir and all subpath
+// Search for '.git' directory inside 'path'. In case there is one,
+// extract the details and add a new entry to the cache(key:path in the file system ,value: git revision & url).
+// Otherwise, move in the parent folder and do the following:
+// 1. Search for .git, and save the details for the current dir and all subpath
 // 2. .git not found, go to parent dir and repeat
 // 3. not found on the root directory, add all subpath to cache with nil as a value
 func (vc *VcsCache) GetVcsDetails(path string) (revision, refUrl, branch string, err error) {
@@ -91,7 +92,7 @@ func (vc *VcsCache) clearCacheIfExceedsMax() {
 }
 
 func tryGetGitDetails(path string) (string, string, string, error) {
-	exists := fileutils.IsPathExists(filepath.Join(path, ".git"), false)
+	exists := fileutils.IsPathAccessible(filepath.Join(path, ".git"))
 	if exists {
 		return extractGitDetails(path)
 	}

--- a/utils/vcsdetails.go
+++ b/utils/vcsdetails.go
@@ -92,8 +92,7 @@ func (vc *VcsCache) clearCacheIfExceedsMax() {
 }
 
 func tryGetGitDetails(path string) (string, string, string, error) {
-	exists := fileutils.IsPathAccessible(filepath.Join(path, ".git"))
-	if exists {
+	if fileutils.IsPathAccessible(filepath.Join(path, ".git")) {
 		return extractGitDetails(path)
 	}
 	return "", "", "", nil


### PR DESCRIPTION
This is an attempt to fix https://github.com/jfrog/jfrog-cli/issues/2442.
The PR adds a new `IsPathAccessible` API, in addition to the existing `IsPathExists` functions. This is because the existing `IsPathExists` returns `false` in case of any error that occurred while accessing the directory, and not only in the case that the directory doesn't exist.
The new `IsPathAccessible` returns `false` in case the directory exists, but the user doesn't have permissions to access it. The usage of the new API by the Artifactory Upload code flow is expected to resolve the above issue. 