### PR TITLE
Fix: Temp Directory Cleanup Continues on Permission Errors

### DIFF
--- a/utils/io/fileutils/temp_test.go
+++ b/utils/io/fileutils/temp_test.go
@@ -2,6 +2,7 @@ package fileutils
 
 import (
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -76,4 +77,75 @@ func TestExtractTimestamp(t *testing.T) {
 func AssertFileExists(t *testing.T, name string) {
 	_, err := os.Stat(name)
 	assert.NoError(t, err)
+}
+
+// TestCleanOldDirsContinuesOnError tests that cleanup continues even when encountering errors.
+// This test verifies that CleanOldDirs() processes all files and collects errors instead of stopping at first error.
+func TestCleanOldDirsContinuesOnError(t *testing.T) {
+	// Save original values
+	defer func(originTempPrefix string) {
+		tempPrefix = originTempPrefix
+	}(tempPrefix)
+	tempPrefix = "test.continue." + tempPrefix
+
+	oldTempDirBase := tempDirBase
+	defer func() { tempDirBase = oldTempDirBase }()
+
+	// Create a temporary test directory
+	testDir, err := os.MkdirTemp("", "test-cleanup-*")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(testDir))
+	}()
+
+	tempDirBase = testDir
+
+	// Save original maxFileAge
+	oldMaxFileAge := maxFileAge
+	defer func() { maxFileAge = oldMaxFileAge }()
+	maxFileAge = 0 // Make all files appear old
+
+	// Create valid temp files that should be deleted
+	validFile1, err := CreateTempFile()
+	assert.NoError(t, err)
+	validFile1Name := validFile1.Name()
+	assert.NoError(t, validFile1.Close())
+
+	// Create a file with invalid timestamp format (will cause extractTimestamp error)
+	invalidFile := path.Join(testDir, tempPrefix+"invalid-no-timestamp")
+	err = os.WriteFile(invalidFile, []byte("test"), 0644)
+	assert.NoError(t, err)
+
+	// Create another valid file that should be deleted
+	validFile2, err := CreateTempFile()
+	assert.NoError(t, err)
+	validFile2Name := validFile2.Name()
+	assert.NoError(t, validFile2.Close())
+
+	// Verify all files exist before cleanup
+	AssertFileExists(t, validFile1Name)
+	AssertFileExists(t, invalidFile)
+	AssertFileExists(t, validFile2Name)
+
+	// Run cleanup
+	err = CleanOldDirs()
+
+	// After fix: should return error mentioning the invalid file
+	// but continue processing other files
+	assert.Error(t, err, "Should return error for invalid file")
+	assert.Contains(t, err.Error(), "failed to cleanup")
+	assert.Contains(t, err.Error(), "invalid-no-timestamp")
+
+	// Verify valid files were deleted despite error with invalid file
+	_, err1 := os.Stat(validFile1Name)
+	assert.True(t, os.IsNotExist(err1), "validFile1 should be deleted")
+
+	_, err2 := os.Stat(validFile2Name)
+	assert.True(t, os.IsNotExist(err2), "validFile2 should be deleted")
+
+	// Invalid file should still exist (couldn't be processed)
+	AssertFileExists(t, invalidFile)
+
+	// Cleanup
+	assert.NoError(t, os.Remove(invalidFile))
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
# Fix: Temp Directory Cleanup Continues on Permission Errors

## Problem

When the JFrog CLI runs cleanup of old temporary files in `/tmp`, if it encounters a file owned by a different user (permission error), it stops immediately and does not continue to delete the remaining files that the current user has permission to delete.

### Example Scenario

Given 3 temp files in `/tmp`:

| Filename | Owner |
|----------|-------|
| `jfrog.cli.temp.-000000-12345` | user-2 |
| `jfrog.cli.temp.-111111-12345` | user-1 |
| `jfrog.cli.temp.-999999-12345` | user-2 |

When `user-2` runs `jf -v`:
- **Before fix**: File `-000000-` is deleted, permission error on `-111111-`, cleanup **stops** - file `-999999-` is **not deleted**
- **After fix**: File `-000000-` is deleted, permission error on `-111111-` is **collected**, file `-999999-` is deleted, then error is reported

## Root Cause

In `utils/io/fileutils/temp.go`, the `CleanOldDirs()` function returned immediately upon encountering any error during file deletion:

```go
// Before fix - returns immediately on first error
if err = RemovePath(filePath); err != nil {
    return fmt.Errorf("Cannot remove path: %s due to: %s", filePath, err.Error())
}
```

## Solution

Modified `CleanOldDirs()` to collect all deletion failures and continue processing remaining files. At the end, it reports all failures in an aggregated error message:

```go
// After fix - collects errors and continues
var failedDeletions []string

for _, file := range files {
    // ... 
    if err = RemovePath(filePath); err != nil {
        // Collect deletion errors and continue processing
        failedDeletions = append(failedDeletions,
            fmt.Sprintf("%s (%v)", filePath, err))
        continue
    }
}

// At the end, return aggregated error message for all failures
if len(failedDeletions) > 0 {
    return fmt.Errorf("failed to cleanup %d file(s): %s",
        len(failedDeletions), strings.Join(failedDeletions, "; "))
}
```

## Changes

- **File**: `utils/io/fileutils/temp.go`
  - Modified `CleanOldDirs()` to use `continue` instead of `return` on errors
  - Added `failedDeletions` slice to collect all failures
  - Returns aggregated error message at the end with count of failed files

## Testing

### Unit Test Added

Added `TestCleanOldDirsContinuesOnError` in `temp_test.go` to verify:
1. Files that can be deleted are deleted
2. Cleanup continues after encountering errors
3. All failures are reported in the final error message

### Docker-based Integration Test

Reproduced the issue and verified the fix using Docker:

**Before Fix (jf 2.85.0):**
```
=== Files before jf -v ===
-rw-r--r--    1 guest    users    /tmp/jfrog.cli.temp.-000000-12345
-rw-r--r--    1 root     root     /tmp/jfrog.cli.temp.-111111-12345
-rw-r--r--    1 guest    users    /tmp/jfrog.cli.temp.-999999-12345

[Warn] failed while attempting to cleanup old CLI temp directories: Cannot remove path: /tmp/jfrog.cli.temp.-111111-12345 due to: operation not permitted

=== Files after jf -v ===
-rw-r--r--    1 root     root     /tmp/jfrog.cli.temp.-111111-12345
-rw-r--r--    1 guest    users    /tmp/jfrog.cli.temp.-999999-12345  <-- BUG: not deleted
```

**After Fix (local build):**
```
=== Files before jf -v ===
-rw-r--r--    1 guest    users    /tmp/jfrog.cli.temp.-000000-12345
-rw-r--r--    1 root     root     /tmp/jfrog.cli.temp.-111111-12345
-rw-r--r--    1 guest    users    /tmp/jfrog.cli.temp.-999999-12345

[Warn] failed while attempting to cleanup old CLI temp directories: failed to cleanup 1 file(s): /tmp/jfrog.cli.temp.-111111-12345 (operation not permitted)

=== Files after jf -v ===
-rw-r--r--    1 root     root     /tmp/jfrog.cli.temp.-111111-12345  <-- Only root's file remains
```
