### PR TITLE
Updated encoding function

### DIFF
--- a/artifactory/services/utils/buildUrlWithEscapingSlash.go
+++ b/artifactory/services/utils/buildUrlWithEscapingSlash.go
@@ -23,7 +23,7 @@ func BuildUrlWithEscapingSlash(baseUrl, restApi, buildName, buildNumber string, 
 	// Semicolons are reserved as separators in some Artifactory APIs, so they'd better be encoded when used for other purposes
 	encodedUrl := strings.ReplaceAll(parsedUrl.String(), ";", url.QueryEscape(";"))
 
-	escapedBuildPath := path.Join(url.QueryEscape(buildName), url.QueryEscape(buildNumber))
+	escapedBuildPath := path.Join(url.PathEscape(buildName), url.PathEscape(buildNumber))
 	urlParts := strings.Split(encodedUrl, "?")
 	resultUrl := urlParts[0] + "/" + escapedBuildPath
 	if len(urlParts) > 1 && urlParts[1] != "" {


### PR DESCRIPTION
Description:
Due to this https://github.com/jfrog/jfrog-client-go/pull/1130/files,
Build Promotion Failure Due to String Encoding as BuildUrlWithEscapingSlash.

Solution
Replace QueryEscape function to PathEscape, because QueryEscape does double encoding and when / present inside build name and number, due to which wrong URL are generating. So, we need to encode special characters only except /.

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----