### PR TITLE
Add support for apptrust manager and getApplicationDetail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3514,3 +3514,31 @@ fmt.Printf("Application Key: %s\n", application.ApplicationKey)
 fmt.Printf("Project Name: %s\n", application.ProjectName)
 fmt.Printf("Project Key: %s\n", application.ProjectKey)
 ```
+
+### Get Application Version Promotions
+
+```go
+applicationKey := "your-application-key"
+applicationVersion := "1.0.0"
+
+// Optional query parameters
+queryParams := map[string]string{
+    "order_by":   "created",
+    "order_asc":  "false",
+    "limit":      "100",
+    "offset":     "0",
+    "filter_by":  "status=COMPLETED",
+}
+
+promotions, err := apptrustManager.GetApplicationVersionPromotions(applicationKey, applicationVersion, queryParams)
+if err != nil {
+    return err
+}
+
+// Access promotion details
+fmt.Printf("Total promotions: %d\n", promotions.Total)
+for _, promotion := range promotions.Promotions {
+    fmt.Printf("Status: %s, Source: %s, Target: %s, Created: %s\n", 
+        promotion.Status, promotion.SourceStage, promotion.TargetStage, promotion.Created)
+}
+```

--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@
         - [Creating New Onemodel Service Manager](#creating-new-onemodel-service-manager)
     - [Using Onemodel Services](#using-onemodel-services)
       - [Graphql query](#graphql-query)
+  - [Apptrust APIs](#apptrust-apis)
+    - [Creating Apptrust Service Manager](#creating-apptrust-service-manager)
+      - [Creating Apptrust Details](#creating-apptrust-details)
+      - [Creating Apptrust Service Config](#creating-apptrust-service-config)
+      - [Creating New Apptrust Service Manager](#creating-new-apptrust-service-manager)
+    - [Get Application Details](#get-application-details)
 
 ## General
 
@@ -3450,4 +3456,61 @@ queryDetails := onemodelService.QueryDetails{
 }
 
 body, err = onemodelManager.GraphqlQuery(queryDetails)
+```
+
+## Apptrust APIs
+
+### Creating Apptrust Service Manager
+
+#### Creating Apptrust Details
+
+```go
+apptrustDetails := auth.NewApptrustDetails()
+apptrustDetails.SetUrl("http://localhost:8081/apptrust")
+apptrustDetails.SetAccessToken("access-token")
+// if client certificates are required
+apptrustDetails.SetClientCertPath("path/to/.cer")
+apptrustDetails.SetClientCertKeyPath("path/to/.key")
+```
+
+#### Creating Apptrust Service Config
+
+```go
+serviceConfig, err := config.NewConfigBuilder().
+    SetServiceDetails(apptrustDetails).
+    SetCertificatesPath(apptrustDetails.GetClientCertPath()).
+    SetInsecureTls(apptrustDetails.IsInsecureTls()).
+    // Add [Context](https://golang.org/pkg/context/)
+    // SetContext(ctx).
+    // Optionally overwrite the default HTTP retries, which is set to 3.
+    // SetHttpRetries(8).
+    Build()
+if err != nil {
+    return err
+}
+```
+
+#### Creating New Apptrust Service Manager
+
+```go
+apptrustManager, err := apptrust.New(serviceConfig)
+if err != nil {
+    return err
+}
+```
+
+### Get Application Details
+
+```go
+applicationKey := "your-application-key"
+application, err := apptrustManager.GetApplicationDetails(applicationKey)
+if err != nil {
+    return err
+}
+
+// Access application details
+fmt.Printf("Application Name: %s\n", application.ApplicationName)
+fmt.Printf("Application Key: %s\n", application.ApplicationKey)
+fmt.Printf("Project Name: %s\n", application.ProjectName)
+fmt.Printf("Project Key: %s\n", application.ProjectKey)
 ```

--- a/apptrust/apptrust_test.go
+++ b/apptrust/apptrust_test.go
@@ -1,0 +1,41 @@
+package apptrust
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/apptrust/auth"
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	apptrustDetails := auth.NewApptrustDetails()
+	apptrustDetails.SetUrl("http://localhost:8080/")
+	apptrustDetails.SetUser("admin")
+	apptrustDetails.SetPassword("password")
+
+	config, err := config.NewConfigBuilder().
+		SetServiceDetails(apptrustDetails).
+		Build()
+	assert.NoError(t, err)
+
+	manager, err := New(config)
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+	assert.NotNil(t, manager.Client())
+}
+
+func TestApptrustDetails(t *testing.T) {
+	apptrustDetails := auth.NewApptrustDetails()
+	assert.NotNil(t, apptrustDetails)
+
+	// Test setting URL
+	testUrl := "http://localhost:8080/"
+	apptrustDetails.SetUrl(testUrl)
+	assert.Equal(t, testUrl, apptrustDetails.GetUrl())
+
+	// Test setting user
+	testUser := "testuser"
+	apptrustDetails.SetUser(testUser)
+	assert.Equal(t, testUser, apptrustDetails.GetUser())
+}

--- a/apptrust/auth/apptrustdetails.go
+++ b/apptrust/auth/apptrustdetails.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/jfrog/jfrog-client-go/auth"
+)
+
+func NewApptrustDetails() auth.ServiceDetails {
+	return &apptrustDetails{}
+}
+
+type apptrustDetails struct {
+	auth.CommonConfigFields
+}
+
+func (rt *apptrustDetails) GetVersion() (string, error) {
+	panic("Failed: Method is not implemented")
+}

--- a/apptrust/manager.go
+++ b/apptrust/manager.go
@@ -6,19 +6,12 @@ import (
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 )
 
-// ApptrustServiceManagerInterface defines the interface for ApptrustServicesManager to enable mocking in tests
-type ApptrustServiceManagerInterface interface {
-	Client() *jfroghttpclient.JfrogHttpClient
-	GetApplicationDetails(applicationKey string) (*services.Application, error)
-	GetApplicationVersionPromotions(applicationKey, applicationVersion string, queryParams map[string]string) (*services.ApplicationPromotionsResponse, error)
-}
-
 type ApptrustServicesManager struct {
 	client *jfroghttpclient.JfrogHttpClient
 	config config.Config
 }
 
-func New(config config.Config) (ApptrustServiceManagerInterface, error) {
+func New(config config.Config) (*ApptrustServicesManager, error) {
 	details := config.GetServiceDetails()
 	var err error
 	manager := &ApptrustServicesManager{config: config}

--- a/apptrust/manager.go
+++ b/apptrust/manager.go
@@ -39,3 +39,8 @@ func (asm *ApptrustServicesManager) GetApplicationDetails(applicationKey string)
 	appService := services.NewApplicationService(asm.config.GetServiceDetails(), asm.client)
 	return appService.GetApplicationDetails(applicationKey)
 }
+
+func (asm *ApptrustServicesManager) GetApplicationVersionPromotions(applicationKey, applicationVersion string, queryParams map[string]string) (*services.ApplicationPromotionsResponse, error) {
+	appService := services.NewApplicationService(asm.config.GetServiceDetails(), asm.client)
+	return appService.GetApplicationVersionPromotions(applicationKey, applicationVersion, queryParams)
+}

--- a/apptrust/manager.go
+++ b/apptrust/manager.go
@@ -6,12 +6,19 @@ import (
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 )
 
+// ApptrustServiceManagerInterface defines the interface for ApptrustServicesManager to enable mocking in tests
+type ApptrustServiceManagerInterface interface {
+	Client() *jfroghttpclient.JfrogHttpClient
+	GetApplicationDetails(applicationKey string) (*services.Application, error)
+	GetApplicationVersionPromotions(applicationKey, applicationVersion string, queryParams map[string]string) (*services.ApplicationPromotionsResponse, error)
+}
+
 type ApptrustServicesManager struct {
 	client *jfroghttpclient.JfrogHttpClient
 	config config.Config
 }
 
-func New(config config.Config) (*ApptrustServicesManager, error) {
+func New(config config.Config) (ApptrustServiceManagerInterface, error) {
 	details := config.GetServiceDetails()
 	var err error
 	manager := &ApptrustServicesManager{config: config}

--- a/apptrust/manager.go
+++ b/apptrust/manager.go
@@ -1,0 +1,41 @@
+package apptrust
+
+import (
+	"github.com/jfrog/jfrog-client-go/apptrust/services"
+	"github.com/jfrog/jfrog-client-go/config"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+)
+
+type ApptrustServicesManager struct {
+	client *jfroghttpclient.JfrogHttpClient
+	config config.Config
+}
+
+func New(config config.Config) (*ApptrustServicesManager, error) {
+	details := config.GetServiceDetails()
+	var err error
+	manager := &ApptrustServicesManager{config: config}
+	manager.client, err = jfroghttpclient.JfrogClientBuilder().
+		SetCertificatesPath(config.GetCertificatesPath()).
+		SetInsecureTls(config.IsInsecureTls()).
+		SetClientCertPath(details.GetClientCertPath()).
+		SetClientCertKeyPath(details.GetClientCertKeyPath()).
+		AppendPreRequestInterceptor(details.RunPreRequestFunctions).
+		SetContext(config.GetContext()).
+		SetDialTimeout(config.GetDialTimeout()).
+		SetOverallRequestTimeout(config.GetOverallRequestTimeout()).
+		SetRetries(config.GetHttpRetries()).
+		SetRetryWaitMilliSecs(config.GetHttpRetryWaitMilliSecs()).
+		Build()
+
+	return manager, err
+}
+
+func (asm *ApptrustServicesManager) Client() *jfroghttpclient.JfrogHttpClient {
+	return asm.client
+}
+
+func (asm *ApptrustServicesManager) GetApplicationDetails(applicationKey string) (*services.Application, error) {
+	appService := services.NewApplicationService(asm.config.GetServiceDetails(), asm.client)
+	return appService.GetApplicationDetails(applicationKey)
+}

--- a/apptrust/services/application.go
+++ b/apptrust/services/application.go
@@ -104,16 +104,16 @@ type ApplicationPromotionsResponse struct {
 }
 
 type ApplicationPromotion struct {
-	ApplicationKey     string                     `json:"application_key"`
-	ApplicationVersion string                     `json:"application_version"`
-	ProjectKey         string                     `json:"project_key"`
-	Status             string                     `json:"status"`
-	SourceStage        string                     `json:"source_stage"`
-	TargetStage        string                     `json:"target_stage"`
-	CreatedBy          string                     `json:"created_by"`
-	Created            string                     `json:"created"`
-	CreatedMillis      int64                      `json:"created_millis"`
-	Evaluations        *PromotionEvaluations      `json:"evaluations,omitempty"`
+	ApplicationKey     string                `json:"application_key"`
+	ApplicationVersion string                `json:"application_version"`
+	ProjectKey         string                `json:"project_key"`
+	Status             PromotionStatus       `json:"status"`
+	SourceStage        string                `json:"source_stage"`
+	TargetStage        string                `json:"target_stage"`
+	CreatedBy          string                `json:"created_by"`
+	Created            string                `json:"created"`
+	CreatedMillis      int64                 `json:"created_millis"`
+	Evaluations        *PromotionEvaluations `json:"evaluations,omitempty"`
 }
 
 type PromotionEvaluations struct {
@@ -127,3 +127,12 @@ type GateEvaluation struct {
 	Decision    string `json:"decision"`
 	Explanation string `json:"explanation,omitempty"`
 }
+
+type PromotionStatus string
+
+const (
+	PromotionStatusCompleted PromotionStatus = "COMPLETED"
+	PromotionStatusFailed    PromotionStatus = "FAILED"
+	PromotionStatusStarted   PromotionStatus = "STARTED"
+	PromotionStatusDeleting  PromotionStatus = "DELETING"
+)

--- a/apptrust/services/application.go
+++ b/apptrust/services/application.go
@@ -1,0 +1,69 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	applicationDetailsAPI = "apptrust/api/v1/applications"
+)
+
+type ApplicationService struct {
+	client          *jfroghttpclient.JfrogHttpClient
+	apptrustDetails auth.ServiceDetails
+}
+
+func NewApplicationService(apptrustDetails auth.ServiceDetails, client *jfroghttpclient.JfrogHttpClient) *ApplicationService {
+	return &ApplicationService{apptrustDetails: apptrustDetails, client: client}
+}
+
+func (as *ApplicationService) GetApptrustDetails() auth.ServiceDetails {
+	return as.apptrustDetails
+}
+
+func (as *ApplicationService) GetApplicationDetails(applicationKey string) (*Application, error) {
+	restApi := path.Join(applicationDetailsAPI, applicationKey)
+	requestFullUrl, err := clientutils.BuildUrl(as.GetApptrustDetails().GetUrl(), restApi, nil)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	httpClientDetails := as.GetApptrustDetails().CreateHttpClientDetails()
+	httpClientDetails.SetContentTypeApplicationJson()
+
+	log.Debug("Getting Application Details for:", applicationKey)
+	resp, body, _, err := as.client.SendGet(requestFullUrl, true, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var applicationResponse ApplicationResponse
+	if err = json.Unmarshal(body, &applicationResponse); err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	return &applicationResponse.Application, nil
+}
+
+type ApplicationResponse struct {
+	Application Application `json:"application"`
+}
+
+type Application struct {
+	ApplicationName string `json:"application_name"`
+	ApplicationKey  string `json:"application_key"`
+	ProjectName     string `json:"project_name"`
+	ProjectKey      string `json:"project_key"`
+}

--- a/apptrust/services/application_test.go
+++ b/apptrust/services/application_test.go
@@ -1,0 +1,176 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/apptrust/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/stretchr/testify/assert"
+)
+
+const mockApplicationKey = "test-app-key"
+
+var mockApplicationResponse = ApplicationResponse{
+	Application: Application{
+		ApplicationName: "Test Application",
+		ApplicationKey:  "test-app-key",
+		ProjectName:     "Test Project",
+		ProjectKey:      "test-proj",
+	},
+}
+
+func TestApplicationService_GetApplicationDetails_Success(t *testing.T) {
+	handlerFunc, requestNum := createApplicationHandlerFunc(t, http.StatusOK, mockApplicationResponse)
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails(mockApplicationKey)
+	assert.NoError(t, err)
+	assert.NotNil(t, application)
+	assert.Equal(t, "Test Application", application.ApplicationName)
+	assert.Equal(t, "test-app-key", application.ApplicationKey)
+	assert.Equal(t, "Test Project", application.ProjectName)
+	assert.Equal(t, "test-proj", application.ProjectKey)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func TestApplicationService_GetApplicationDetails_NotFound(t *testing.T) {
+	handlerFunc, requestNum := createApplicationHandlerFunc(t, http.StatusNotFound, ApplicationResponse{})
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails("non-existent-key")
+	assert.Error(t, err)
+	assert.Nil(t, application)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func TestApplicationService_GetApplicationDetails_BadRequest(t *testing.T) {
+	handlerFunc, requestNum := createApplicationHandlerFunc(t, http.StatusBadRequest, ApplicationResponse{})
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails("invalid-key")
+	assert.Error(t, err)
+	assert.Nil(t, application)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func TestApplicationService_GetApplicationDetails_Unauthorized(t *testing.T) {
+	handlerFunc, requestNum := createApplicationHandlerFunc(t, http.StatusUnauthorized, ApplicationResponse{})
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails(mockApplicationKey)
+	assert.Error(t, err)
+	assert.Nil(t, application)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func TestApplicationService_GetApplicationDetails_Forbidden(t *testing.T) {
+	handlerFunc, requestNum := createApplicationHandlerFunc(t, http.StatusForbidden, ApplicationResponse{})
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails(mockApplicationKey)
+	assert.Error(t, err)
+	assert.Nil(t, application)
+	assert.Equal(t, 1, *requestNum)
+}
+
+func TestApplicationService_GetApplicationDetails_InvalidJSON(t *testing.T) {
+	requestNum := 0
+	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
+		expectedURI := "/apptrust/api/v1/applications/" + mockApplicationKey
+		if r.RequestURI == expectedURI {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			w.WriteHeader(http.StatusOK)
+			requestNum++
+			// Write invalid JSON
+			_, err := w.Write([]byte("invalid json"))
+			assert.NoError(t, err)
+		}
+	}
+
+	mockServer, applicationService := createMockApplicationServer(t, handlerFunc)
+	defer mockServer.Close()
+
+	application, err := applicationService.GetApplicationDetails(mockApplicationKey)
+	assert.Error(t, err)
+	assert.Nil(t, application)
+	assert.Equal(t, 1, requestNum)
+}
+
+func TestApplicationService_NewApplicationService(t *testing.T) {
+	apptrustDetails := auth.NewApptrustDetails()
+	apptrustDetails.SetUrl("http://localhost:8081/")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewApplicationService(apptrustDetails, client)
+	assert.NotNil(t, service)
+	assert.Equal(t, apptrustDetails, service.GetApptrustDetails())
+}
+
+func TestApplicationService_GetApptrustDetails(t *testing.T) {
+	apptrustDetails := auth.NewApptrustDetails()
+	apptrustDetails.SetUrl("http://localhost:8081/")
+	apptrustDetails.SetUser("testuser")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	service := NewApplicationService(apptrustDetails, client)
+	retrievedDetails := service.GetApptrustDetails()
+
+	assert.Equal(t, "http://localhost:8081/", retrievedDetails.GetUrl())
+	assert.Equal(t, "testuser", retrievedDetails.GetUser())
+}
+
+func createMockApplicationServer(t *testing.T, testHandler http.HandlerFunc) (*httptest.Server, *ApplicationService) {
+	testServer := httptest.NewServer(testHandler)
+
+	apptrustDetails := auth.NewApptrustDetails()
+	apptrustDetails.SetUrl(testServer.URL + "/")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	return testServer, NewApplicationService(apptrustDetails, client)
+}
+
+func createApplicationHandlerFunc(t *testing.T, statusCode int, response ApplicationResponse) (http.HandlerFunc, *int) {
+	requestNum := 0
+	return func(w http.ResponseWriter, r *http.Request) {
+		expectedURI := "/apptrust/api/v1/applications/" + mockApplicationKey
+		if r.RequestURI == expectedURI || r.RequestURI == "/apptrust/api/v1/applications/non-existent-key" || r.RequestURI == "/apptrust/api/v1/applications/invalid-key" {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			w.WriteHeader(statusCode)
+			requestNum++
+
+			if statusCode == http.StatusOK {
+				writeMockApplicationResponse(t, w, response)
+			}
+		}
+	}, &requestNum
+}
+
+func writeMockApplicationResponse(t *testing.T, w http.ResponseWriter, response ApplicationResponse) {
+	content, err := json.Marshal(response)
+	assert.NoError(t, err)
+	_, err = w.Write(content)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add Support for AppTrust Client Manager in client.
Add GetApplicationDetails API to go-client.
Add README section of AppTrust manager  