### PR TITLE
Add Changed files to GitInfoContext

### DIFF
--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -219,7 +219,7 @@ type XscGitInfoContext struct {
 type GitDiffContext struct {
 	Target       *CommitContext      `json:"target,omitempty"`
 	PullRequest  *PullRequestContext `json:"pull_request,omitempty"`
-	ChangedFiles []string
+	ChangedFiles []string            `json:"-"`
 }
 
 type CommitContext struct {

--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -219,7 +219,7 @@ type XscGitInfoContext struct {
 type GitDiffContext struct {
 	Target       *CommitContext      `json:"target,omitempty"`
 	PullRequest  *PullRequestContext `json:"pull_request,omitempty"`
-	ChangedFiles []string            `json:"changed_files,omitempty"`
+	ChangedFiles []string
 }
 
 type CommitContext struct {

--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -209,11 +209,17 @@ type XscAnalyticsGeneralEvent struct {
 }
 
 type XscGitInfoContext struct {
-	Source       CommitContext       `json:"source"`
+	GitDiffContext
+	Source       CommitContext `json:"source"`
+	GitProvider  string        `json:"git_provider,omitempty"`
+	Technologies []string      `json:"technologies,omitempty"`
+}
+
+// Optional fields for git diff context
+type GitDiffContext struct {
 	Target       *CommitContext      `json:"target,omitempty"`
 	PullRequest  *PullRequestContext `json:"pull_request,omitempty"`
-	GitProvider  string              `json:"git_provider,omitempty"`
-	Technologies []string            `json:"technologies,omitempty"`
+	ChangedFiles []string            `json:"changed_files,omitempty"`
 }
 
 type CommitContext struct {


### PR DESCRIPTION
## `feat: add changed files to GitInfoContext`

## Summary

Extends `XscGitInfoContext` so git-related analytics can carry an optional `changed_files` list via a new embedded `GitDiffContext` type, alongside existing source/target/PR and metadata fields.

## Changes

- **`xsc/services/analytics.go`**: Introduce `GitDiffContext` (target, pull request, `changed_files`, etc.); embed it in `XscGitInfoContext` and keep `Source` plus optional `git_provider` / `technologies` on the outer struct.
