### PR TITLE
add delete evidence by subject endpoint call

### DIFF
--- a/evidence/manager.go
+++ b/evidence/manager.go
@@ -39,3 +39,8 @@ func (esm *EvidenceServicesManager) UploadEvidence(evidenceDetails services.Evid
 	evidenceService := services.NewEvidenceService(esm.config.GetServiceDetails(), esm.client)
 	return evidenceService.UploadEvidence(evidenceDetails)
 }
+
+func (esm *EvidenceServicesManager) DeleteEvidence(subjectRepoPath, evidenceName string) error {
+	evidenceService := services.NewEvidenceService(esm.config.GetServiceDetails(), esm.client)
+	return evidenceService.DeleteEvidence(subjectRepoPath, evidenceName)
+}

--- a/evidence/services/delete.go
+++ b/evidence/services/delete.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const evidenceDeleteApi = "api/v1/evidence"
+
+func (es *EvidenceService) DeleteEvidence(subjectRepoPath, evidenceName string) error {
+	fullPath := path.Join(evidenceDeleteApi, subjectRepoPath, evidenceName)
+	u := url.URL{Path: fullPath}
+
+	requestFullUrl, err := clientutils.BuildUrl(es.GetEvidenceDetails().GetUrl(), u.String(), nil)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+
+	httpClientDetails := es.GetEvidenceDetails().CreateHttpClientDetails()
+	httpClientDetails.SetContentTypeApplicationJson()
+
+	log.Debug("Deleting evidence: ", requestFullUrl)
+
+	resp, body, err := es.client.SendDelete(requestFullUrl, nil, &httpClientDetails)
+	if err != nil {
+		return err
+	}
+
+	return errorutils.CheckResponseStatusWithBody(resp, body, http.StatusNoContent)
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
**Description**:
This PR is the part of the two PRs which introduce a new command for the jf evd CLI tool that allows users to delete evidence based on specific criteria. The new delete command resolves the subject and facilitates the deletion of evidence using its name.

jfrog-cli-artifactory PR:

The command uses the same subject definition as create and verify commands.
The output of help command:
`Name:
  jf evd delete-evidence -  Delete evidence associated with a specified subject by evidence name. 

Usage:
  jf evd delete-evidence [command options] --evidence-name=<value>
  
Options:
  --access-token              [Optional] JFrog access token.
  --build-name                [Optional] Build name.
  --build-number              [Optional] Build number.
  --evidence-name             [Mandatory] Evidence file name.
  --package-name              [Optional] Package name.
  --package-repo-name         [Optional] Package repository Name.
  --package-version           [Optional] Package version.
  --project                   [Optional] Project key associated with the created evidence.
  --release-bundle            [Optional] Release Bundle name.
  --release-bundle-version    [Optional] Release Bundle version.
  --server-id                 [Optional] Server ID configured using the config command.
  --subject-repo-path         [Optional] Full path to some subject location.
  --url                       [Optional] JFrog Platform URL.
  --user                      [Optional] JFrog username`

Example of call:
`jf evd delete --release-bundle mishas_bundle --release-bundle-version 45  --evidence-name release-bundle-signature-1753360796034-204c2ab4.json`