### PR TITLE
Verbose log level

### DIFF
--- a/artifactory/services/fspatterns/utils.go
+++ b/artifactory/services/fspatterns/utils.go
@@ -64,7 +64,7 @@ func filterFilesFunc(rootPath string, includeDirs, excludeWithRelativePath, pres
 			return false, err
 		}
 		if isExcludedByPattern {
-			log.Debug(fmt.Sprintf("The path '%s' is excluded", path))
+			log.Verbose(fmt.Sprintf("The path '%s' is excluded", path))
 			return false, nil
 		}
 
@@ -75,7 +75,7 @@ func filterFilesFunc(rootPath string, includeDirs, excludeWithRelativePath, pres
 			}
 			// Check if the file size is within the limits
 			if !fileInfo.IsDir() && !sizeThreshold.IsSizeWithinThreshold(fileInfo.Size()) {
-				log.Debug(fmt.Sprintf("The path '%s' is excluded", path))
+				log.Verbose(fmt.Sprintf("The path '%s' is excluded", path))
 				return false, nil
 			}
 		}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Add a new log level `Verbose` (lower level than DEBUG).
In addition, make some of the utils logs output in the new level to prevent big logs in our commands