### PR TITLE
Add project key param to Xray api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1918,6 +1918,11 @@ serviceConfig, err := config.NewConfigBuilder().
 xrayManager, err := xray.New(serviceConfig)
 ```
 
+If the provided token is scoped for a `project` you need to set its value in the manager for authentications in relevant API's
+```go
+xrayManager, err := xray.New(serviceConfig).SetProjectKey("project")
+```
+
 ### Using Xray Services
 
 #### Fetching Xray's Version

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -622,3 +622,29 @@ func SetEnvWithResetCallback(key, value string) (func() error, error) {
 		return errorutils.CheckError(os.Unsetenv(key))
 	}, nil
 }
+
+const (
+	// If the access token used for the client is project-scoped, the API call needs to contain the project key as query param to pass to the Server.
+	ProjectKeyQueryParam = "projectKey="
+)
+
+// To access some of the API calls in Xray, we need to add the project key as a query parameter (used for validations if the token is project-scoped).
+func AppendScopedProjectKeyParam(url, projectKey string) string {
+	// make sure the project key is not empty and not already in the URL
+	if projectKey != "" && urlContainsProjectKeyParam(url) {
+		return url
+	}
+	if strings.Contains(url, "?") {
+		// the URL already contains query parameters, append the project key with an '&'
+		url += "&" + ProjectKeyQueryParam + projectKey
+	} else {
+		// the URL does not contain any query parameters, add the project key with a '?'
+		url += "?" + ProjectKeyQueryParam + projectKey
+	}
+	return url
+}
+
+func urlContainsProjectKeyParam(url string) bool {
+	// check if the URL already contains the project key query parameter
+	return len(url) > 0 && strings.Contains(url, ProjectKeyQueryParam)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -631,7 +631,7 @@ const (
 // To access some of the API calls in Xray, we need to add the project key as a query parameter (used for validations if the token is project-scoped).
 func AppendScopedProjectKeyParam(url, projectKey string) string {
 	// make sure the project key is not empty and not already in the URL
-	if projectKey != "" && urlContainsProjectKeyParam(url) {
+	if projectKey == "" || urlContainsProjectKeyParam(url) {
 		return url
 	}
 	if strings.Contains(url, "?") {

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -161,6 +161,7 @@ func (sm *XrayServicesManager) IsTokenValidationEnabled() (isEnabled bool, err e
 func (sm *XrayServicesManager) ScanGraph(params services.XrayGraphScanParams) (scanId string, err error) {
 	scanService := services.NewScanService(sm.client)
 	scanService.XrayDetails = sm.config.GetServiceDetails()
+	scanService.ScopeProjectKey = sm.scopeProjectKey
 	return scanService.ScanGraph(params)
 }
 
@@ -169,6 +170,7 @@ func (sm *XrayServicesManager) ScanGraph(params services.XrayGraphScanParams) (s
 func (sm *XrayServicesManager) GetScanGraphResults(scanID, xrayVersion string, includeVulnerabilities, includeLicenses, xscEnabled bool) (*services.ScanResponse, error) {
 	scanService := services.NewScanService(sm.client)
 	scanService.XrayDetails = sm.config.GetServiceDetails()
+	scanService.ScopeProjectKey = sm.scopeProjectKey
 	return scanService.GetScanGraphResults(scanID, xrayVersion, includeVulnerabilities, includeLicenses, xscEnabled)
 }
 

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -12,6 +12,8 @@ import (
 type XrayServicesManager struct {
 	client *jfroghttpclient.JfrogHttpClient
 	config config.Config
+	// Global reference to the provided project key, used for API endpoints that require it for authentication
+	scopeProjectKey string
 }
 
 // New creates a service manager to interact with Xray
@@ -32,6 +34,11 @@ func New(config config.Config) (*XrayServicesManager, error) {
 		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
 		Build()
 	return manager, err
+}
+
+func (sm *XrayServicesManager) SetProjectKey(projectKey string) *XrayServicesManager {
+	sm.scopeProjectKey = projectKey
+	return sm
 }
 
 // Client will return the http client

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -194,6 +194,7 @@ func (sm *XrayServicesManager) GetImportGraphResults(scanID string) (*services.S
 func (sm *XrayServicesManager) BuildScan(params services.XrayBuildParams, includeVulnerabilities bool) (scanResponse *services.BuildScanResponse, noFailBuildPolicy bool, err error) {
 	buildScanService := services.NewBuildScanService(sm.client)
 	buildScanService.XrayDetails = sm.config.GetServiceDetails()
+	buildScanService.ScopeProjectKey = sm.scopeProjectKey
 	return buildScanService.ScanBuild(params, includeVulnerabilities)
 }
 

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -259,5 +259,6 @@ func (sm *XrayServicesManager) IsEntitled(featureId string) (bool, error) {
 func (sm *XrayServicesManager) Xsc() *xsc.XscInnerService {
 	xscService := xsc.NewXscService(sm.client)
 	xscService.XrayDetails = sm.config.GetServiceDetails()
+	xscService.ScopeProjectKey = sm.scopeProjectKey
 	return xscService
 }

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -248,6 +248,7 @@ func (sm *XrayServicesManager) ArtifactSummary(params services.ArtifactSummaryPa
 func (sm *XrayServicesManager) IsEntitled(featureId string) (bool, error) {
 	entitlementsService := services.NewEntitlementsService(sm.client)
 	entitlementsService.XrayDetails = sm.config.GetServiceDetails()
+	entitlementsService.ScopeProjectKey = sm.scopeProjectKey
 	return entitlementsService.IsEntitled(featureId)
 }
 

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -67,5 +67,6 @@ func (xs *XscInnerService) GetConfigProfileByUrl(repoUrl string) (*services.Conf
 func (xs *XscInnerService) GetResourceWatches(gitRepo, project string) (watches *utils.ResourcesWatchesBody, err error) {
 	watchService := services.NewWatchService(xs.client)
 	watchService.XrayDetails = xs.XrayDetails
+	watchService.ScopeProjectKey = xs.ScopeProjectKey
 	return watchService.GetResourceWatches(gitRepo, project)
 }

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -55,12 +55,14 @@ func (xs *XscInnerService) GetAnalyticsGeneralEvent(msi string) (*services.XscAn
 func (xs *XscInnerService) GetConfigProfileByName(profileName string) (*services.ConfigProfile, error) {
 	configProfileService := services.NewConfigurationProfileService(xs.client)
 	configProfileService.XrayDetails = xs.XrayDetails
+	configProfileService.ScopeProjectKey = xs.ScopeProjectKey
 	return configProfileService.GetConfigurationProfileByName(profileName)
 }
 
 func (xs *XscInnerService) GetConfigProfileByUrl(repoUrl string) (*services.ConfigProfile, error) {
 	configProfileService := services.NewConfigurationProfileService(xs.client)
 	configProfileService.XrayDetails = xs.XrayDetails
+	configProfileService.ScopeProjectKey = xs.ScopeProjectKey
 	return configProfileService.GetConfigurationProfileByUrl(repoUrl)
 }
 

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -12,6 +12,7 @@ import (
 type XscInnerService struct {
 	client      *jfroghttpclient.JfrogHttpClient
 	XrayDetails auth.ServiceDetails
+	ScopeProjectKey string
 }
 
 func NewXscService(client *jfroghttpclient.JfrogHttpClient) *XscInnerService {

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -10,8 +10,8 @@ import (
 // XscService is the Xray Source Control service in the Xray service, available from v3.107.13.
 // This service replaces the Xray Source Control service, which was available as a standalone service.
 type XscInnerService struct {
-	client      *jfroghttpclient.JfrogHttpClient
-	XrayDetails auth.ServiceDetails
+	client          *jfroghttpclient.JfrogHttpClient
+	XrayDetails     auth.ServiceDetails
 	ScopeProjectKey string
 }
 
@@ -35,6 +35,7 @@ func (xs *XscInnerService) AddAnalyticsGeneralEvent(event services.XscAnalyticsG
 func (xs *XscInnerService) SendXscLogErrorRequest(errorLog *services.ExternalErrorLog) error {
 	logErrorService := services.NewLogErrorEventService(xs.client)
 	logErrorService.XrayDetails = xs.XrayDetails
+	logErrorService.ScopeProjectKey = xs.ScopeProjectKey
 	return logErrorService.SendLogErrorEvent(errorLog)
 }
 

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -28,6 +28,7 @@ func (xs *XscInnerService) GetVersion() (string, error) {
 func (xs *XscInnerService) AddAnalyticsGeneralEvent(event services.XscAnalyticsGeneralEvent, xrayVersion string) (string, error) {
 	eventService := services.NewAnalyticsEventService(xs.client)
 	eventService.XrayDetails = xs.XrayDetails
+	eventService.ScopeProjectKey = xs.ScopeProjectKey
 	return eventService.AddGeneralEvent(event, xrayVersion)
 }
 
@@ -40,12 +41,14 @@ func (xs *XscInnerService) SendXscLogErrorRequest(errorLog *services.ExternalErr
 func (xs *XscInnerService) UpdateAnalyticsGeneralEvent(event services.XscAnalyticsGeneralEventFinalize) error {
 	eventService := services.NewAnalyticsEventService(xs.client)
 	eventService.XrayDetails = xs.XrayDetails
+	eventService.ScopeProjectKey = xs.ScopeProjectKey
 	return eventService.UpdateGeneralEvent(event)
 }
 
 func (xs *XscInnerService) GetAnalyticsGeneralEvent(msi string) (*services.XscAnalyticsGeneralEvent, error) {
 	eventService := services.NewAnalyticsEventService(xs.client)
 	eventService.XrayDetails = xs.XrayDetails
+	eventService.ScopeProjectKey = xs.ScopeProjectKey
 	return eventService.GetGeneralEvent(msi)
 }
 

--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -21,9 +21,9 @@ const (
 )
 
 type AnalyticsEventService struct {
-	client      *jfroghttpclient.JfrogHttpClient
-	XscDetails  auth.ServiceDetails
-	XrayDetails auth.ServiceDetails
+	client          *jfroghttpclient.JfrogHttpClient
+	XscDetails      auth.ServiceDetails
+	XrayDetails     auth.ServiceDetails
 	ScopeProjectKey string
 }
 

--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -3,13 +3,15 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
 	servicesutils "github.com/jfrog/jfrog-client-go/xsc/services/utils"
 	xscutils "github.com/jfrog/jfrog-client-go/xsc/services/utils"
-	"net/http"
 )
 
 const (
@@ -22,45 +24,54 @@ type AnalyticsEventService struct {
 	client      *jfroghttpclient.JfrogHttpClient
 	XscDetails  auth.ServiceDetails
 	XrayDetails auth.ServiceDetails
+	ScopeProjectKey string
 }
 
 func NewAnalyticsEventService(client *jfroghttpclient.JfrogHttpClient) *AnalyticsEventService {
 	return &AnalyticsEventService{client: client}
 }
 
-func (vs *AnalyticsEventService) sendPostRequest(requestContent []byte) (resp *http.Response, body []byte, err error) {
+func (vs *AnalyticsEventService) getAnalyticsEndPoint() string {
 	if vs.XrayDetails != nil {
-		httpClientDetails := vs.XrayDetails.CreateHttpClientDetails()
-		resp, body, err = vs.client.SendPost(utils.AddTrailingSlashIfNeeded(vs.XrayDetails.GetUrl())+xscutils.XscInXraySuffix+xscEventApi, requestContent, &httpClientDetails)
-		return
+		return utils.AddTrailingSlashIfNeeded(vs.XrayDetails.GetUrl()) + xscutils.XscInXraySuffix + xscEventApi
 	}
 	// Backward compatibility
-	httpClientDetails := vs.XscDetails.CreateHttpClientDetails()
-	resp, body, err = vs.client.SendPost(utils.AddTrailingSlashIfNeeded(vs.XscDetails.GetUrl())+xscDeprecatedEventApiSuffix, requestContent, &httpClientDetails)
+	return utils.AddTrailingSlashIfNeeded(vs.XscDetails.GetUrl()) + xscDeprecatedEventApiSuffix
+}
+
+func (vs *AnalyticsEventService) sendPostRequest(requestContent []byte) (resp *http.Response, body []byte, err error) {
+	var httpClientDetails httputils.HttpClientDetails
+	if vs.XrayDetails != nil {
+		httpClientDetails = vs.XrayDetails.CreateHttpClientDetails()
+	} else {
+		// Backward compatibility
+		httpClientDetails = vs.XscDetails.CreateHttpClientDetails()
+	}
+	resp, body, err = vs.client.SendPost(utils.AppendScopedProjectKeyParam(vs.getAnalyticsEndPoint(), vs.ScopeProjectKey), requestContent, &httpClientDetails)
 	return
 }
 
 func (vs *AnalyticsEventService) sendPutRequest(requestContent []byte) (resp *http.Response, body []byte, err error) {
+	var httpClientDetails httputils.HttpClientDetails
 	if vs.XrayDetails != nil {
-		httpClientDetails := vs.XrayDetails.CreateHttpClientDetails()
-		resp, body, err = vs.client.SendPut(utils.AddTrailingSlashIfNeeded(vs.XrayDetails.GetUrl())+xscutils.XscInXraySuffix+xscEventApi, requestContent, &httpClientDetails)
-		return
+		httpClientDetails = vs.XrayDetails.CreateHttpClientDetails()
+	} else {
+		// Backward compatibility
+		httpClientDetails = vs.XscDetails.CreateHttpClientDetails()
 	}
-	// Backward compatibility
-	httpClientDetails := vs.XscDetails.CreateHttpClientDetails()
-	resp, body, err = vs.client.SendPut(utils.AddTrailingSlashIfNeeded(vs.XscDetails.GetUrl())+xscDeprecatedEventApiSuffix, requestContent, &httpClientDetails)
+	resp, body, err = vs.client.SendPut(utils.AppendScopedProjectKeyParam(vs.getAnalyticsEndPoint(), vs.ScopeProjectKey), requestContent, &httpClientDetails)
 	return
 }
 
 func (vs *AnalyticsEventService) sendGetRequest(msi string) (resp *http.Response, body []byte, err error) {
+	var httpClientDetails httputils.HttpClientDetails
 	if vs.XrayDetails != nil {
-		httpClientDetails := vs.XrayDetails.CreateHttpClientDetails()
-		resp, body, _, err = vs.client.SendGet(fmt.Sprintf("%s%s%s/%s", vs.XrayDetails.GetUrl(), xscutils.XscInXraySuffix, xscEventApi, msi), true, &httpClientDetails)
-		return
+		httpClientDetails = vs.XrayDetails.CreateHttpClientDetails()
+	} else {
+		// Backward compatibility
+		httpClientDetails = vs.XscDetails.CreateHttpClientDetails()
 	}
-	// Backward compatibility
-	httpClientDetails := vs.XscDetails.CreateHttpClientDetails()
-	resp, body, _, err = vs.client.SendGet(fmt.Sprintf("%s%s/%s", vs.XscDetails.GetUrl(), xscDeprecatedEventApiSuffix, msi), true, &httpClientDetails)
+	resp, body, _, err = vs.client.SendGet(utils.AppendScopedProjectKeyParam(fmt.Sprintf("%s/%s", vs.getAnalyticsEndPoint(), msi), vs.ScopeProjectKey), true, &httpClientDetails)
 	return
 
 }

--- a/xsc/services/logerrorevent.go
+++ b/xsc/services/logerrorevent.go
@@ -18,9 +18,10 @@ const (
 )
 
 type LogErrorEventService struct {
-	client      *jfroghttpclient.JfrogHttpClient
-	XscDetails  auth.ServiceDetails
-	XrayDetails auth.ServiceDetails
+	client          *jfroghttpclient.JfrogHttpClient
+	XscDetails      auth.ServiceDetails
+	XrayDetails     auth.ServiceDetails
+	ScopeProjectKey string
 }
 
 type ExternalErrorLog struct {
@@ -37,13 +38,13 @@ func (les *LogErrorEventService) sendLogErrorRequest(requestContent []byte) (url
 	if les.XrayDetails != nil {
 		httpClientDetails := les.XrayDetails.CreateHttpClientDetails()
 		url = utils.AddTrailingSlashIfNeeded(les.XrayDetails.GetUrl()) + xscutils.XscInXraySuffix + xscLogErrorApiSuffix
-		resp, body, err = les.client.SendPost(url, requestContent, &httpClientDetails)
+		resp, body, err = les.client.SendPost(utils.AppendScopedProjectKeyParam(url, les.ScopeProjectKey), requestContent, &httpClientDetails)
 		return
 	}
 	// Backward compatibility
 	httpClientDetails := les.XscDetails.CreateHttpClientDetails()
 	url = utils.AddTrailingSlashIfNeeded(les.XscDetails.GetUrl()) + xscDeprecatedLogErrorApiSuffix
-	resp, body, err = les.client.SendPost(url, requestContent, &httpClientDetails)
+	resp, body, err = les.client.SendPost(utils.AppendScopedProjectKeyParam(url, les.ScopeProjectKey), requestContent, &httpClientDetails)
 	return
 }
 

--- a/xsc/services/profile.go
+++ b/xsc/services/profile.go
@@ -24,9 +24,9 @@ const (
 )
 
 type ConfigurationProfileService struct {
-	client      *jfroghttpclient.JfrogHttpClient
-	XscDetails  auth.ServiceDetails
-	XrayDetails auth.ServiceDetails
+	client          *jfroghttpclient.JfrogHttpClient
+	XscDetails      auth.ServiceDetails
+	XrayDetails     auth.ServiceDetails
 	ScopeProjectKey string
 }
 

--- a/xsc/services/profile.go
+++ b/xsc/services/profile.go
@@ -27,6 +27,7 @@ type ConfigurationProfileService struct {
 	client      *jfroghttpclient.JfrogHttpClient
 	XscDetails  auth.ServiceDetails
 	XrayDetails auth.ServiceDetails
+	ScopeProjectKey string
 }
 
 func NewConfigurationProfileService(client *jfroghttpclient.JfrogHttpClient) *ConfigurationProfileService {
@@ -145,7 +146,7 @@ func (cp *ConfigurationProfileService) sendConfigProfileByNameRequest(profileNam
 	if cp.XrayDetails != nil {
 		httpDetails := cp.XrayDetails.CreateHttpClientDetails()
 		url = fmt.Sprintf("%s%s%s/%s", utils.AddTrailingSlashIfNeeded(cp.XrayDetails.GetUrl()), xscutils.XscInXraySuffix, xscConfigProfileByNameApi, profileName)
-		resp, body, _, err = cp.client.SendGet(url, true, &httpDetails)
+		resp, body, _, err = cp.client.SendGet(utils.AppendScopedProjectKeyParam(url, cp.ScopeProjectKey), true, &httpDetails)
 		return
 	}
 	// Backward compatibility
@@ -177,7 +178,7 @@ func (cp *ConfigurationProfileService) sendConfigProfileByUrlRequest(repoUrl str
 	httpDetails := cp.XrayDetails.CreateHttpClientDetails()
 	url = fmt.Sprintf("%s%s%s", utils.AddTrailingSlashIfNeeded(cp.XrayDetails.GetUrl()), xscutils.XscInXraySuffix, xscConfigProfileByUrlApi)
 	requestContent := []byte(fmt.Sprintf(getProfileByUrlBody, repoUrl))
-	resp, body, err = cp.client.SendPost(url, requestContent, &httpDetails)
+	resp, body, err = cp.client.SendPost(utils.AppendScopedProjectKeyParam(url, cp.ScopeProjectKey), requestContent, &httpDetails)
 	return
 }
 

--- a/xsc/services/watch.go
+++ b/xsc/services/watch.go
@@ -25,8 +25,8 @@ const (
 
 // WatchService defines the http client and Xray details
 type WatchService struct {
-	client      *jfroghttpclient.JfrogHttpClient
-	XrayDetails auth.ServiceDetails
+	client          *jfroghttpclient.JfrogHttpClient
+	XrayDetails     auth.ServiceDetails
 	ScopeProjectKey string
 }
 
@@ -79,5 +79,5 @@ func (xws *WatchService) getWatchURL(gitRepo, project string) string {
 	if project != "" {
 		params = append(params, fmt.Sprintf("%s=%s", projectResourceUrlKey, project))
 	}
-	return utils.AppendScopedProjectKeyParam(url + "?" + strings.Join(params, "&"), xws.ScopeProjectKey) 
+	return utils.AppendScopedProjectKeyParam(url+"?"+strings.Join(params, "&"), xws.ScopeProjectKey)
 }

--- a/xsc/services/watch.go
+++ b/xsc/services/watch.go
@@ -27,6 +27,7 @@ const (
 type WatchService struct {
 	client      *jfroghttpclient.JfrogHttpClient
 	XrayDetails auth.ServiceDetails
+	ScopeProjectKey string
 }
 
 // NewWatchService creates a new Xray Watch Service
@@ -78,5 +79,5 @@ func (xws *WatchService) getWatchURL(gitRepo, project string) string {
 	if project != "" {
 		params = append(params, fmt.Sprintf("%s=%s", projectResourceUrlKey, project))
 	}
-	return url + "?" + strings.Join(params, "&")
+	return utils.AppendScopedProjectKeyParam(url + "?" + strings.Join(params, "&"), xws.ScopeProjectKey) 
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

For some of the API's, if the access token is project-scoped, it is expected to pass the related project key as a query param in the URL endpoint