### PR TITLE
Add "Fail Fast" flag for Upload Service

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -58,6 +58,7 @@ type ArtifactoryServicesManager interface {
 	GetItemProps(relativePath string) (*utils.ItemProperties, error)
 	UploadFilesWithSummary(params ...services.UploadParams) (operationSummary *utils.OperationSummary, err error)
 	UploadFiles(params ...services.UploadParams) (totalUploaded, totalFailed int, err error)
+	UploadFilesWithFailFast(params ...services.UploadParams) (totalUploaded, totalFailed int, err error)
 	Copy(params ...services.MoveCopyParams) (successCount, failedCount int, err error)
 	Move(params ...services.MoveCopyParams) (successCount, failedCount int, err error)
 	PublishGoProject(params _go.GoParams) (*utils.OperationSummary, error)
@@ -263,6 +264,10 @@ func (esm *EmptyArtifactoryServicesManager) GetItemProps(string) (*utils.ItemPro
 }
 
 func (esm *EmptyArtifactoryServicesManager) UploadFiles(...services.UploadParams) (int, int, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) UploadFilesWithFailFast(...services.UploadParams) (int, int, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -33,20 +33,7 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 	if err != nil {
 		return nil, err
 	}
-	client, err := jfroghttpclient.JfrogClientBuilder().
-		SetCertificatesPath(config.GetCertificatesPath()).
-		SetInsecureTls(config.IsInsecureTls()).
-		SetContext(config.GetContext()).
-		SetDialTimeout(config.GetDialTimeout()).
-		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
-		SetClientCertPath(artDetails.GetClientCertPath()).
-		SetClientCertKeyPath(artDetails.GetClientCertKeyPath()).
-		AppendPreRequestInterceptor(artDetails.RunPreRequestFunctions).
-		SetContext(config.GetContext()).
-		SetRetries(config.GetHttpRetries()).
-		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
-		SetHttpClient(config.GetHttpClient()).
-		Build()
+	client, err := BuildJFrogHttpClient(config, artDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +46,23 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 	}
 	manager.progress = progress
 	return manager, err
+}
+
+func BuildJFrogHttpClient(config config.Config, authDetails auth.ServiceDetails) (*jfroghttpclient.JfrogHttpClient, error) {
+	return jfroghttpclient.JfrogClientBuilder().
+		SetCertificatesPath(config.GetCertificatesPath()).
+		SetInsecureTls(config.IsInsecureTls()).
+		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
+		SetClientCertPath(authDetails.GetClientCertPath()).
+		SetClientCertKeyPath(authDetails.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(authDetails.RunPreRequestFunctions).
+		SetContext(config.GetContext()).
+		SetRetries(config.GetHttpRetries()).
+		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
+		SetHttpClient(config.GetHttpClient()).
+		Build()
 }
 
 func NewWithClient(config config.Config, client *jfroghttpclient.JfrogHttpClient) (*ArtifactoryServicesManagerImp, error) {

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -33,7 +33,7 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 	if err != nil {
 		return nil, err
 	}
-	client, err := BuildJFrogHttpClient(config, artDetails)
+	client, err := buildJFrogHttpClient(config, artDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -46,23 +46,6 @@ func NewWithProgress(config config.Config, progress ioutils.ProgressMgr) (Artifa
 	}
 	manager.progress = progress
 	return manager, err
-}
-
-func BuildJFrogHttpClient(config config.Config, authDetails auth.ServiceDetails) (*jfroghttpclient.JfrogHttpClient, error) {
-	return jfroghttpclient.JfrogClientBuilder().
-		SetCertificatesPath(config.GetCertificatesPath()).
-		SetInsecureTls(config.IsInsecureTls()).
-		SetContext(config.GetContext()).
-		SetDialTimeout(config.GetDialTimeout()).
-		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
-		SetClientCertPath(authDetails.GetClientCertPath()).
-		SetClientCertKeyPath(authDetails.GetClientCertKeyPath()).
-		AppendPreRequestInterceptor(authDetails.RunPreRequestFunctions).
-		SetContext(config.GetContext()).
-		SetRetries(config.GetHttpRetries()).
-		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
-		SetHttpClient(config.GetHttpClient()).
-		Build()
 }
 
 func NewWithClient(config config.Config, client *jfroghttpclient.JfrogHttpClient) (*ArtifactoryServicesManagerImp, error) {
@@ -331,12 +314,21 @@ func (sm *ArtifactoryServicesManagerImp) initUploadService() *services.UploadSer
 }
 
 func (sm *ArtifactoryServicesManagerImp) UploadFiles(params ...services.UploadParams) (totalUploaded, totalFailed int, err error) {
+	return sm.uploadFiles(sm.initUploadService(), params...)
+}
+
+func (sm *ArtifactoryServicesManagerImp) UploadFilesWithFailFast(params ...services.UploadParams) (totalUploaded, totalFailed int, err error) {
 	uploadService := sm.initUploadService()
-	summary, e := uploadService.UploadFiles(params...)
+	uploadService.SetFailFast(true)
+	return sm.uploadFiles(uploadService, params...)
+}
+
+func (sm *ArtifactoryServicesManagerImp) uploadFiles(uploadService *services.UploadService, uploadParams ...services.UploadParams) (totalUploaded, totalFailed int, err error) {
+	summary, err := uploadService.UploadFiles(uploadParams...)
 	if summary == nil {
-		return 0, 0, e
+		return 0, 0, err
 	}
-	return summary.TotalSucceeded, summary.TotalFailed, e
+	return summary.TotalSucceeded, summary.TotalFailed, err
 }
 
 func (sm *ArtifactoryServicesManagerImp) UploadFilesWithSummary(params ...services.UploadParams) (operationSummary *utils.OperationSummary, err error) {
@@ -613,4 +605,21 @@ func (sm *ArtifactoryServicesManagerImp) CalculateStorageInfo() error {
 func (sm *ArtifactoryServicesManagerImp) ImportReleaseBundle(filePath string) error {
 	releaseService := services.NewReleaseService(sm.config.GetServiceDetails(), sm.client)
 	return releaseService.ImportReleaseBundle(filePath)
+}
+
+func buildJFrogHttpClient(config config.Config, authDetails auth.ServiceDetails) (*jfroghttpclient.JfrogHttpClient, error) {
+	return jfroghttpclient.JfrogClientBuilder().
+		SetCertificatesPath(config.GetCertificatesPath()).
+		SetInsecureTls(config.IsInsecureTls()).
+		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
+		SetClientCertPath(authDetails.GetClientCertPath()).
+		SetClientCertKeyPath(authDetails.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(authDetails.RunPreRequestFunctions).
+		SetContext(config.GetContext()).
+		SetRetries(config.GetHttpRetries()).
+		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
+		SetHttpClient(config.GetHttpClient()).
+		Build()
 }

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -46,8 +46,8 @@ type UploadService struct {
 	ArtDetails      auth.ServiceDetails
 	MultipartUpload *utils.MultipartUpload
 	DryRun          bool
-	FailFast        bool
 	saveSummary     bool
+	failFast        bool
 	Threads         int
 	resultsManager  *resultsManager
 }
@@ -78,6 +78,10 @@ func (us *UploadService) SetSaveSummary(saveSummary bool) {
 	us.saveSummary = saveSummary
 }
 
+func (us *UploadService) SetFailFast(failFast bool) {
+	us.failFast = failFast
+}
+
 func (us *UploadService) getOperationSummary(totalSucceeded, totalFailed int) *utils.OperationSummary {
 	if !us.saveSummary {
 		return &utils.OperationSummary{
@@ -91,7 +95,7 @@ func (us *UploadService) getOperationSummary(totalSucceeded, totalFailed int) *u
 func (us *UploadService) UploadFiles(uploadParams ...UploadParams) (summary *utils.OperationSummary, err error) {
 	// Uploading threads are using this struct to report upload results.
 	uploadSummary := utils.NewResult(us.Threads)
-	producerConsumer := parallel.NewRunner(us.Threads, 20000, us.FailFast)
+	producerConsumer := parallel.NewRunner(us.Threads, 20000, us.failFast)
 	errorsQueue := clientutils.NewErrorsQueue(1)
 	if us.saveSummary {
 		us.resultsManager, err = newResultManager()

--- a/artifactory/services/upload.go
+++ b/artifactory/services/upload.go
@@ -46,8 +46,9 @@ type UploadService struct {
 	ArtDetails      auth.ServiceDetails
 	MultipartUpload *utils.MultipartUpload
 	DryRun          bool
-	Threads         int
+	FailFast        bool
 	saveSummary     bool
+	Threads         int
 	resultsManager  *resultsManager
 }
 
@@ -90,7 +91,7 @@ func (us *UploadService) getOperationSummary(totalSucceeded, totalFailed int) *u
 func (us *UploadService) UploadFiles(uploadParams ...UploadParams) (summary *utils.OperationSummary, err error) {
 	// Uploading threads are using this struct to report upload results.
 	uploadSummary := utils.NewResult(us.Threads)
-	producerConsumer := parallel.NewRunner(us.Threads, 20000, false)
+	producerConsumer := parallel.NewRunner(us.Threads, 20000, us.FailFast)
 	errorsQueue := clientutils.NewErrorsQueue(1)
 	if us.saveSummary {
 		us.resultsManager, err = newResultManager()

--- a/artifactory/services/utils/multipartupload.go
+++ b/artifactory/services/utils/multipartupload.go
@@ -191,7 +191,7 @@ func (mu *MultipartUpload) uploadPartsConcurrently(logMsgPrefix string, fileSize
 		return fmt.Errorf("failed to convert number of retries to uint64: %w", err)
 	}
 	log.Info(fmt.Sprintf("%sSplitting file to %d parts of %s each, using %d working threads for uploading...", logMsgPrefix, numberOfParts, ConvertIntToStorageSizeString(chunkSize), splitCount))
-	producerConsumer := parallel.NewRunner(splitCount, uint(numberOfParts), false)
+	producerConsumer := parallel.NewRunner(splitCount, uint(unsignedNumOfParts), false)
 
 	wg := new(sync.WaitGroup)
 	wg.Add(int(numberOfParts))

--- a/artifactory/services/utils/multipartupload.go
+++ b/artifactory/services/utils/multipartupload.go
@@ -171,7 +171,7 @@ func (mu *MultipartUpload) UploadFileConcurrently(localPath, targetPath string, 
 		progressReader = progress.SetMergingState(progressReader.GetId(), false)
 	}
 
-	unsignedNumRetries, err := utils.ConvertIntToUint(mu.client.GetHttpClient().GetRetries())
+	unsignedNumRetries, err := utils.SafeIntToUint(mu.client.GetHttpClient().GetRetries())
 	if err != nil {
 		return "", fmt.Errorf("failed to convert number of retries to uint64: %w", err)
 	}
@@ -182,11 +182,11 @@ func (mu *MultipartUpload) UploadFileConcurrently(localPath, targetPath string, 
 
 func (mu *MultipartUpload) uploadPartsConcurrently(logMsgPrefix string, fileSize, chunkSize int64, splitCount int, localPath string, progressReader ioutils.Progress, multipartUploadClient *httputils.HttpClientDetails) (err error) {
 	numberOfParts := calculateNumberOfParts(fileSize, chunkSize)
-	unsignedNumOfParts, err := utils.ConvertInt64ToUint64(numberOfParts)
+	unsignedNumOfParts, err := utils.SafeInt64ToUint64(numberOfParts)
 	if err != nil {
 		return fmt.Errorf("failed to convert number of parts to uint64: %w", err)
 	}
-	unsignedNumRetries, err := utils.ConvertInt64ToUint64(int64(mu.client.GetHttpClient().GetRetries()))
+	unsignedNumRetries, err := utils.SafeInt64ToUint64(int64(mu.client.GetHttpClient().GetRetries()))
 	if err != nil {
 		return fmt.Errorf("failed to convert number of retries to uint64: %w", err)
 	}

--- a/artifactory/services/utils/multipartupload.go
+++ b/artifactory/services/utils/multipartupload.go
@@ -184,11 +184,10 @@ func (mu *MultipartUpload) uploadPartsConcurrently(logMsgPrefix string, fileSize
 	wg := new(sync.WaitGroup)
 	wg.Add(int(numberOfParts))
 	attemptsAllowed := new(atomic.Uint64)
-	numRetries := uint64(mu.client.GetHttpClient().GetRetries())
-	attemptsAllowed.Add(numberOfParts * numRetries)
+	attemptsAllowed.Add(uint64(numberOfParts) * uint64(mu.client.GetHttpClient().GetRetries()))
 	go func() {
 		for i := 0; i < int(numberOfParts); i++ {
-			if err = mu.produceUploadTask(producerConsumer, logMsgPrefix, localPath, fileSize, int64(numberOfParts), int64(i), chunkSize, progressReader, multipartUploadClient, attemptsAllowed, wg); err != nil {
+			if err = mu.produceUploadTask(producerConsumer, logMsgPrefix, localPath, fileSize, numberOfParts, int64(i), chunkSize, progressReader, multipartUploadClient, attemptsAllowed, wg); err != nil {
 				return
 			}
 		}
@@ -421,8 +420,8 @@ func calculatePartSize(fileSize, partNumber, requestedChunkSize int64) int64 {
 
 // Calculates the number of parts based on the file size and the requested chunks size.
 // fileSize - the file size
-func calculateNumberOfParts(fileSize, chunkSize int64) uint64 {
-	return uint64(fileSize+chunkSize-1) / uint64(chunkSize)
+func calculateNumberOfParts(fileSize, chunkSize int64) int64 {
+	return (fileSize + chunkSize - 1) / chunkSize
 }
 
 func parseMultipartUploadStatus(status statusResponse) (shouldKeepPolling, shouldRerunComplete bool, err error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -617,16 +617,16 @@ func SetEnvWithResetCallback(key, value string) (func() error, error) {
 	}, nil
 }
 
-func ConvertInt64ToUint64(val int64) (uint64, error) {
+func SafeInt64ToUint64(val int64) (uint64, error) {
 	if val < 0 {
-		return 0, fmt.Errorf("value %d is negative", val)
+		return 0, fmt.Errorf("cannot convert int64 to uint64. value %d is negative", val)
 	}
 	return uint64(val), nil
 }
 
-func ConvertIntToUint(val int) (uint, error) {
+func SafeIntToUint(val int) (uint, error) {
 	if val < 0 {
-		return 0, fmt.Errorf("value %d is negative", val)
+		return 0, fmt.Errorf("cannot convert int to uint. value %d is negative", val)
 	}
 	return uint(val), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -619,14 +619,14 @@ func SetEnvWithResetCallback(key, value string) (func() error, error) {
 
 func SafeInt64ToUint64(val int64) (uint64, error) {
 	if val < 0 {
-		return 0, fmt.Errorf("cannot convert int64 to uint64. value %d is negative", val)
+		return 0, fmt.Errorf("cannot convert negative int64 (%d) to uint64", val)
 	}
 	return uint64(val), nil
 }
 
 func SafeIntToUint(val int) (uint, error) {
 	if val < 0 {
-		return 0, fmt.Errorf("cannot convert int to uint. value %d is negative", val)
+		return 0, fmt.Errorf("cannot convert negative int (%d) to uint", val)
 	}
 	return uint(val), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -616,3 +616,17 @@ func SetEnvWithResetCallback(key, value string) (func() error, error) {
 		return errorutils.CheckError(os.Unsetenv(key))
 	}, nil
 }
+
+func ConvertInt64ToUint64(val int64) (uint64, error) {
+	if val < 0 {
+		return 0, fmt.Errorf("value %d is negative", val)
+	}
+	return uint64(val), nil
+}
+
+func ConvertIntToUint(val int) (uint, error) {
+	if val < 0 {
+		return 0, fmt.Errorf("value %d is negative", val)
+	}
+	return uint(val), nil
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
- Due to Static Analysis update, this PR also introduces safe int to uint and int64 to uint64 conversions in the multipartupload code.