### PR TITLE
Add support for OIDC token exchange in Access manager

### DIFF
--- a/access/manager.go
+++ b/access/manager.go
@@ -138,7 +138,7 @@ func (sm *AccessServicesManager) GetLoginAuthenticationToken(uuid string) (auth.
 	return loginService.GetLoginAuthenticationToken(uuid)
 }
 
-func (sm *AccessServicesManager) ExchangeOidcToken(params services.CreateOidcTokenParams) (auth.CreateTokenResponseData, error) {
+func (sm *AccessServicesManager) ExchangeOidcToken(params services.CreateOidcTokenParams) (auth.OidcTokenResponseData, error) {
 	tokenService := services.NewTokenService(sm.client)
 	tokenService.ServiceDetails = sm.config.GetServiceDetails()
 	return tokenService.ExchangeOidcToken(params)

--- a/access/manager.go
+++ b/access/manager.go
@@ -137,3 +137,9 @@ func (sm *AccessServicesManager) GetLoginAuthenticationToken(uuid string) (auth.
 	loginService.ServiceDetails = sm.config.GetServiceDetails()
 	return loginService.GetLoginAuthenticationToken(uuid)
 }
+
+func (sm *AccessServicesManager) ExchangeOidcToken(params services.CreateOidcTokenParams) (auth.CreateTokenResponseData, error) {
+	tokenService := services.NewTokenService(sm.client)
+	tokenService.ServiceDetails = sm.config.GetServiceDetails()
+	return tokenService.ExchangeOidcToken(params)
+}

--- a/access/services/accesstoken.go
+++ b/access/services/accesstoken.go
@@ -101,6 +101,10 @@ func (ps *TokenService) handleUnauthenticated(params CreateTokenParams, httpDeta
 
 func (ps *TokenService) ExchangeOidcToken(params CreateOidcTokenParams) (auth.CreateTokenResponseData, error) {
 	var tokenInfo auth.CreateTokenResponseData
+	// TODO remove this
+	log.Debug("this is full params:")
+	log.Debug(params)
+
 	httpDetails := ps.ServiceDetails.CreateHttpClientDetails()
 	httpDetails.SetContentTypeApplicationJson()
 	requestContent, err := json.Marshal(params)

--- a/access/services/accesstoken.go
+++ b/access/services/accesstoken.go
@@ -8,6 +8,7 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"net/http"
 )
 
@@ -111,6 +112,9 @@ func (ps *TokenService) ExchangeOidcToken(params CreateOidcTokenParams) (auth.Cr
 	if err != nil {
 		return tokenInfo, err
 	}
+	// TODO remove logs
+	log.Debug("this is full response:")
+	log.Debug(string(body))
 	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
 		return tokenInfo, err
 	}

--- a/access/services/accesstoken.go
+++ b/access/services/accesstoken.go
@@ -8,7 +8,6 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"net/http"
 )
 
@@ -99,12 +98,8 @@ func (ps *TokenService) handleUnauthenticated(params CreateTokenParams, httpDeta
 	return errorutils.CheckErrorf("cannot create access token without credentials")
 }
 
-func (ps *TokenService) ExchangeOidcToken(params CreateOidcTokenParams) (auth.CreateTokenResponseData, error) {
-	var tokenInfo auth.CreateTokenResponseData
-	// TODO remove this
-	log.Debug("this is full params:")
-	log.Debug(params)
-
+func (ps *TokenService) ExchangeOidcToken(params CreateOidcTokenParams) (auth.OidcTokenResponseData, error) {
+	var tokenInfo auth.OidcTokenResponseData
 	httpDetails := ps.ServiceDetails.CreateHttpClientDetails()
 	httpDetails.SetContentTypeApplicationJson()
 	requestContent, err := json.Marshal(params)
@@ -116,9 +111,6 @@ func (ps *TokenService) ExchangeOidcToken(params CreateOidcTokenParams) (auth.Cr
 	if err != nil {
 		return tokenInfo, err
 	}
-	// TODO remove logs
-	log.Debug("this is full response:")
-	log.Debug(string(body))
 	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
 		return tokenInfo, err
 	}

--- a/auth/authutils.go
+++ b/auth/authutils.go
@@ -17,6 +17,12 @@ type CreateTokenResponseData struct {
 	TokenId        string `json:"token_id,omitempty"`
 }
 
+type OidcTokenResponseData struct {
+	CommonTokenParams
+	IssuedTokenType string `json:"issued_token_type,omitempty"`
+	Username        string `json:"username,omitempty"`
+}
+
 type CommonTokenParams struct {
 	Scope        string `json:"scope,omitempty"`
 	AccessToken  string `json:"access_token,omitempty"`


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

📝 PR Description:

This PR introduces support for exchanging OIDC ID tokens with access tokens in the JFrog CLI's access manager. It includes:

    ✅ New ExchangeOidcToken method added to AccessServicesManager

    ✅ Implementation of ExchangeOidcToken in TokenService, using the api/v1/oidc/token endpoint

    ✅ New struct CreateOidcTokenParams to represent parameters required for token exchange

    ✅ New struct OidcTokenResponseData to handle the response from the OIDC token exchange API

🔍 Purpose:

Enables CLI-based integration with OIDC providers by supporting the OIDC token exchange flow, as part of broader OIDC authentication support in the CLI.