### PR TITLE
Added retry mechanism for close contentReader in download.

### DIFF
--- a/utils/io/content/contentreader.go
+++ b/utils/io/content/contentreader.go
@@ -16,9 +16,6 @@ import (
 	"sync"
 )
 
-var downloadAttempts = 0
-var maxForcedAttempts = 4
-
 // Open and read JSON files, find the array key inside it and load its value into the memory in small chunks.
 // Currently, 'ContentReader' only support extracting a single value for a given key (arrayKey), other keys are ignored.
 // The value must be of type array.

--- a/utils/io/content/contentreader.go
+++ b/utils/io/content/contentreader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/jfrog/gofrog/http/retryexecutor"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -95,31 +96,34 @@ func (cr *ContentReader) Reset() {
 	cr.once = new(sync.Once)
 }
 
+func removeFileWithRetry(filePath string) error {
+	// Check if file exists before attempting to remove
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		log.Debug("File does not exist: %s", filePath)
+		return nil
+	}
+	log.Debug("Attempting to remove file: %s", filePath)
+	executor := retryexecutor.RetryExecutor{
+		Context:                  context.Background(),
+		MaxRetries:               5,
+		RetriesIntervalMilliSecs: 100,
+		ErrorMessage:             "Failed to remove file",
+		LogMsgPrefix:             "Attempting removal",
+		ExecutionHandler: func() (bool, error) {
+			return false, errorutils.CheckError(os.Remove(filePath))
+		},
+	}
+	return executor.Execute()
+}
+
 // Cleanup the reader data with retry
 func (cr *ContentReader) Close() error {
 	for _, filePath := range cr.filesPaths {
 		if filePath == "" {
 			continue
 		}
-		// Check if file exists before attempting to remove
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			log.Debug("File does not exist: %s", filePath)
-			continue
-		}
-		log.Debug("Attempting to remove file: %s", filePath)
-		executor := retryexecutor.RetryExecutor{
-			Context:                  context.Background(),
-			MaxRetries:               5,
-			RetriesIntervalMilliSecs: 100,
-			ErrorMessage:             "Retrying file removal",
-			LogMsgPrefix:             "File Removal",
-			ExecutionHandler: func() (bool, error) {
-				return false, errorutils.CheckError(os.Remove(filePath))
-			},
-		}
-		err := executor.Execute()
-		if err != nil {
-			return errors.New("Failed to close reader: " + err.Error())
+		if err := removeFileWithRetry(filePath); err != nil {
+			return fmt.Errorf("failed to close reader: %w", err)
 		}
 	}
 	cr.filesPaths = nil


### PR DESCRIPTION
**Enhance Retry Mechanism for Content Reader Closure in Downloads**
**Summary**:
This PR improves the reliability of the download process by introducing a retry mechanism when closing the contentReader. 

**Changes:**
Added a retry mechanism to handle potential failures when closing the contentReader in the download process.

-----
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----