### PR TITLE
Remove remaining temp file after Artifactory download

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -3,16 +3,17 @@ package services
 import (
 	"errors"
 	"fmt"
-	"github.com/jfrog/build-info-go/entities"
-	"github.com/jfrog/gofrog/crypto"
-	ioutils "github.com/jfrog/gofrog/io"
-	"github.com/jfrog/gofrog/version"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/gofrog/crypto"
+	ioutils "github.com/jfrog/gofrog/io"
+	"github.com/jfrog/gofrog/version"
 
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 

--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -3,8 +3,10 @@ package httpclient
 import (
 	"bytes"
 	"context"
-	"github.com/minio/sha256-simd"
 	"strings"
+
+	"github.com/minio/sha256-simd"
+
 	//#nosec G505 -- sha1 is supported by Artifactory.
 	"crypto/sha1"
 	"encoding/hex"

--- a/utils/io/fileutils/temp.go
+++ b/utils/io/fileutils/temp.go
@@ -25,10 +25,6 @@ func init() {
 	tempDirBase = os.TempDir()
 }
 
-func GetTempFilePrefix() string {
-	return tempPrefix
-}
-
 // Creates the temp dir at tempDirBase.
 // Set tempDirPath to the created directory path.
 func CreateTempDir() (string, error) {

--- a/utils/io/fileutils/temp.go
+++ b/utils/io/fileutils/temp.go
@@ -25,6 +25,10 @@ func init() {
 	tempDirBase = os.TempDir()
 }
 
+func GetTempFilePrefix() string {
+	return tempPrefix
+}
+
 // Creates the temp dir at tempDirBase.
 // Set tempDirPath to the created directory path.
 func CreateTempDir() (string, error) {


### PR DESCRIPTION
Fix a bug where after a file is downloaded from Artifactory, there's one temporary file that remains in the OS temp dir. This fix removes this temporary file.
