### PR TITLE
Add FailPr files to Violation struct to support new fail_pr policy rule

### DIFF
--- a/xray/services/scan.go
+++ b/xray/services/scan.go
@@ -240,6 +240,7 @@ type Violation struct {
 	Cves                []Cve                `json:"cves,omitempty"`
 	References          []string             `json:"references,omitempty"`
 	FailBuild           bool                 `json:"fail_build,omitempty"`
+	FailPr              bool                 `json:"fail_pull_request,omitempty"`
 	LicenseKey          string               `json:"license_key,omitempty"`
 	LicenseName         string               `json:"license_name,omitempty"`
 	IgnoreUrl           string               `json:"ignore_url,omitempty"`


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
This PR adds the 'FailPr' field to violation struct in order to support new fail_pr rule