### PR TITLE
Fix the "Get Distribution Export" polling logic

### DIFF
--- a/lifecycle/services/export.go
+++ b/lifecycle/services/export.go
@@ -3,10 +3,11 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"path"
+
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"path"
 )
 
 const (
@@ -101,8 +102,13 @@ func (rbs *ReleaseBundlesService) waitForExport(rbDetails ReleaseBundleDetails, 
 		switch response.Status {
 		case ExportProcessing:
 			return false, nil, nil
-		case ExportCompleted, ExportFailed:
+		case ExportFailed:
 			return true, responseBody, nil
+		case ExportCompleted:
+			if response.RelativeUrl != "" && response.RelativeUrl != "/" {
+				return true, responseBody, nil
+			}
+			return false, nil, nil
 		default:
 			return true, nil, errorutils.CheckErrorf("received unexpected status: '%s'", response.Status)
 		}

--- a/lifecycle/services/export.go
+++ b/lifecycle/services/export.go
@@ -105,7 +105,8 @@ func (rbs *ReleaseBundlesService) waitForExport(rbDetails ReleaseBundleDetails, 
 		case ExportFailed:
 			return true, responseBody, nil
 		case ExportCompleted:
-			if response.RelativeUrl != "" && response.RelativeUrl != "/" {
+			if response.RelativeUrl != "" && response.RelativeUrl != "/" &&
+				response.DownloadUrl != "" {
 				return true, responseBody, nil
 			}
 			return false, nil, nil


### PR DESCRIPTION
Modify the logic of the code that waits for the distribution export to finish.
Instead of waiting of the a completion signal from the API, we're also waiting for the relative path to not be "" or "/"