### PR TITLE
fix: regex parsing

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -108,7 +108,9 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 			continue
 		}
 		if patternType == RegExp {
-			if strings.Contains(section, "(") {
+			// Break on any regex metacharacter, not just '(' (capture groups), so that
+			// regexes without capture groups still produce a valid filesystem root path.
+			if strings.ContainsAny(section, `.*+?[{(|\`) {
 				break
 			}
 		} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -263,6 +263,41 @@ func TestReplacePlaceHolders(t *testing.T) {
 	}
 }
 
+func TestGetRootPath(t *testing.T) {
+	emptyParentheses := NewParenthesesSlice([]Parentheses{})
+	tests := []struct {
+		name        string
+		path        string
+		patternType PatternType
+		expected    string
+	}{
+		// RegExp without capture groups: the fix — root path must stop before regex metacharacters
+		{"regexp dot-star", "dir/.*\\.txt", RegExp, "dir"},
+		{"regexp dot-star no extension", "dir/.*", RegExp, "dir"},
+		{"regexp char class", "dir/[0-9]+/file", RegExp, "dir"},
+		{"regexp plus quantifier", "dir/prefix.+suffix", RegExp, "dir"},
+		{"regexp question mark", "dir/colou?r", RegExp, "dir"},
+		{"regexp alternation pipe", "dir/foo|bar", RegExp, "dir"},
+		{"regexp backslash escape", "dir/file\\.txt", RegExp, "dir"},
+		{"regexp nested dirs no metachar", "a/b/c", RegExp, "a/b/c"},
+		{"regexp starts with metachar", ".*\\.txt", RegExp, "."},
+		{"regexp multi-level prefix", "a/b/c/.*", RegExp, "a/b/c"},
+		// RegExp with capture groups: existing behaviour preserved
+		{"regexp with capture group", "dir/(.*)/file", RegExp, "dir"},
+		{"regexp capture at root", "(.*)/file", RegExp, "."},
+		// Wildcard: existing behaviour unchanged
+		{"wildcard star", "dir/*/file.txt", WildCardPattern, "dir"},
+		{"wildcard multi-level", "a/b/*/c", WildCardPattern, "a/b"},
+		{"wildcard no star", "a/b/c", WildCardPattern, "a/b/c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetRootPath(tt.path, tt.patternType, emptyParentheses)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestValidateMinimumVersion(t *testing.T) {
 	minTestVersion := "6.9.0"
 	tests := []struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
without this the jfrog cli doesn't parse regexes correctly but requires a capture group