### PR TITLE
Add dev sonar integration

### DIFF
--- a/sonar/auth/sonardetails.go
+++ b/sonar/auth/sonardetails.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/jfrog/jfrog-client-go/auth"
+)
+
+type sonarDetails struct {
+	auth.CommonConfigFields
+}
+
+func NewSonarDetails() auth.ServiceDetails {
+	return &sonarDetails{}
+}
+
+func (sd *sonarDetails) GetVersion() (string, error) {
+	panic("Failed: Method is not implemented")
+}

--- a/sonar/auth/sonardetails_test.go
+++ b/sonar/auth/sonardetails_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSonarDetails(t *testing.T) {
+	details := NewSonarDetails()
+	assert.NotNil(t, details)
+	assert.IsType(t, &sonarDetails{}, details)
+}
+
+func TestSonarDetails_GetVersion(t *testing.T) {
+	details := NewSonarDetails()
+
+	assert.Panics(t, func() {
+		details.GetVersion()
+	}, "GetVersion should panic as it's not implemented")
+}

--- a/sonar/auth/sonardetails_test.go
+++ b/sonar/auth/sonardetails_test.go
@@ -11,11 +11,3 @@ func TestNewSonarDetails(t *testing.T) {
 	assert.NotNil(t, details)
 	assert.IsType(t, &sonarDetails{}, details)
 }
-
-func TestSonarDetails_GetVersion(t *testing.T) {
-	details := NewSonarDetails()
-
-	assert.Panics(t, func() {
-		details.GetVersion()
-	}, "GetVersion should panic as it's not implemented")
-}

--- a/sonar/manager.go
+++ b/sonar/manager.go
@@ -11,7 +11,7 @@ import (
 type Manager interface {
 	GetQualityGateAnalysis(analysisID string) (*services.QualityGatesAnalysis, error)
 	GetTaskDetails(ceTaskID string) (*services.TaskDetails, error)
-	GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error)
+	GetSonarIntotoStatement(ceTaskID string) ([]byte, error)
 }
 
 type sonarManager struct {
@@ -47,9 +47,9 @@ func (sm *sonarManager) Client() *jfroghttpclient.JfrogHttpClient {
 	return sm.client
 }
 
-func (sm *sonarManager) GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error) {
+func (sm *sonarManager) GetSonarIntotoStatement(ceTaskID string) ([]byte, error) {
 	sonarService := services.NewSonarService(sm.config.GetServiceDetails(), sm.client)
-	return sonarService.GetSonarIntotoStatementRaw(ceTaskID)
+	return sonarService.GetSonarIntotoStatement(ceTaskID)
 }
 
 func (sm *sonarManager) GetQualityGateAnalysis(analysisID string) (*services.QualityGatesAnalysis, error) {

--- a/sonar/manager.go
+++ b/sonar/manager.go
@@ -1,0 +1,63 @@
+package sonar
+
+import (
+	"fmt"
+
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/sonar/services"
+)
+
+type Manager interface {
+	GetQualityGateAnalysis(analysisID string) (*services.QualityGatesAnalysis, error)
+	GetTaskDetails(ceTaskID string) (*services.TaskDetails, error)
+	GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error)
+}
+
+type sonarManager struct {
+	client *jfroghttpclient.JfrogHttpClient
+	config config.Config
+}
+
+func NewManager(config config.Config) (Manager, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	details := config.GetServiceDetails()
+	var err error
+	manager := &sonarManager{config: config}
+	manager.client, err = jfroghttpclient.JfrogClientBuilder().
+		SetCertificatesPath(config.GetCertificatesPath()).
+		SetInsecureTls(config.IsInsecureTls()).
+		SetClientCertPath(details.GetClientCertPath()).
+		SetClientCertKeyPath(details.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
+		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
+		SetRetries(config.GetHttpRetries()).
+		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
+		Build()
+
+	return manager, err
+}
+
+func (sm *sonarManager) Client() *jfroghttpclient.JfrogHttpClient {
+	return sm.client
+}
+
+func (sm *sonarManager) GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error) {
+	sonarService := services.NewSonarService(sm.config.GetServiceDetails(), sm.client)
+	return sonarService.GetSonarIntotoStatementRaw(ceTaskID)
+}
+
+func (sm *sonarManager) GetQualityGateAnalysis(analysisID string) (*services.QualityGatesAnalysis, error) {
+	sonarService := services.NewSonarService(sm.config.GetServiceDetails(), sm.client)
+	return sonarService.GetQualityGateAnalysis(analysisID)
+}
+
+func (sm *sonarManager) GetTaskDetails(ceTaskID string) (*services.TaskDetails, error) {
+	sonarService := services.NewSonarService(sm.config.GetServiceDetails(), sm.client)
+	return sonarService.GetTaskDetails(ceTaskID)
+}

--- a/sonar/manager_test.go
+++ b/sonar/manager_test.go
@@ -40,7 +40,8 @@ func TestSonarManager_Client(t *testing.T) {
 	manager, err := NewManager(cfg)
 	assert.NoError(t, err)
 
-	sm := manager.(*sonarManager)
+	sm, ok := manager.(*sonarManager)
+	assert.True(t, ok)
 	client := sm.Client()
 	assert.NotNil(t, client)
 }

--- a/sonar/manager_test.go
+++ b/sonar/manager_test.go
@@ -60,5 +60,5 @@ func TestSonarManager_InterfaceMethods(t *testing.T) {
 	// Call interface methods; network outcome is not asserted
 	_, _ = manager.GetQualityGateAnalysis("test-analysis-id")
 	_, _ = manager.GetTaskDetails("test-task-id")
-	_, _ = manager.GetSonarIntotoStatementRaw("test-task-id")
+	_, _ = manager.GetSonarIntotoStatement("test-task-id")
 }

--- a/sonar/manager_test.go
+++ b/sonar/manager_test.go
@@ -1,0 +1,63 @@
+package sonar
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/config"
+	sonarauth "github.com/jfrog/jfrog-client-go/sonar/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewManager(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	cfg, err := config.NewConfigBuilder().SetServiceDetails(serviceDetails).Build()
+	assert.NoError(t, err)
+
+	manager, err := NewManager(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+	assert.IsType(t, &sonarManager{}, manager)
+}
+
+func TestNewManager_WithInvalidConfig(t *testing.T) {
+	// Test with nil config
+	manager, err := NewManager(nil)
+	assert.Error(t, err)
+	assert.Nil(t, manager)
+}
+
+func TestSonarManager_Client(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	cfg, err := config.NewConfigBuilder().SetServiceDetails(serviceDetails).Build()
+	assert.NoError(t, err)
+
+	manager, err := NewManager(cfg)
+	assert.NoError(t, err)
+
+	sm := manager.(*sonarManager)
+	client := sm.Client()
+	assert.NotNil(t, client)
+}
+
+func TestSonarManager_InterfaceMethods(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	cfg, err := config.NewConfigBuilder().SetServiceDetails(serviceDetails).Build()
+	assert.NoError(t, err)
+
+	manager, err := NewManager(cfg)
+	assert.NoError(t, err)
+
+	// Call interface methods; network outcome is not asserted
+	_, _ = manager.GetQualityGateAnalysis("test-analysis-id")
+	_, _ = manager.GetTaskDetails("test-task-id")
+	_, _ = manager.GetSonarIntotoStatementRaw("test-task-id")
+}

--- a/sonar/services/sonar.go
+++ b/sonar/services/sonar.go
@@ -63,7 +63,7 @@ type TaskDetails struct {
 type Service interface {
 	GetQualityGateAnalysis(analysisID string) (*QualityGatesAnalysis, error)
 	GetTaskDetails(ceTaskID string) (*TaskDetails, error)
-	GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error)
+	GetSonarIntotoStatement(ceTaskID string) ([]byte, error)
 }
 
 type sonarService struct {
@@ -122,8 +122,8 @@ func (s *sonarService) httpGetJSON(urlStr string) ([]byte, int, error) {
 
 // GetSonarIntotoStatementRaw returns the raw JSON bytes of the in-toto statement.
 // We return []byte instead of a typed object to avoid extra marshal/unmarshal cycles and
-// to allow callers to augment the statement (e.g., add subject/stage) and sign it as-is.
-func (s *sonarService) GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error) {
+// to allow callers to sign it as-is.
+func (s *sonarService) GetSonarIntotoStatement(ceTaskID string) ([]byte, error) {
 	if ceTaskID == "" {
 		return nil, errorutils.CheckError(fmt.Errorf("missing ce task id for enterprise endpoint"))
 	}

--- a/sonar/services/sonar.go
+++ b/sonar/services/sonar.go
@@ -1,0 +1,204 @@
+package services
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	DefaultSonarURL = "https://api.sonarcloud.io"
+)
+
+// Response models for SonarQube API endpoints
+type QualityGatesAnalysis struct {
+	ProjectStatus struct {
+		Status     string `json:"status"`
+		Conditions []struct {
+			Status         string `json:"status"`
+			MetricKey      string `json:"metricKey"`
+			Comparator     string `json:"comparator"`
+			PeriodIndex    int    `json:"periodIndex"`
+			ErrorThreshold string `json:"errorThreshold"`
+			ActualValue    string `json:"actualValue"`
+		} `json:"conditions"`
+		Periods []struct {
+			Index int    `json:"index"`
+			Mode  string `json:"mode"`
+			Date  string `json:"date"`
+		} `json:"periods"`
+		IgnoredConditions bool `json:"ignoredConditions"`
+	} `json:"projectStatus"`
+}
+
+type TaskDetails struct {
+	Task struct {
+		ID                 string      `json:"id"`
+		Type               string      `json:"type"`
+		ComponentID        string      `json:"componentId"`
+		ComponentKey       string      `json:"componentKey"`
+		ComponentName      string      `json:"componentName"`
+		ComponentQualifier string      `json:"componentQualifier"`
+		AnalysisID         string      `json:"analysisId"`
+		Status             string      `json:"status"`
+		SubmittedAt        string      `json:"submittedAt"`
+		StartedAt          string      `json:"startedAt"`
+		ExecutedAt         string      `json:"executedAt"`
+		ExecutionTimeMs    int         `json:"executionTimeMs"`
+		Logs               interface{} `json:"logs"`
+		HasScannerContext  bool        `json:"hasScannerContext"`
+		Organization       string      `json:"organization"`
+	} `json:"task"`
+}
+
+type Service interface {
+	GetQualityGateAnalysis(analysisID string) (*QualityGatesAnalysis, error)
+	GetTaskDetails(ceTaskID string) (*TaskDetails, error)
+	GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error)
+}
+
+type sonarService struct {
+	client         *jfroghttpclient.JfrogHttpClient
+	serviceDetails auth.ServiceDetails
+}
+
+func NewSonarService(serviceDetails auth.ServiceDetails, client *jfroghttpclient.JfrogHttpClient) Service {
+	return &sonarService{serviceDetails: serviceDetails, client: client}
+}
+
+func (s *sonarService) GetSonarDetails() auth.ServiceDetails {
+	return s.serviceDetails
+}
+
+func (s *sonarService) buildAuthHeader() string {
+	// 1) Access token
+	token := s.serviceDetails.GetAccessToken()
+	if token != "" {
+		return "Bearer " + token
+	}
+	// 2) API key
+	if apiKey := s.serviceDetails.GetApiKey(); apiKey != "" {
+		return "Bearer " + apiKey
+	}
+	// 3) Basic auth
+	user := s.serviceDetails.GetUser()
+	pass := s.serviceDetails.GetPassword()
+	if user != "" && pass != "" {
+		creds := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+		return "Basic " + creds
+	}
+	// 4) Env token fallback
+	if val := os.Getenv("SONAR_TOKEN"); val != "" {
+		return "Bearer " + val
+	}
+	if val := os.Getenv("SONARQUBE_TOKEN"); val != "" {
+		return "Bearer " + val
+	}
+	return ""
+}
+
+func (s *sonarService) httpGetJSON(urlStr string) ([]byte, int, error) {
+	httpClientDetails := s.GetSonarDetails().CreateHttpClientDetails()
+	httpClientDetails.Headers["Authorization"] = s.buildAuthHeader()
+
+	log.Debug("HTTP GET", urlStr)
+	resp, body, _, err := s.client.SendGet(urlStr, true, &httpClientDetails)
+	if err != nil {
+		log.Debug("HTTP GET error for", urlStr, "error:", err.Error())
+		return nil, 0, err
+	}
+	log.Debug("HTTP GET response for", urlStr, "status:", resp.StatusCode, "body:", string(body))
+	return body, resp.StatusCode, nil
+}
+
+// GetSonarIntotoStatementRaw returns the raw JSON bytes of the in-toto statement.
+// We return []byte instead of a typed object to avoid extra marshal/unmarshal cycles and
+// to allow callers to augment the statement (e.g., add subject/stage) and sign it as-is.
+func (s *sonarService) GetSonarIntotoStatementRaw(ceTaskID string) ([]byte, error) {
+	if ceTaskID == "" {
+		return nil, errorutils.CheckError(fmt.Errorf("missing ce task id for enterprise endpoint"))
+	}
+	sonarBaseURL := s.GetSonarDetails().GetUrl()
+	if sonarBaseURL == "" {
+		sonarBaseURL = DefaultSonarURL
+	}
+	baseURL := strings.TrimRight(sonarBaseURL, "/")
+	u, _ := url.Parse(baseURL)
+	hostname := u.Hostname()
+	if hostname != "localhost" && net.ParseIP(hostname) == nil && !strings.HasPrefix(hostname, "api.") {
+		baseURL = strings.Replace(baseURL, "://", "://api.", 1)
+	}
+	enterpriseURL := fmt.Sprintf("%s/dop-translation/jfrog-evidence/%s", baseURL, url.QueryEscape(ceTaskID))
+	body, statusCode, err := s.httpGetJSON(enterpriseURL)
+	if err != nil {
+		return nil, errorutils.CheckErrorf("enterprise endpoint failed with status %d and response %s %v", statusCode, string(body), err)
+	}
+	if statusCode != 200 {
+		return nil, errorutils.CheckErrorf("enterprise endpoint returned status %d: %s", statusCode, string(body))
+	}
+	return body, nil
+}
+
+func (s *sonarService) GetQualityGateAnalysis(analysisID string) (*QualityGatesAnalysis, error) {
+	if analysisID == "" {
+		return nil, errorutils.CheckError(fmt.Errorf("missing analysis id for quality gates endpoint"))
+	}
+
+	sonarBaseURL := s.GetSonarDetails().GetUrl()
+	if sonarBaseURL == "" {
+		sonarBaseURL = DefaultSonarURL
+	}
+
+	qualityGatesURL := fmt.Sprintf("%s/api/qualitygates/project_status?analysisId=%s", strings.TrimRight(sonarBaseURL, "/"), url.QueryEscape(analysisID))
+
+	body, statusCode, err := s.httpGetJSON(qualityGatesURL)
+	if err != nil {
+		return nil, errorutils.CheckErrorf("quality gates endpoint failed with status %d: %v", statusCode, err)
+	}
+	if statusCode != 200 {
+		return nil, errorutils.CheckErrorf("quality gates endpoint returned status %d: %s", statusCode, string(body))
+	}
+
+	var response QualityGatesAnalysis
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, errorutils.CheckErrorf("failed to parse quality gates response: %v", err)
+	}
+
+	return &response, nil
+}
+
+func (s *sonarService) GetTaskDetails(ceTaskID string) (*TaskDetails, error) {
+	if ceTaskID == "" {
+		return nil, nil
+	}
+
+	sonarBaseURL := s.GetSonarDetails().GetUrl()
+	if sonarBaseURL == "" {
+		sonarBaseURL = DefaultSonarURL
+	}
+
+	taskURL := fmt.Sprintf("%s/api/ce/task?id=%s", strings.TrimRight(sonarBaseURL, "/"), url.QueryEscape(ceTaskID))
+	body, statusCode, err := s.httpGetJSON(taskURL)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != 200 {
+		return nil, errorutils.CheckErrorf("task endpoint returned status %d: %s", statusCode, string(body))
+	}
+
+	var response TaskDetails
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, errorutils.CheckErrorf("failed to parse task response: %v", err)
+	}
+
+	return &response, nil
+}

--- a/sonar/services/sonar.go
+++ b/sonar/services/sonar.go
@@ -120,7 +120,7 @@ func (s *sonarService) httpGetJSON(urlStr string) ([]byte, int, error) {
 	return body, resp.StatusCode, nil
 }
 
-// GetSonarIntotoStatementRaw returns the raw JSON bytes of the in-toto statement.
+// GetSonarIntotoStatement returns the raw JSON bytes of the in-toto statement.
 // We return []byte instead of a typed object to avoid extra marshal/unmarshal cycles and
 // to allow callers to sign it as-is.
 func (s *sonarService) GetSonarIntotoStatement(ceTaskID string) ([]byte, error) {

--- a/sonar/services/sonar_test.go
+++ b/sonar/services/sonar_test.go
@@ -146,7 +146,7 @@ func TestSonarService_GetEnterpriseResponse(t *testing.T) {
 
 	service := NewSonarService(serviceDetails, client)
 
-	body, err := service.GetSonarIntotoStatementRaw("test-task-id")
+	body, err := service.GetSonarIntotoStatement("test-task-id")
 	assert.NoError(t, err)
 	assert.NotNil(t, body)
 
@@ -167,7 +167,7 @@ func TestSonarService_GetEnterpriseResponse_EmptyTaskID(t *testing.T) {
 
 	service := NewSonarService(serviceDetails, client)
 
-	body, err := service.GetSonarIntotoStatementRaw("")
+	body, err := service.GetSonarIntotoStatement("")
 	assert.Error(t, err)
 	assert.Nil(t, body)
 	assert.Contains(t, err.Error(), "missing ce task id")

--- a/sonar/services/sonar_test.go
+++ b/sonar/services/sonar_test.go
@@ -1,0 +1,334 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	sonarauth "github.com/jfrog/jfrog-client-go/sonar/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+// Local copy for unmarshalling expectations
+type localStatement struct {
+	Type          string                 `json:"_type"`
+	PredicateType string                 `json:"predicateType"`
+	Predicate     map[string]interface{} `json:"predicate"`
+	CreatedAt     string                 `json:"createdAt"`
+	CreatedBy     string                 `json:"createdBy"`
+	Markdown      string                 `json:"markdown"`
+}
+
+func TestNewSonarService(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+	assert.NotNil(t, service)
+	assert.IsType(t, &sonarService{}, service)
+}
+
+func TestSonarService_BuildAuthHeader(t *testing.T) {
+	os.Unsetenv("SONAR_TOKEN")
+	tests := []struct {
+		name           string
+		accessToken    string
+		apiKey         string
+		user           string
+		password       string
+		envToken       string
+		expectedPrefix string
+	}{
+		{
+			name:           "Access token takes precedence",
+			accessToken:    "access-token",
+			apiKey:         "api-key",
+			user:           "user",
+			password:       "password",
+			envToken:       "",
+			expectedPrefix: "Bearer access-token",
+		},
+		{
+			name:           "API key used when no access token",
+			accessToken:    "",
+			apiKey:         "api-key",
+			user:           "user",
+			password:       "password",
+			envToken:       "",
+			expectedPrefix: "Bearer api-key",
+		},
+		{
+			name:           "Basic auth used when no token",
+			accessToken:    "",
+			apiKey:         "",
+			user:           "user",
+			password:       "password",
+			envToken:       "",
+			expectedPrefix: "Basic dXNlcjpwYXNzd29yZA==",
+		},
+		{
+			name:           "Environment token used when no service details",
+			accessToken:    "",
+			apiKey:         "",
+			user:           "",
+			password:       "",
+			envToken:       "env-token",
+			expectedPrefix: "Bearer env-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serviceDetails := sonarauth.NewSonarDetails()
+			serviceDetails.SetAccessToken(tt.accessToken)
+			serviceDetails.SetApiKey(tt.apiKey)
+			serviceDetails.SetUser(tt.user)
+			serviceDetails.SetPassword(tt.password)
+
+			client, err := jfroghttpclient.JfrogClientBuilder().Build()
+			assert.NoError(t, err)
+
+			service := &sonarService{
+				client:         client,
+				serviceDetails: serviceDetails,
+			}
+
+			if tt.envToken != "" {
+				os.Setenv("SONAR_TOKEN", tt.envToken)
+				defer os.Unsetenv("SONAR_TOKEN")
+			} else {
+				os.Unsetenv("SONAR_TOKEN")
+			}
+
+			authHeader := service.buildAuthHeader()
+			assert.Contains(t, authHeader, tt.expectedPrefix)
+		})
+	}
+}
+
+func TestSonarService_GetEnterpriseResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/dop-translation/jfrog-evidence/")
+
+		response := localStatement{
+			Type:          "test-type",
+			PredicateType: "test-type",
+			Predicate:     map[string]interface{}{"test": "data"},
+			Markdown:      "test markdown",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl(server.URL)
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	body, err := service.GetSonarIntotoStatementRaw("test-task-id")
+	assert.NoError(t, err)
+	assert.NotNil(t, body)
+
+	var result localStatement
+	assert.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, "test-type", result.PredicateType)
+	assert.Equal(t, "test markdown", result.Markdown)
+	assert.Equal(t, "data", result.Predicate["test"])
+}
+
+func TestSonarService_GetEnterpriseResponse_EmptyTaskID(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	body, err := service.GetSonarIntotoStatementRaw("")
+	assert.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), "missing ce task id")
+}
+
+func TestSonarService_GetQualityGatesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/qualitygates/project_status")
+		assert.Contains(t, r.URL.RawQuery, "analysisId=test-analysis-id")
+
+		response := QualityGatesAnalysis{
+			ProjectStatus: struct {
+				Status     string `json:"status"`
+				Conditions []struct {
+					Status         string `json:"status"`
+					MetricKey      string `json:"metricKey"`
+					Comparator     string `json:"comparator"`
+					PeriodIndex    int    `json:"periodIndex"`
+					ErrorThreshold string `json:"errorThreshold"`
+					ActualValue    string `json:"actualValue"`
+				} `json:"conditions"`
+				Periods []struct {
+					Index int    `json:"index"`
+					Mode  string `json:"mode"`
+					Date  string `json:"date"`
+				} `json:"periods"`
+				IgnoredConditions bool `json:"ignoredConditions"`
+			}{
+				Status: "OK",
+				Conditions: []struct {
+					Status         string `json:"status"`
+					MetricKey      string `json:"metricKey"`
+					Comparator     string `json:"comparator"`
+					PeriodIndex    int    `json:"periodIndex"`
+					ErrorThreshold string `json:"errorThreshold"`
+					ActualValue    string `json:"actualValue"`
+				}{
+					{
+						Status:         "OK",
+						MetricKey:      "new_reliability_rating",
+						Comparator:     "GT",
+						PeriodIndex:    1,
+						ErrorThreshold: "1",
+						ActualValue:    "1",
+					},
+				},
+				Periods: []struct {
+					Index int    `json:"index"`
+					Mode  string `json:"mode"`
+					Date  string `json:"date"`
+				}{
+					{
+						Index: 1,
+						Mode:  "previous_version",
+						Date:  "2025-01-15T10:30:00+0000",
+					},
+				},
+				IgnoredConditions: false,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl(server.URL)
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	result, err := service.GetQualityGateAnalysis("test-analysis-id")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "OK", result.ProjectStatus.Status)
+	assert.Len(t, result.ProjectStatus.Conditions, 1)
+	assert.Equal(t, "new_reliability_rating", result.ProjectStatus.Conditions[0].MetricKey)
+}
+
+func TestSonarService_GetQualityGatesResponse_EmptyAnalysisID(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	result, err := service.GetQualityGateAnalysis("")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "missing analysis id")
+}
+
+func TestSonarService_GetTaskResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/ce/task")
+		assert.Contains(t, r.URL.RawQuery, "id=test-task-id")
+
+		response := TaskDetails{
+			Task: struct {
+				ID                 string      `json:"id"`
+				Type               string      `json:"type"`
+				ComponentID        string      `json:"componentId"`
+				ComponentKey       string      `json:"componentKey"`
+				ComponentName      string      `json:"componentName"`
+				ComponentQualifier string      `json:"componentQualifier"`
+				AnalysisID         string      `json:"analysisId"`
+				Status             string      `json:"status"`
+				SubmittedAt        string      `json:"submittedAt"`
+				StartedAt          string      `json:"startedAt"`
+				ExecutedAt         string      `json:"executedAt"`
+				ExecutionTimeMs    int         `json:"executionTimeMs"`
+				Logs               interface{} `json:"logs"`
+				HasScannerContext  bool        `json:"hasScannerContext"`
+				Organization       string      `json:"organization"`
+			}{
+				ID:           "test-task-id",
+				ComponentKey: "test-project",
+				AnalysisID:   "test-analysis-id",
+				Status:       "SUCCESS",
+				Logs:         nil,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl(server.URL)
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	result, err := service.GetTaskDetails("test-task-id")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "test-task-id", result.Task.ID)
+	assert.Equal(t, "test-project", result.Task.ComponentKey)
+	assert.Equal(t, "test-analysis-id", result.Task.AnalysisID)
+}
+
+func TestSonarService_GetTaskResponse_EmptyTaskID(t *testing.T) {
+	serviceDetails := sonarauth.NewSonarDetails()
+	serviceDetails.SetUrl("https://sonarcloud.io")
+	serviceDetails.SetAccessToken("test-token")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewSonarService(serviceDetails, client)
+
+	result, err := service.GetTaskDetails("")
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}

--- a/sonar/services/sonar_test.go
+++ b/sonar/services/sonar_test.go
@@ -101,7 +101,10 @@ func TestSonarService_BuildAuthHeader(t *testing.T) {
 			}
 
 			if tt.envToken != "" {
-				os.Setenv("SONAR_TOKEN", tt.envToken)
+				err := os.Setenv("SONAR_TOKEN", tt.envToken)
+				if err != nil {
+					assert.FailNow(t, "Failed to set env variable SONAR_TOKEN")
+				}
 				defer os.Unsetenv("SONAR_TOKEN")
 			} else {
 				os.Unsetenv("SONAR_TOKEN")
@@ -127,7 +130,10 @@ func TestSonarService_GetEnterpriseResponse(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
 	}))
 	defer server.Close()
 
@@ -226,7 +232,10 @@ func TestSonarService_GetQualityGatesResponse(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
 	}))
 	defer server.Close()
 
@@ -297,7 +306,10 @@ func TestSonarService_GetTaskResponse(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
**Description**
This PR introduces a new integration with SonarQube for evidence creation, enhancing the SLSA compliance capabilities of the JFrog CLI. 🛡️

A new flag, --use-sonar-predicate, has been added to the jf evd create command. When this flag is used, the CLI will:

Fetch the in-toto statement with a Sonar predicate from a SonarQube scan.

Use this statement to generate and sign a piece of evidence.

Attach the evidence to the specified build artifacts in Artifactory.

This allows users to create verifiable, signed evidence of their code quality and security scans, linking them directly to their build artifacts and strengthening their software supply chain security posture.

**Usage**
To create evidence using a SonarQube scan predicate, use the --use-sonar-predicate flag. You must also provide a signing key and an alias.

**Example Command:**

`jf evd create --use-sonar-predicate --key {signing-key} --key-alias {alias} <build-name> <build-number>`
**Related PRs**
jfrog-cli-artifactory: [Link to jfrog-cli-artifactory PR]