### PR TITLE
Add Xray API to download Indexer

### DIFF
--- a/xray/manager.go
+++ b/xray/manager.go
@@ -255,6 +255,13 @@ func (sm *XrayServicesManager) IsEntitled(featureId string) (bool, error) {
 	return entitlementsService.IsEntitled(featureId)
 }
 
+func (sm *XrayServicesManager) DownloadIndexer(localDirPath, localFileName string) (string, error) {
+	indexerService := services.NewIndexerService(sm.client)
+	indexerService.XrayDetails = sm.config.GetServiceDetails()
+	indexerService.ScopeProjectKey = sm.scopeProjectKey
+	return indexerService.Download(localDirPath, localFileName)
+}
+
 // Xsc returns the Xsc service inside Xray
 func (sm *XrayServicesManager) Xsc() *xsc.XscInnerService {
 	xscService := xsc.NewXscService(sm.client)

--- a/xray/services/indexer.go
+++ b/xray/services/indexer.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+const (
+	DownloadIndexerAPI = "api/v1/indexer-resources/download"
+)
+
+type IndexerService struct {
+	client          *jfroghttpclient.JfrogHttpClient
+	XrayDetails     auth.ServiceDetails
+	ScopeProjectKey string
+}
+
+func NewIndexerService(client *jfroghttpclient.JfrogHttpClient) *IndexerService {
+	return &IndexerService{client: client}
+}
+
+func (is *IndexerService) Download(localDirPath, localBinaryName string) (string, error) {
+	httpClientDetails := is.XrayDetails.CreateHttpClientDetails()
+	url := is.getUrlForDownloadApi()
+	// Download the indexer from Xray to the provided directory
+	downloadFileDetails := &httpclient.DownloadFileDetails{
+		DownloadPath:  url,
+		LocalPath:     localDirPath,
+		LocalFileName: localBinaryName,
+	}
+	resp, err := is.client.DownloadFile(downloadFileDetails, "", &httpClientDetails, false, false)
+	if err != nil {
+		return "", fmt.Errorf("an error occurred while trying to download '%s':\n%s", url, err.Error())
+	}
+	if err = errorutils.CheckResponseStatus(resp, http.StatusOK); err != nil {
+		if resp.StatusCode == http.StatusUnauthorized {
+			err = fmt.Errorf("%s\nHint: It appears that the credentials provided do not have sufficient permissions for JFrog Xray. This could be due to either incorrect credentials or limited permissions restricted to Artifactory only", err.Error())
+		}
+		return "", fmt.Errorf("failed while attempting to download '%s':\n%s", url, err.Error())
+	}
+	// Add execution permissions to the indexer binary
+	downloadedFilePath := filepath.Join(localDirPath, localBinaryName)
+	if err = os.Chmod(downloadedFilePath, 0777); err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	return downloadedFilePath, errorutils.CheckError(err)
+}
+
+func (is *IndexerService) getUrlForDownloadApi() string {
+	return utils.AppendScopedProjectKeyParam(is.XrayDetails.GetUrl()+fmt.Sprintf("%s/%s/%s", DownloadIndexerAPI, runtime.GOOS, runtime.GOARCH), is.ScopeProjectKey)
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Moving logic from `security-cli`, adding option to download the Xray Indexer to a local directory.