### PR TITLE
Add Get Artifact Scan Status Xray API

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
       - [Get Violations Report Content](#get-violations-report-content)
       - [Delete Violations Report](#delete-violations-report)
       - [Get Artifact Summary](#get-artifact-summary)
+      - [Get Artifact Scan Status](#get-artifact-scan-status)
       - [Get Entitlement info](#get-entitlement-info)
     - [XSC APIs](#xsc-apis)
       - [Creating XSC Service Manager](#creating-xray-service-manager)
@@ -2642,6 +2643,23 @@ artifactSummaryRequest := services.ArtifactSummaryParams{
   Paths:     []string{"default/example-repository/example-folder/example-artifact"},
 }
 artifactSummary, err := xrayManager.ArtifactSummary(artifactSummaryRequest)
+```
+
+#### Get Artifact Scan Status
+```go
+// Get the scan status of an artifact in a specific repository
+repo := "example-repository"
+path := "path/to/artifact"
+artifactStatus, err := xrayManager.GetArtifactStatus(repo, path)
+
+// The response contains overall status and detailed status for different scan types
+if err == nil {
+    fmt.Printf("Overall scan status: %s\n", artifactStatus.Overall.Status)
+    fmt.Printf("SCA scan status: %s\n", artifactStatus.Details.Sca.Status)
+    fmt.Printf("Contextual Analysis status: %s\n", artifactStatus.Details.ContextualAnalysis.Status)
+    fmt.Printf("Exposures scan status: %s\n", artifactStatus.Details.Exposures.Status)
+    fmt.Printf("Violations status: %s\n", artifactStatus.Details.Violations.Status)
+}
 ```
 
 #### Get Entitlement Info

--- a/artifactory/services/utils/tests/xray/consts.go
+++ b/artifactory/services/utils/tests/xray/consts.go
@@ -1439,6 +1439,81 @@ const XscGitInfoResponse = `{"multi_scan_id": "3472b4e2-bddc-11ee-a9c9-acde48001
 
 const XscGitInfoBadResponse = `"failed create git info request: git_repo_url field must contain value"`
 
+const ArtifactStatusResponse = `{
+  "overall": {
+    "status": "DONE",
+    "time": "2023-12-01T10:00:00Z"
+  },
+  "details": {
+    "sca": {
+      "status": "DONE",
+      "time": "2023-12-01T10:00:00Z"
+    },
+    "contextual_analysis": {
+      "status": "DONE",
+      "time": "2023-12-01T10:00:00Z"
+    },
+    "exposures": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T10:00:00Z"
+    },
+    "violations": {
+      "status": "FAILED",
+      "time": "2023-12-01T10:00:00Z"
+    }
+  }
+}`
+
+const ArtifactStatusPendingResponse = `{
+  "overall": {
+    "status": "PENDING",
+    "time": "2023-12-01T09:30:00Z"
+  },
+  "details": {
+    "sca": {
+      "status": "PENDING",
+      "time": "2023-12-01T09:30:00Z"
+    },
+    "contextual_analysis": {
+      "status": "NOT_SCANNED",
+      "time": "2023-12-01T09:30:00Z"
+    },
+    "exposures": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T09:30:00Z"
+    },
+    "violations": {
+      "status": "NOT_SCANNED",
+      "time": "2023-12-01T09:30:00Z"
+    }
+  }
+}`
+
+const ArtifactStatusNotSupportedResponse = `{
+  "overall": {
+    "status": "NOT_SUPPORTED",
+    "time": "2023-12-01T11:00:00Z"
+  },
+  "details": {
+    "sca": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T11:00:00Z"
+    },
+    "contextual_analysis": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T11:00:00Z"
+    },
+    "exposures": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T11:00:00Z"
+    },
+    "violations": {
+      "status": "NOT_SUPPORTED",
+      "time": "2023-12-01T11:00:00Z"
+    }
+  }
+}`
+
 var GitInfoContextWithMinimalRequiredFields = xscServices.XscGitInfoContext{
 	Source: xscServices.CommitContext{
 		GitRepoHttpsCloneUrl: "https://git.jfrog.info/projects/XSC/repos/xsc-service",

--- a/tests/xrayartifact_test.go
+++ b/tests/xrayartifact_test.go
@@ -1,0 +1,101 @@
+package tests
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils/tests/xray"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+func TestArtifactStatus(t *testing.T) {
+	initXrayTest(t)
+	xrayServerPort := xray.StartXrayMockServer(t)
+	xrayDetails := GetXrayDetails()
+	client, err := jfroghttpclient.JfrogClientBuilder().
+		SetClientCertPath(xrayDetails.GetClientCertPath()).
+		SetClientCertKeyPath(xrayDetails.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(xrayDetails.RunPreRequestFunctions).
+		Build()
+	if err != nil {
+		t.Error(err)
+	}
+	testsArtifactService := services.NewArtifactService(client)
+	testsArtifactService.XrayDetails = xrayDetails
+	testsArtifactService.XrayDetails.SetUrl("http://localhost:" + strconv.Itoa(xrayServerPort) + "/")
+
+	tests := []struct {
+		name           string
+		repo           string
+		path           string
+		expectedStatus services.ArtifactStatus
+		expectedTime   string
+	}{
+		{
+			name:           "completed-scan",
+			repo:           "test-repo",
+			path:           "path/to/artifact",
+			expectedStatus: services.ArtifactStatusDone,
+			expectedTime:   "2023-12-01T10:00:00Z",
+		},
+		{
+			name:           "pending-scan",
+			repo:           "test-repo",
+			path:           "path/to/pending-artifact",
+			expectedStatus: services.ArtifactStatusPending,
+			expectedTime:   "2023-12-01T09:30:00Z",
+		},
+		{
+			name:           "unsupported-artifact",
+			repo:           "test-repo",
+			path:           "path/to/unsupported-artifact",
+			expectedStatus: services.ArtifactStatusNotSupported,
+			expectedTime:   "2023-12-01T11:00:00Z",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := testsArtifactService.GetStatus(test.repo, test.path)
+			assert.NoError(t, err)
+			assert.NotNil(t, response)
+
+			// Verify the overall status and timestamp
+			assert.Equal(t, test.expectedStatus, response.Overall.Status)
+			assert.Equal(t, test.expectedTime, response.Overall.Timestamp)
+
+			// Verify that all details have timestamps
+			assert.NotEmpty(t, response.Details.Sca.Timestamp)
+			assert.NotEmpty(t, response.Details.ContextualAnalysis.Timestamp)
+			assert.NotEmpty(t, response.Details.Exposures.Timestamp)
+			assert.NotEmpty(t, response.Details.Violations.Timestamp)
+		})
+	}
+
+	// Test specific scenario details for the completed scan
+	t.Run("completed-scan-details", func(t *testing.T) {
+		response, err := testsArtifactService.GetStatus("test-repo", "path/to/artifact")
+		assert.NoError(t, err)
+
+		// Verify specific statuses for the completed scan
+		assert.Equal(t, services.ArtifactStatusDone, response.Details.Sca.Status)
+		assert.Equal(t, services.ArtifactStatusDone, response.Details.ContextualAnalysis.Status)
+		assert.Equal(t, services.ArtifactStatusNotSupported, response.Details.Exposures.Status)
+		assert.Equal(t, services.ArtifactStatusFailed, response.Details.Violations.Status)
+	})
+
+	// Test specific scenario details for the pending scan
+	t.Run("pending-scan-details", func(t *testing.T) {
+		response, err := testsArtifactService.GetStatus("test-repo", "path/to/pending-artifact")
+		assert.NoError(t, err)
+
+		// Verify specific statuses for the pending scan
+		assert.Equal(t, services.ArtifactStatusPending, response.Details.Sca.Status)
+		assert.Equal(t, services.ArtifactStatusNotScanned, response.Details.ContextualAnalysis.Status)
+		assert.Equal(t, services.ArtifactStatusNotSupported, response.Details.Exposures.Status)
+		assert.Equal(t, services.ArtifactStatusNotScanned, response.Details.Violations.Status)
+	})
+}

--- a/xray/manager.go
+++ b/xray/manager.go
@@ -262,3 +262,10 @@ func (sm *XrayServicesManager) Xsc() *xsc.XscInnerService {
 	xscService.ScopeProjectKey = sm.scopeProjectKey
 	return xscService
 }
+
+func (sm *XrayServicesManager) GetArtifactStatus(repo, path string) (*services.ArtifactStatusResponse, error) {
+	artifactService := services.NewArtifactService(sm.client)
+	artifactService.XrayDetails = sm.config.GetServiceDetails()
+	artifactService.ScopeProjectKey = sm.scopeProjectKey
+	return artifactService.GetStatus(repo, path)
+}

--- a/xray/services/artifact.go
+++ b/xray/services/artifact.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+const (
+	statusAPI = "api/v1/artifact/status"
+)
+
+// ArtifactStatus represents the status of an artifact in Xray
+const (
+	ArtifactStatusNotSupported ArtifactStatus = "NOT_SUPPORTED"
+	ArtifactStatusNotScanned   ArtifactStatus = "NOT_SCANNED"
+	ArtifactStatusPending      ArtifactStatus = "PENDING"
+	ArtifactStatusScanning     ArtifactStatus = "SCANNING"
+	ArtifactStatusDone         ArtifactStatus = "DONE"
+	ArtifactStatusPartial      ArtifactStatus = "PARTIAL"
+	ArtifactStatusFailed       ArtifactStatus = "FAILED"
+)
+
+type ArtifactStatus string
+
+type ArtifactService struct {
+	client          *jfroghttpclient.JfrogHttpClient
+	XrayDetails     auth.ServiceDetails
+	ScopeProjectKey string
+}
+
+// NewArtifactService creates a new service for interacting with artifacts in Xray.
+func NewArtifactService(client *jfroghttpclient.JfrogHttpClient) *ArtifactService {
+	return &ArtifactService{client: client}
+}
+
+func (as *ArtifactService) GetStatus(repo, path string) (response *ArtifactStatusResponse, err error) {
+	httpClientsDetails := as.XrayDetails.CreateHttpClientDetails()
+	httpClientsDetails.SetContentTypeApplicationJson()
+
+	requestBody, err := json.Marshal(ArtifactStatusRequest{Repository: repo, Path: path})
+	if errorutils.CheckError(err) != nil {
+		return
+	}
+
+	resp, body, err := as.client.SendPost(clientutils.AppendScopedProjectKeyParam(as.XrayDetails.GetUrl()+statusAPI, as.ScopeProjectKey), requestBody, &httpClientsDetails)
+	if err != nil {
+		return
+	}
+
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		err = fmt.Errorf("got unexpected server response while attempting to get artifact status for %s/%s:\n%s", repo, path, err.Error())
+		return
+	}
+
+	response = &ArtifactStatusResponse{}
+	if err = json.Unmarshal(body, response); err != nil {
+		err = errorutils.CheckErrorf("couldn't parse JFrog Xray artifact status response: %s", err.Error())
+	}
+	return
+}
+
+type ArtifactStatusRequest struct {
+	Repository string `json:"repo"`
+	Path       string `json:"path"`
+}
+
+type ArtifactStatusResponse struct {
+	Overall ArtifactScanStatus     `json:"overall"`
+	Details ArtifactDetailedStatus `json:"details"`
+}
+
+type ArtifactScanStatus struct {
+	Status ArtifactStatus `json:"status"`
+	// Timestamp in RFC 3339 format
+	Timestamp string `json:"time"`
+}
+
+type ArtifactDetailedStatus struct {
+	Sca                ArtifactScanStatus `json:"sca"`
+	ContextualAnalysis ArtifactScanStatus `json:"contextual_analysis"`
+	Exposures          ArtifactScanStatus `json:"exposures"`
+	Violations         ArtifactScanStatus `json:"violations"`
+}
+
+type ArtifactExposureScanStatus struct {
+	// Overall status of the exposure scans
+	ArtifactScanStatus
+	Categories ArtifactExposureCategoriesStatus `json:"categories"`
+}
+
+type ArtifactExposureCategoriesStatus struct {
+	IaC          ArtifactScanStatus `json:"iac"`
+	Secrets      ArtifactScanStatus `json:"secrets"`
+	Services     ArtifactScanStatus `json:"services"`
+	Applications ArtifactScanStatus `json:"applications"`
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----


Add new Get Artifact Scan Status API to Xray manager, following:
* https://jfrog.com/help/r/xray-rest-apis/artifact-scan-status