### PR TITLE
Add option to allow Emojis in log output

### DIFF
--- a/artifactory/services/repositories.go
+++ b/artifactory/services/repositories.go
@@ -62,7 +62,7 @@ func (rs *RepositoriesService) GetWithFilter(params RepositoriesFilterParams) (*
 // This function is used to create the URL for the repositories API with the given filter params.
 // The function expects to get a RepositoriesFilterParams struct that contains the desired filter params.
 // The function returns the URL string.
-func (rs *RepositoriesService)createUrlWithFilter(params RepositoriesFilterParams) string {
+func (rs *RepositoriesService) createUrlWithFilter(params RepositoriesFilterParams) string {
 	u := url.URL{
 		Path: apiRepositories,
 	}

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -259,11 +259,11 @@ func IsEmojiAllow() bool {
 	return allowEmojis
 }
 
-func SetAllowEmojiFlagWithCallback(allowEmoji bool) func() {
-	prevAllowEmoji := allowEmojis
-	allowEmojis = allowEmoji
+func SetAllowEmojiFlagWithCallback(allow bool) func() {
+	prevAllowEmojis := allowEmojis
+	allowEmojis = allow
 	return func() {
-		allowEmojis = prevAllowEmoji
+		allowEmojis = prevAllowEmojis
 	}
 }
 

--- a/utils/log/logger_test.go
+++ b/utils/log/logger_test.go
@@ -20,6 +20,17 @@ func TestLoggerLeaveEmojis(t *testing.T) {
 	testLoggerWithEmojis(t, true, expected)
 }
 
+func TestLoggerForceEmojis(t *testing.T) {
+	// Force emojis
+	assert.False(t, allowEmojis)
+	testLoggerWithEmojis(t, true, expectedLogOutputWithEmojis)
+	callback := SetAllowEmojiFlagWithCallback(true)
+	assert.True(t, allowEmojis)
+	testLoggerWithEmojis(t, true, expectedLogOutputWithEmojis)
+	callback()
+	assert.False(t, allowEmojis)
+}
+
 func testLoggerWithEmojis(t *testing.T, mockIsTerminalFlags bool, expected string) {
 	previousLog := Logger
 	// Restore previous logger when the function returns.


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Add option for the logger not to remove Emojis.