### PR TITLE
Fixed failing TestXrayWatch test

### DIFF
--- a/tests/xraywatch_test.go
+++ b/tests/xraywatch_test.go
@@ -314,17 +314,17 @@ func testXrayWatchUpdateMissingWatch(t *testing.T) {
 	paramsMissingWatch.Policies = []utils.AssignedPolicy{}
 
 	err := testsXrayWatchService.Update(paramsMissingWatch)
-	assert.EqualError(t, err, "server response: 404 Not Found\n{\n  \"error\": \"Failed to update Watch: Watch was not found\"\n}")
+	assert.EqualError(t, err, "server response: 404 Not Found")
 }
 
 func testXrayWatchDeleteMissingWatch(t *testing.T) {
 	err := testsXrayWatchService.Delete("client-go-tests-watch-builds-missing")
-	assert.EqualError(t, err, "server response: 404 Not Found\n{\n  \"error\": \"Failed to delete Watch: Watch was not found\"\n}")
+	assert.EqualError(t, err, "server response: 404 Not Found")
 }
 
 func testXrayWatchGetMissingWatch(t *testing.T) {
 	_, err := testsXrayWatchService.Get("client-go-tests-watch-builds-missing")
-	assert.EqualError(t, err, "server response: 404 Not Found\n{\n  \"error\": \"Watch was not found\"\n}")
+	assert.EqualError(t, err, "server response: 404 Not Found")
 }
 
 func validateWatchGeneralSettings(t *testing.T, params utils.WatchParams) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

This Pr updated the error messages to which we compare the returned error messages in TestXrayWatch test

We can see an example for the failure here: https://github.com/jfrog/jfrog-client-go/actions/runs/10479231153/job/29217753075
This pipeline was all green, and after re-running it few days later it started to fail due to a change in the returned error message