### PR TITLE
Add onemodel support in go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@
       - [Creating New Metadata Service Manager](#creating-new-metadata-service-manager)
     - [Using Metadata Services](#using-metadata-services)
       - [Graphql query](#graphql-query)
+    - [Onemodel APIs](#onemodel-apis)
+      - [Creating Onemodel Service Manager](#creating-onemodel-service-manager)
+        - [Creating Onemodel Details](#creating-onemodel-details)
+        - [Creating Onemodel Service Config](#creating-onemodel-service-config)
+        - [Creating New Onemodel Service Manager](#creating-new-onemodel-service-manager)
+    - [Using Onemodel Services](#using-onemodel-services)
+      - [Graphql query](#graphql-query)
 
 ## General
 

--- a/onemodel/auth/onemodeldetails.go
+++ b/onemodel/auth/onemodeldetails.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/jfrog/jfrog-client-go/auth"
+)
+
+type onemodelDetails struct {
+	auth.CommonConfigFields
+}
+
+func NewOnemodelDetails() auth.ServiceDetails {
+	return &onemodelDetails{}
+}
+
+func (rt *onemodelDetails) GetVersion() (string, error) {
+	panic("Failed: Method is not implemented")
+}

--- a/onemodel/manager.go
+++ b/onemodel/manager.go
@@ -1,0 +1,45 @@
+package onemodel
+
+import (
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/onemodel/services"
+)
+
+type Manager interface {
+	GraphqlQuery(query []byte) ([]byte, error)
+}
+
+type onemodelManager struct {
+	client *jfroghttpclient.JfrogHttpClient
+	config config.Config
+}
+
+func NewManager(config config.Config) (Manager, error) {
+	details := config.GetServiceDetails()
+	var err error
+	manager := &onemodelManager{config: config}
+	manager.client, err = jfroghttpclient.JfrogClientBuilder().
+		SetCertificatesPath(config.GetCertificatesPath()).
+		SetInsecureTls(config.IsInsecureTls()).
+		SetClientCertPath(details.GetClientCertPath()).
+		SetClientCertKeyPath(details.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
+		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
+		SetRetries(config.GetHttpRetries()).
+		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
+		Build()
+
+	return manager, err
+}
+
+func (omm *onemodelManager) Client() *jfroghttpclient.JfrogHttpClient {
+	return omm.client
+}
+
+func (omm *onemodelManager) GraphqlQuery(query []byte) ([]byte, error) {
+	onemodelService := services.NewOnemodelService(omm.config.GetServiceDetails(), omm.client)
+	return onemodelService.Query(query)
+}

--- a/onemodel/services/graphql.go
+++ b/onemodel/services/graphql.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	rtUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+const queryUrl = "api/v1/graphql"
+
+type Service interface {
+	Query(query []byte) ([]byte, error)
+}
+
+type onemodelService struct {
+	client         *jfroghttpclient.JfrogHttpClient
+	serviceDetails *auth.ServiceDetails
+}
+
+func NewOnemodelService(serviceDetails auth.ServiceDetails, client *jfroghttpclient.JfrogHttpClient) Service {
+	return &onemodelService{serviceDetails: &serviceDetails, client: client}
+}
+
+func (m *onemodelService) GetOnemodelDetails() auth.ServiceDetails {
+	return *m.serviceDetails
+}
+
+func (m *onemodelService) Query(query []byte) ([]byte, error) {
+	graphqlUrl, err := url.Parse(m.GetOnemodelDetails().GetUrl() + queryUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	httpClientDetails := m.GetOnemodelDetails().CreateHttpClientDetails()
+	rtUtils.SetContentType("application/json", &httpClientDetails.Headers)
+
+	resp, body, err := m.client.SendPost(graphqlUrl.String(), query, &httpClientDetails)
+	if err != nil {
+		return []byte{}, err
+	}
+	return body, errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK)
+}

--- a/onemodel/services/graphql_test.go
+++ b/onemodel/services/graphql_test.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/stretchr/testify/assert"
+)
+
+const queryData = `{"query":"someGraphqlQuery"}`
+
+func TestOnemodelService_Query(t *testing.T) {
+	handlerFunc, requestNum := createOnemodelHandlerFunc(t)
+
+	mockServer, onemodelService := createMockonemodelServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	_, err := onemodelService.Query([]byte(queryData))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func createMockonemodelServer(t *testing.T, testHandler http.HandlerFunc) (*httptest.Server, *onemodelService) {
+	testServer := httptest.NewServer(testHandler)
+
+	serviceDetails := auth.NewArtifactoryDetails()
+	serviceDetails.SetUrl(testServer.URL + "/")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+	return testServer, &onemodelService{serviceDetails: &serviceDetails, client: client}
+}
+
+func createOnemodelHandlerFunc(t *testing.T) (http.HandlerFunc, *int) {
+	requestNum := 0
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/api/v1/graphql" {
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			w.WriteHeader(http.StatusOK)
+			requestNum++
+			writeMockonemodelResponse(t, w, []byte(queryData))
+		}
+	}, &requestNum
+}
+
+func writeMockonemodelResponse(t *testing.T, w http.ResponseWriter, payload []byte) {
+	content, err := json.Marshal(payload)
+	assert.NoError(t, err)
+	_, err = w.Write(content)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----