### PR TITLE
Add Verbose log level

### DIFF
--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -64,7 +64,7 @@ func filterFilesFunc(rootPath string, includeDirs, excludeWithRelativePath, pres
 			return false, err
 		}
 		if isExcludedByPattern {
-			log.Debug(fmt.Sprintf("The path '%s' is excluded", path))
+			log.Verbose(fmt.Sprintf("The path '%s' is excluded", path))
 			return false, nil
 		}
 

--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -75,7 +75,7 @@ func filterFilesFunc(rootPath string, includeDirs, excludeWithRelativePath, pres
 			}
 			// Check if the file size is within the limits
 			if !fileInfo.IsDir() && !sizeThreshold.IsSizeWithinThreshold(fileInfo.Size()) {
-				log.Debug(fmt.Sprintf("The path '%s' is excluded", path))
+				log.Verbose(fmt.Sprintf("The path '%s' is excluded", path))
 				return false, nil
 			}
 		}

--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -75,7 +75,7 @@ func filterFilesFunc(rootPath string, includeDirs, excludeWithRelativePath, pres
 			}
 			// Check if the file size is within the limits
 			if !fileInfo.IsDir() && !sizeThreshold.IsSizeWithinThreshold(fileInfo.Size()) {
-				log.Verbose(fmt.Sprintf("The path '%s' is excluded", path))
+				log.Verbose(fmt.Sprintf("The path '%s' is excluded (size limit)", path))
 				return false, nil
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,6 @@ require (
 )
 
 // attiasas:add_verbose_log_level
-replace github.com/jfrog/build-info-go => github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f
+replace github.com/jfrog/build-info-go => github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.7.6-0.20240909061051-2d36ae4bd05a

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// attiasas:add_verbose_log_level
-replace github.com/jfrog/build-info-go => github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20250910075402-a0c1a53e465a
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.7.6-0.20240909061051-2d36ae4bd05a

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20250203111011-4ff16d3d42be
+// attiasas:add_verbose_log_level
+replace github.com/jfrog/build-info-go => github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.7.6-0.20240909061051-2d36ae4bd05a

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f h1:SeLBE0wLncONRppr+HLO5wPsocNoHGtoKilg8fMSjQE=
+github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -57,8 +59,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
-github.com/jfrog/build-info-go v1.10.17 h1:wnVd9KkyFGQgNL+oU1wXyJB7/Ui9O/MqUnNKUMsyoRw=
-github.com/jfrog/build-info-go v1.10.17/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f h1:SeLBE0wLncONRppr+HLO5wPsocNoHGtoKilg8fMSjQE=
-github.com/attiasas/build-info-go v0.0.0-20250908090859-eddd2702e67f/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
+github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a h1:2Zci+3r0c6IPHmKeIkI/PFpjU/ODbp1GqAyVVtWsQeQ=
+github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a h1:2Zci+3r0c6IPHmKeIkI/PFpjU/ODbp1GqAyVVtWsQeQ=
-github.com/attiasas/build-info-go v0.0.0-20250908103108-2a651898674a/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -59,6 +57,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
+github.com/jfrog/build-info-go v1.8.9-0.20250910075402-a0c1a53e465a h1:cKO89K5ciCPImTMTdEePz/wvPJVIPwIOK3G2zXv1ITE=
+github.com/jfrog/build-info-go v1.8.9-0.20250910075402-a0c1a53e465a/go.mod h1:szdz9+WzB7+7PGnILLUgyY+OF5qD5geBT7UGNIxibyw=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on:
* https://github.com/jfrog/build-info-go/pull/321

Add a new log level `Verbose` (lower level than DEBUG).
In addition, make some of the utils logs output in the new level to prevent big logs in our commands