### PR TITLE
Update projectKey const name to indicate its relation to permissions service in Xray

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -630,7 +630,7 @@ func SetEnvWithResetCallback(key, value string) (func() error, error) {
 
 const (
 	// If the access token used for the client is project-scoped, the API call needs to contain the project key as query param to pass to the Server.
-	ProjectKeyQueryParam = "projectKey="
+	ProjectKeyPermissionsQueryParam = "projectKey="
 )
 
 // To access some of the API calls in Xray, we need to add the project key as a query parameter (used for validations if the token is project-scoped).
@@ -641,17 +641,17 @@ func AppendScopedProjectKeyParam(url, projectKey string) string {
 	}
 	if strings.Contains(url, "?") {
 		// the URL already contains query parameters, append the project key with an '&'
-		url += "&" + ProjectKeyQueryParam + projectKey
+		url += "&" + ProjectKeyPermissionsQueryParam + projectKey
 	} else {
 		// the URL does not contain any query parameters, add the project key with a '?'
-		url += "?" + ProjectKeyQueryParam + projectKey
+		url += "?" + ProjectKeyPermissionsQueryParam + projectKey
 	}
 	return url
 }
 
 func urlContainsProjectKeyParam(url string) bool {
 	// check if the URL already contains the project key query parameter
-	return len(url) > 0 && strings.Contains(url, ProjectKeyQueryParam)
+	return len(url) > 0 && strings.Contains(url, ProjectKeyPermissionsQueryParam)
 }
 
 func CalculateBackoff(attempt int, initialDelay, maxDelay time.Duration) time.Duration {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
This PR changes the projectKey query param const name to indicate its relation to permissions service in Xray