### PR TITLE
Fix: Don't treat literal dots in directory names as regex metacharacters

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -85,6 +85,25 @@ func ValidateMinimumVersion(product MinVersionProduct, currentVersion, minimumVe
 	return nil
 }
 
+// hasRegexPattern checks if a path section contains actual regex patterns.
+// It distinguishes between literal dots in filenames (e.g., "my.folder", "file.txt")
+// and regex metacharacters/patterns (e.g., ".*", ".+", "[0-9]", "(group)").
+// Returns true if the section appears to contain regex syntax.
+func hasRegexPattern(section string) bool {
+	// Check for regex quantifiers and patterns
+	if strings.ContainsAny(section, `*+?[{(|`) {
+		return true
+	}
+
+	// Check for escaped characters (backslash indicates regex mode)
+	// e.g., "file\.txt", "\d+", "\w*"
+	if strings.Contains(section, `\`) {
+		return true
+	}
+
+	return false
+}
+
 // Get the local root path, from which to start collecting artifacts to be used for:
 // 1. Uploaded to Artifactory,
 // 2. Adding to the local build-info, to be later published to Artifactory.
@@ -108,9 +127,10 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 			continue
 		}
 		if patternType == RegExp {
-			// Break on any regex metacharacter, not just '(' (capture groups), so that
-			// regexes without capture groups still produce a valid filesystem root path.
-			if strings.ContainsAny(section, `.*+?[{(|\`) {
+			// Break when we encounter actual regex patterns, not just any dot.
+			// A literal dot in a directory/file name (e.g., "my.folder", "file.txt") is valid.
+			// We only break on regex constructs like ".*", ".+", "[...]", "(..)", etc.
+			if hasRegexPattern(section) {
 				break
 			}
 		} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -282,6 +282,11 @@ func TestGetRootPath(t *testing.T) {
 		{"regexp nested dirs no metachar", "a/b/c", RegExp, "a/b/c"},
 		{"regexp starts with metachar", ".*\\.txt", RegExp, "."},
 		{"regexp multi-level prefix", "a/b/c/.*", RegExp, "a/b/c"},
+		// Literal dots in directory/file names should NOT trigger regex detection
+		{"regexp literal dot in dirname", "/tmp/jfrog.cli.temp.-1775042212-1894730057/(.*)", RegExp, "/tmp/jfrog.cli.temp.-1775042212-1894730057"},
+		{"regexp literal dots in filename", "my.folder/file.txt/(.*)", RegExp, "my.folder/file.txt"},
+		{"regexp multiple literal dots", "archive.tar.gz.backup/.*", RegExp, "archive.tar.gz.backup"},
+		{"regexp dots with numbers", "dir.1.2.3/test.file/(.*)", RegExp, "dir.1.2.3/test.file"},
 		// RegExp with capture groups: existing behaviour preserved
 		{"regexp with capture group", "dir/(.*)/file", RegExp, "dir"},
 		{"regexp capture at root", "(.*)/file", RegExp, "."},


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Fixed regex parsing by breaking on more metacharacters, but incorrectly included '.' (dot) in the check. This caused literal dots in directory/file names (e.g., "my.folder", "file.txt", "jfrog.cli.temp.-123") to trigger regex detection, breaking path resolution.

Impact:
When uploading from paths like "/tmp/jfrog.cli.temp.-123/(.*)", the code would break at the first dot, treating "/tmp" as the root path instead of "/tmp/jfrog.cli.temp.-123". This caused the upload to traverse the entire /tmp directory, including restricted directories like /tmp/snap-private-tmp, resulting in permission errors.

Solution:
- Added hasRegexPattern() helper to distinguish between literal dots and actual regex patterns
- Only breaks on regex constructs: *, +, ?, [, {, (, |, and \
- Literal dots in filenames are now correctly preserved
- Added test cases for paths with literal dots

Fixes the TestArtifactoryUploadExcludeByCli2Regex failure in jfrog-cli PR #3413 (version bump to 2.98.0)