### PR TITLE
feat: Add GetTokens, GetTokensByID, RevokeTokenByID methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@
       - [Creating an Access Token](#creating-an-access-token)
       - [Refreshing an Access Token](#refreshing-an-access-token)
       - [Exchanging an OIDC Access Token](#exchanging-an-oidc-access-token)
+      - [Getting Access Tokens](#getting-access-tokens)
+      - [Getting an Access Token by ID](#getting-an-access-token-by-id)
+      - [Revoking an Access Token by ID](#revoking-an-access-token-by-id)
   - [Distribution APIs](#distribution-apis)
     - [Creating Distribution Service Manager](#creating-distribution-service-manager)
       - [Creating Distribution Details](#creating-distribution-details)
@@ -1877,6 +1880,37 @@ params := services.CreateOidcTokenParams{
 }
 
 response, err = servicesManager.ExchangeOidcToken(params)
+```
+
+#### Getting Access Tokens
+
+```go
+params := services.GetTokensParams{
+    // Optional filters
+    Description:     "my-token-description",      // Filter by token description
+    Username:        "admin",                     // Filter by username
+    Refreshable:     utils.Pointer(true),         // Filter by refreshable status
+    TokenId:         "token-id",                  // Filter by specific token ID
+    OrderBy:         "token_id",                  // Order by field (created|token_id|owner|subject|expiry)
+    DescendingOrder: utils.Pointer(false),        // Sort order (true for descending)
+}
+
+tokens, err := accessManager.GetTokens(params)
+```
+
+#### Getting an Access Token by ID
+
+```go 
+token, err := accessManager.GetTokenByID("my-token-id")
+
+# currently used token
+token, err := accessManager.GetTokenByID("me")
+```
+
+#### Revoking an Access Token by ID
+
+```go
+err := accessManager.RevokeTokenByID("my-token-id")
 ```
 
 ## Distribution APIs

--- a/access/manager.go
+++ b/access/manager.go
@@ -143,3 +143,21 @@ func (sm *AccessServicesManager) ExchangeOidcToken(params services.CreateOidcTok
 	tokenService.ServiceDetails = sm.config.GetServiceDetails()
 	return tokenService.ExchangeOidcToken(params)
 }
+
+func (sm *AccessServicesManager) GetTokens(params services.GetTokensParams) ([]services.TokenInfo, error) {
+	tokenService := services.NewTokenService(sm.client)
+	tokenService.ServiceDetails = sm.config.GetServiceDetails()
+	return tokenService.GetTokens(params)
+}
+
+func (sm *AccessServicesManager) GetTokenByID(tokenId string) (*services.TokenInfo, error) {
+	tokenService := services.NewTokenService(sm.client)
+	tokenService.ServiceDetails = sm.config.GetServiceDetails()
+	return tokenService.GetTokenByID(tokenId)
+}
+
+func (sm *AccessServicesManager) RevokeTokenByID(tokenId string) error {
+	tokenService := services.NewTokenService(sm.client)
+	tokenService.ServiceDetails = sm.config.GetServiceDetails()
+	return tokenService.RevokeTokenByID(tokenId)
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

(This PR is a resubmission of #1255. Sorry for the inconvenience.)

This pull request adds new functionality to manage access tokens more effectively, including retrieving and revoking tokens by ID, as well as filtering and listing tokens. It introduces new methods in the access token service and manager, updates the documentation, and adds comprehensive tests for these features.

**New Access Token Management Features:**

* Added methods to `TokenService` and `AccessServicesManager` for:
  - Listing tokens with filters (`GetTokens`)
    - https://jfrog.com/help/r/jfrog-rest-apis/get-tokens
  - Retrieving a token by ID (`GetTokenByID`)
    - https://jfrog.com/help/r/jfrog-rest-apis/get-token-by-id
  - Revoking a token by ID (`RevokeTokenByID`) [[1]](diffhunk://#diff-a2b816bcb286fb61176557a93e6ffd7c436f368f51021c4f60d9d94a747e8917R146-R163) [[2]](diffhunk://#diff-a8828abb71ab9e7bdcf542ba698b2bc421b1ddc8530c4de8a565f6f3d3cd69cfR56-R81) [[3]](diffhunk://#diff-a8828abb71ab9e7bdcf542ba698b2bc421b1ddc8530c4de8a565f6f3d3cd69cfR159-R239)
    - https://jfrog.com/help/r/jfrog-rest-apis/revoke-token-by-id

* Introduced new parameter and response types:
  - `GetTokensParams`, `TokenInfo`, and `TokenInfos` structs for handling token queries and responses

**Documentation Updates:**

* Expanded the `README.md` to document:
  - How to get access tokens (with filters)
  - How to get a token by ID
  - How to revoke a token by ID [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1885-R1916)

**Testing Enhancements:**

* Added tests for the new access token methods:
  - `testGetTokens`
  - `testGetTokenByID`
  - `testRevokeTokenByID` [[1]](diffhunk://#diff-fc3eac9c82e2688cef6a5414bf4ae3241dd4d77b5bee2689dfc292dfa50ec224R29-R31) [[2]](diffhunk://#diff-fc3eac9c82e2688cef6a5414bf4ae3241dd4d77b5bee2689dfc292dfa50ec224R172-R368)

These changes make it easier to programmatically manage access tokens, improving both usability and test coverage.