### PR TITLE
Added on demand log level to debug for add props

### DIFF
--- a/artifactory/services/props_test.go
+++ b/artifactory/services/props_test.go
@@ -1,0 +1,200 @@
+package services
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPropsParams(t *testing.T) {
+	params := NewPropsParams()
+	assert.Nil(t, params.Reader)
+	assert.Empty(t, params.Props)
+	assert.False(t, params.IsRepoOnly)
+	assert.False(t, params.UseDebugLogs)
+	assert.False(t, params.IsRecursive)
+}
+
+func TestPropsParamsGetProps(t *testing.T) {
+	tests := []struct {
+		name     string
+		props    string
+		expected string
+	}{
+		{"empty props", "", ""},
+		{"single property", "key=value", "key=value"},
+		{"multiple properties", "key1=val1;key2=val2", "key1=val1;key2=val2"},
+		{"property with special chars", "key=val;ue", "key=val;ue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := PropsParams{Props: tt.props}
+			assert.Equal(t, tt.expected, params.GetProps())
+		})
+	}
+}
+
+func TestPropsParamsFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		isRepoOnly   bool
+		useDebugLogs bool
+		isRecursive  bool
+	}{
+		{"all false", false, false, false},
+		{"isRepoOnly true", true, false, false},
+		{"useDebugLogs true", false, true, false},
+		{"isRecursive true", false, false, true},
+		{"all true", true, true, true},
+		{"isRepoOnly and isRecursive", true, false, true},
+		{"useDebugLogs and isRecursive", false, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := PropsParams{
+				IsRepoOnly:   tt.isRepoOnly,
+				UseDebugLogs: tt.useDebugLogs,
+				IsRecursive:  tt.isRecursive,
+			}
+			assert.Equal(t, tt.isRepoOnly, params.IsRepoOnly)
+			assert.Equal(t, tt.useDebugLogs, params.UseDebugLogs)
+			assert.Equal(t, tt.isRecursive, params.IsRecursive)
+		})
+	}
+}
+
+func TestGetEncodedParam(t *testing.T) {
+	ps := NewPropsService(nil)
+
+	tests := []struct {
+		name        string
+		props       string
+		isDelete    bool
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "set single property",
+			props:       "key=value",
+			isDelete:    false,
+			expected:    "key=value",
+			expectError: false,
+		},
+		{
+			name:        "set multiple properties",
+			props:       "key1=value1;key2=value2",
+			isDelete:    false,
+			expected:    "key1=value1;key2=value2",
+			expectError: false,
+		},
+		{
+			name:        "delete single property",
+			props:       "key",
+			isDelete:    true,
+			expected:    "key",
+			expectError: false,
+		},
+		{
+			name:        "delete multiple properties",
+			props:       "key1,key2",
+			isDelete:    true,
+			expected:    "key1,key2",
+			expectError: false,
+		},
+		{
+			name:        "delete property with special chars",
+			props:       "key;special,key2",
+			isDelete:    true,
+			expected:    "key%3Bspecial,key2",
+			expectError: false,
+		},
+		{
+			name:        "set property with escaped semicolon in value",
+			props:       "key=val\\;ue",
+			isDelete:    false,
+			expected:    "key=val%3Bue",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := PropsParams{Props: tt.props}
+			result, err := ps.getEncodedParam(params, tt.isDelete)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, result, tt.expected[:3]) // Check prefix to handle encoding variations
+			}
+		})
+	}
+}
+
+func TestActionTypeBasedOnIsDeleteFlag(t *testing.T) {
+	ps := NewPropsService(nil)
+
+	t.Run("delete action assigned when isDelete is true", func(t *testing.T) {
+		var action func(string, string, string, bool) (*http.Response, []byte, error)
+		ps.actionTypeBasedOnIsDeleteFlag(true, &action)
+		assert.NotNil(t, action)
+	})
+
+	t.Run("put action assigned when isDelete is false", func(t *testing.T) {
+		var action func(string, string, string, bool) (*http.Response, []byte, error)
+		ps.actionTypeBasedOnIsDeleteFlag(false, &action)
+		assert.NotNil(t, action)
+	})
+}
+
+func TestRecursiveURLConstruction(t *testing.T) {
+	tests := []struct {
+		name        string
+		isRecursive bool
+		expected    string
+	}{
+		{
+			name:        "non-recursive adds recursive=0",
+			isRecursive: false,
+			expected:    "&recursive=0",
+		},
+		{
+			name:        "recursive adds recursive=1",
+			isRecursive: true,
+			expected:    "&recursive=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the recursive flag logic
+			recursive := "&recursive=0"
+			if tt.isRecursive {
+				recursive = "&recursive=1"
+			}
+			assert.Equal(t, tt.expected, recursive)
+		})
+	}
+}
+
+func TestPropsServiceGetters(t *testing.T) {
+	ps := NewPropsService(nil)
+
+	t.Run("IsDryRun returns false", func(t *testing.T) {
+		assert.False(t, ps.IsDryRun())
+	})
+
+	t.Run("GetThreads returns set value", func(t *testing.T) {
+		ps.Threads = 5
+		assert.Equal(t, 5, ps.GetThreads())
+	})
+
+	t.Run("GetThreads returns zero when not set", func(t *testing.T) {
+		ps2 := NewPropsService(nil)
+		assert.Equal(t, 0, ps2.GetThreads())
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gookit/color v1.6.0
 	github.com/jfrog/archiver/v3 v3.6.1
-	github.com/jfrog/build-info-go v1.12.4
+	github.com/jfrog/build-info-go v1.12.5-0.20251209031413-f5f0e93dc8db
 	github.com/jfrog/gofrog v1.7.6
 	github.com/minio/sha256-simd v1.0.1
 	github.com/stretchr/testify v1.11.1
@@ -56,6 +56,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v0.0.0-20241201000000-COMMIT_HASH
+//replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.12.5-0.20251209031413-f5f0e93dc8db
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.7.6-0.20240909061051-2d36ae4bd05a

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
-github.com/jfrog/build-info-go v1.12.4 h1:eoHoJDOF7Rx2gAOAXEAjbEIpnH+4y5ha2quQT48Py3Q=
-github.com/jfrog/build-info-go v1.12.4/go.mod h1:NEJwH1HxzhtWuiT8eR/anbjT0A3OyLBWpZZrDJs+hWQ=
+github.com/jfrog/build-info-go v1.12.5-0.20251209031413-f5f0e93dc8db h1:5q4hUqZVl7Xt+R+ono5lDH1/lkvV1spnfDtp0VtJqlo=
+github.com/jfrog/build-info-go v1.12.5-0.20251209031413-f5f0e93dc8db/go.mod h1:9W4U440fdTHwW1HiB/R0VQvz/5q8ZHsms9MWcq+JrdY=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Description:
1. Add on demand debug log level for set props function
2. Apply props recursively to contents of folder