### PR TITLE
Improve HTTP connection handling

### DIFF
--- a/http/httpclient/client.go
+++ b/http/httpclient/client.go
@@ -179,7 +179,6 @@ func (jc *HttpClient) createReq(method, url string, content []byte) (req *http.R
 
 func (jc *HttpClient) doRequest(req *http.Request, content []byte, followRedirect bool, closeBody bool, httpClientsDetails httputils.HttpClientDetails) (resp *http.Response, respBody []byte, redirectUrl string, err error) {
 	log.Debug(fmt.Sprintf("Sending HTTP %s request to: %s", req.Method, req.URL))
-	req.Close = true
 	setAuthentication(req, httpClientsDetails)
 	addUserAgentHeader(req)
 	copyHeaders(httpClientsDetails, req)
@@ -338,7 +337,6 @@ func (jc *HttpClient) UploadFileFromReader(reader io.Reader, url string, httpCli
 		return
 	}
 	req.ContentLength = size
-	req.Close = true
 
 	setRequestHeaders(httpClientsDetails, size, req)
 	setAuthentication(req, httpClientsDetails)

--- a/http/httpclient/clientBuilder.go
+++ b/http/httpclient/clientBuilder.go
@@ -124,7 +124,9 @@ func (builder *httpClientBuilder) createDefaultHttpTransport() *http.Transport {
 			KeepAlive: 20 * time.Second,
 			DualStack: true,
 		}).DialContext,
+		ForceAttemptHTTP2:     true, // Enable HTTP/2 for HTTPS when the server supports it.
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   6, // Increased from default (2) to improve performance when making multiple requests to the same host.
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/http/httpclient/client_test.go
+++ b/http/httpclient/client_test.go
@@ -42,3 +42,16 @@ func TestShouldRetry(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultTransportEnablesConnectionReuse(t *testing.T) {
+	client, err := ClientBuilder().Build()
+	assert.NoError(t, err)
+
+	transport, ok := client.GetClient().Transport.(*http.Transport)
+	if !ok {
+		t.Skip("transport is not *http.Transport (e.g. custom certs); skipping connection reuse config check")
+	}
+
+	assert.True(t, transport.ForceAttemptHTTP2, "ForceAttemptHTTP2 should be true for HTTP/2 support")
+	assert.Equal(t, 6, transport.MaxIdleConnsPerHost, "MaxIdleConnsPerHost should be 6 for connection reuse to the same host")
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Closes jfrog/jfrog-cli-artifactory#290 

### What does this MR do?

This MR enables the underlying `http.client` to reuse HTTP connections.

### Why was this MR needed?

The relevant part of the HTTP client implementation has remained unchanged since 2017. It is unclear why `req.Close` was set to `true`, which forces the Go `http.Client` to close the connection immediately after the response is received. Reusing established HTTP(S) connections is a common best practice and can significantly improve performance.

The function `createDefaultHttpTransport` in `http/httpclient/clientBuilder.go` uses the same defaults as the original `DefaultTransport` implementation in the `net/http` package. Since `ForceAttemptHTTP2` was added as a default in the `net/http` package after 2017, I added this option as well.

After performance testing, I set the parameter `MaxIdleConnsPerHost` to `6`, aligning with modern web browsers’ common default and providing a balanced improvement in connection reuse, especially when HTTP/2 is not used. The previous default of 2 resulted in a high number of short-lived TCP connections under multi-threaded workloads.


### Performance test case
Download a directory from Artifactory with 4591 files ranging from 100 Bytes to 21 MByte (total size 892.13 MByte) with a max connection throughput of 350 Mbit/s. Tests were conducted on the internet where the Artifactory server is hosted at AWS behind an AWS ALB. Client and AWS region are in the same country. The `jfrog-cli` was used with its default configuration. All test were executed multiple times.

current jfrog-cli release (2.78.10)
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 3: 221 secs
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 10 : 97 secs
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 20 : 69 secs

with the change of the PR applied:
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 3: 124 secs
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 10 : 64 secs
Download as directory using jfrog-cli with options --include-dirs --quiet --threads 20 : 46 secs

During the test runs with the change of the PR applied, the number of TCP connections was  stable, and TCP connections got reused. Furthermore the total amount of open TCP connections when using HTTP2 was not more than 4 connections.

 ### Potential Drawbacks

While reusing connections generally improves performance, it's important to note that the Go `http.Client` has set a `IdleConnTimeout` of 90 seconds. This means that idle connections will be closed after 90 seconds of inactivity, preventing them from becoming stale indefinitely. Therefore, the risk of long-lived connections causing issues is mitigated by this timeout. The benefits of connection reuse are expected to outweigh any potential drawbacks in most common scenarios.