### PR TITLE
Add project key to GetAllRepositoriesFiltered

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,7 @@ You can get all repositories from Artifactory filtered according to theirs type 
 params := services.NewRepositoriesFilterParams()
 params.RepoType = "remote"
 params.PackageType = "maven"
+params.ProjectKey = "project-key"
 err := servicesManager.GetAllRepositoriesFiltered(params)
 ```
 

--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -79,7 +79,7 @@ func createWithFilterUrl(params RepositoriesFilterParams) string {
 	}
 
 	if len(queryParams) > 0 {
-		log.Info("Getting repositories with filter:", queryParams.Encode())
+		log.Debug("Getting repositories with filter:", queryParams.Encode())
 	}
 	u.RawQuery = queryParams.Encode()
 	return u.String()

--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -79,7 +79,7 @@ func createWithFilterUrl(params RepositoriesFilterParams) string {
 	}
 
 	if len(queryParams) > 0 {
-		log.Info("Getting repositories with filter: ", queryParams.Encode())
+		log.Info("Getting repositories with filter:", queryParams.Encode())
 	}
 	u.RawQuery = queryParams.Encode()
 	return u.String()

--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -50,7 +50,6 @@ func (rs *RepositoriesService) GetAll() (*[]RepositoryDetails, error) {
 }
 
 func (rs *RepositoriesService) GetWithFilter(params RepositoriesFilterParams) (*[]RepositoryDetails, error) {
-	log.Info("Getting repositories with filter ...")
 	body, err := rs.sendGet(createWithFilterUrl(params))
 	if err != nil {
 		return nil, err
@@ -80,7 +79,7 @@ func createWithFilterUrl(params RepositoriesFilterParams) string {
 	}
 
 	if len(queryParams) > 0 {
-		log.Info("Getting repositories with filter: %s", queryParams.Encode())
+		log.Info("Getting repositories with filter: ", queryParams.Encode())
 	}
 	u.RawQuery = queryParams.Encode()
 	return u.String()

--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -60,24 +60,27 @@ func (rs *RepositoriesService) GetWithFilter(params RepositoriesFilterParams) (*
 	return repoDetails, errorutils.CheckError(err)
 }
 
+// This function is used to create the URL for the repositories API with the given filter params.
+// The function expects to get a RepositoriesFilterParams struct that contains the desired filter params.
+// The function returns the URL string.
 func createWithFilterUrl(params RepositoriesFilterParams) string {
 	u := url.URL{
 		Path: apiRepositories,
 	}
 
 	queryParams := url.Values{}
-
 	if params.RepoType != "" {
-		log.Info("Getting repositories with type:", params.RepoType)
 		queryParams.Add("type", params.RepoType)
 	}
 	if params.PackageType != "" {
-		log.Info("Getting repositories with package type:", params.PackageType)
 		queryParams.Add("packageType", params.PackageType)
 	}
 	if params.ProjectKey != "" {
-		log.Info("Getting repositories with project key:", params.ProjectKey)
 		queryParams.Add("project", params.ProjectKey)
+	}
+
+	if len(queryParams) > 0 {
+		log.Info("Getting repositories with filter: %s", queryParams.Encode())
 	}
 	u.RawQuery = queryParams.Encode()
 	return u.String()

--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -50,7 +50,7 @@ func (rs *RepositoriesService) GetAll() (*[]RepositoryDetails, error) {
 }
 
 func (rs *RepositoriesService) GetWithFilter(params RepositoriesFilterParams) (*[]RepositoryDetails, error) {
-	body, err := rs.sendGet(createWithFilterUrl(params))
+	body, err := rs.sendGet(rs.createUrlWithFilter(params))
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (rs *RepositoriesService) GetWithFilter(params RepositoriesFilterParams) (*
 // This function is used to create the URL for the repositories API with the given filter params.
 // The function expects to get a RepositoriesFilterParams struct that contains the desired filter params.
 // The function returns the URL string.
-func createWithFilterUrl(params RepositoriesFilterParams) string {
+func (rs *RepositoriesService)createUrlWithFilter(params RepositoriesFilterParams) string {
 	u := url.URL{
 		Path: apiRepositories,
 	}
@@ -78,9 +78,6 @@ func createWithFilterUrl(params RepositoriesFilterParams) string {
 		queryParams.Add("project", params.ProjectKey)
 	}
 
-	if len(queryParams) > 0 {
-		log.Debug("Getting repositories with filter:", queryParams.Encode())
-	}
 	u.RawQuery = queryParams.Encode()
 	return u.String()
 }

--- a/artifactory/services/repositories_test.go
+++ b/artifactory/services/repositories_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateWithFilterUrl(t *testing.T) {
-	tests := []struct {
+func TestCreateUrlWithFilter(t *testing.T) {
+	rs := RepositoriesService{}
+	testCases := []struct {
 		params   RepositoriesFilterParams
 		expected string
 	}{
@@ -19,8 +20,8 @@ func TestCreateWithFilterUrl(t *testing.T) {
 		{RepositoriesFilterParams{}, "api/repositories"},
 	}
 
-	for _, test := range tests {
-		result := createWithFilterUrl(test.params)
-		assert.Equal(t, test.expected, result, "For params %+v, expected %s, but got %s", test.params, test.expected, result)
+	for _, testCase := range testCases {
+		result := rs.createUrlWithFilter(testCase.params)
+		assert.Equal(t, testCase.expected, result, "For params %+v, expected %s, but got %s", testCase.params, testCase.expected, result)
 	}
 }

--- a/artifactory/services/repositories_test.go
+++ b/artifactory/services/repositories_test.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateWithFilterUrl(t *testing.T) {
+	tests := []struct {
+		params   RepositoriesFilterParams
+		expected string
+	}{
+		{RepositoriesFilterParams{RepoType: "git", PackageType: "npm", ProjectKey: "123"}, "api/repositories?packageType=npm&project=123&type=git"},
+		{RepositoriesFilterParams{RepoType: "git", PackageType: "npm"}, "api/repositories?packageType=npm&type=git"},
+		{RepositoriesFilterParams{RepoType: "git"}, "api/repositories?type=git"},
+		{RepositoriesFilterParams{PackageType: "npm"}, "api/repositories?packageType=npm"},
+		{RepositoriesFilterParams{ProjectKey: "123"}, "api/repositories?project=123"},
+		{RepositoriesFilterParams{}, "api/repositories"},
+	}
+
+	for _, test := range tests {
+		result := createWithFilterUrl(test.params)
+		assert.Equal(t, test.expected, result, "For params %+v, expected %s, but got %s", test.params, test.expected, result)
+	}
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

With this PR, all repositories for a specific project can be retrieved. It uses the current GetAllRepositoriesFiltered function with the project key added as a parameter.

Fixes https://github.com/jfrog/jfrog-client-go/issues/812