### PR TITLE
fix: build+pattern downloads against virtual repos

### DIFF
--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -14,6 +14,10 @@ import (
 
 const spaceEncoding = "%20"
 
+// errTransitiveMultiRepoMsg is shared by both pattern-based and build-with-pattern AQL
+// builders so the validation and its error text stay in lockstep.
+const errTransitiveMultiRepoMsg = "when searching or downloading with the transitive setting, the pattern must include a single repository only, meaning wildcards are allowed only after the first slash"
+
 var specialAqlCharacters = map[rune]string{
 	'/':  "%2F",
 	'\\': "%5C",
@@ -34,7 +38,7 @@ func CreateAqlBodyForSpecWithPattern(params *CommonParams) (string, error) {
 		return "", err
 	}
 	if params.Transitive && !singleRepo {
-		return "", errorutils.CheckErrorf("when searching or downloading with the transitive setting, the pattern must include a single repository only, meaning wildcards are allowed only after the first slash.")
+		return "", errorutils.CheckErrorf(errTransitiveMultiRepoMsg)
 	}
 	includeRoot := strings.Count(searchPattern, "/") < 2
 	triplesSize := len(repoPathFileTriples)
@@ -108,54 +112,98 @@ func handleArchiveSearch(triple RepoPathFile, archivePathFilePairs []RepoPathFil
 	return query
 }
 
+// createAqlBodyForBuildArtifacts builds the AQL body for build artifacts with no pattern or
+// exclusions. Safe wrapper: the underlying function only errors on user-supplied input, which
+// is nil here.
 func createAqlBodyForBuildArtifacts(builds []Build) string {
-	return createAqlBodyForBuildArtifactsWithExclusions(builds, nil)
+	body, _ := createAqlBodyForBuildArtifactsWithExclusions(builds, nil)
+	return body
 }
 
-// createAqlBodyForBuildArtifactsWithExclusions creates an AQL body for build artifacts with optional exclusions.
-func createAqlBodyForBuildArtifactsWithExclusions(builds []Build, params *CommonParams) string {
-	buildArtifactsItem := `{"$and":[{"artifact.module.build.name":"%s","artifact.module.build.number":"%s"}]}`
-	var items []string
-	for _, build := range builds {
-		items = append(items, fmt.Sprintf(buildArtifactsItem, build.BuildName, build.BuildNumber))
+// createAqlBodyForBuildArtifactsWithExclusions builds the AQL body for build artifacts.
+// When a non-trivial pattern is supplied, its repo/path/name triples are included in the AQL
+// so Artifactory performs the match server-side; this preserves virtual-repo resolution that
+// a client-side string compare on the result's Repo cannot do.
+func createAqlBodyForBuildArtifactsWithExclusions(builds []Build, params *CommonParams) (string, error) {
+	items := buildClauseItems(builds, "artifact")
+	buildOr := fmt.Sprintf(`"$or":[%s]`, strings.Join(items, ","))
+
+	excludeQuery, err := maybeBuildExcludeQuery(params)
+	if err != nil {
+		return "", err
 	}
 
-	// Build the exclusion query if params with exclusions are provided
-	excludeQuery := ""
-	if params != nil && len(params.GetExclusions()) > 0 {
-		var err error
-		excludeQuery, err = buildExcludeQueryPart(params, true, params.Recursive)
-		if err != nil {
-			excludeQuery = ""
-		}
+	patternOr, err := buildPatternFilterForBuildArtifacts(params)
+	if err != nil {
+		return "", err
 	}
-
-	return `{` + excludeQuery + `"$or":[` + strings.Join(items, ",") + "]}"
+	if patternOr != "" {
+		return fmt.Sprintf(`{%s"$and":[{%s},{%s}]}`, excludeQuery, buildOr, patternOr), nil
+	}
+	return fmt.Sprintf(`{%s%s}`, excludeQuery, buildOr), nil
 }
 
+// buildPatternFilterForBuildArtifacts returns an AQL "$or" clause matching the pattern's
+// repo/path/name triples, or an empty string when no non-trivial pattern is supplied. Callers
+// compose it with the build-name/build-number filter under "$and".
+func buildPatternFilterForBuildArtifacts(params *CommonParams) (string, error) {
+	if params == nil || params.Pattern == "" || params.Pattern == "*" {
+		return "", nil
+	}
+	searchPattern := prepareSourceSearchPattern(params.Pattern, params.Target)
+	triples, singleRepo, err := createRepoPathFileTriples(searchPattern, params.Recursive)
+	if err != nil {
+		return "", err
+	}
+	if params.Transitive && !singleRepo {
+		return "", errorutils.CheckErrorf(errTransitiveMultiRepoMsg)
+	}
+	if len(triples) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf(`"$or":[%s]`, handleRepoPathFileTriples(triples, nil, len(triples))), nil
+}
+
+// createAqlBodyForBuildDependencies builds the AQL body for build dependencies with no
+// exclusions. Safe wrapper: the underlying function only errors on user-supplied exclusions,
+// which are nil here.
 func createAqlBodyForBuildDependencies(builds []Build) string {
-	return createAqlBodyForBuildDependenciesWithExclusions(builds, nil)
+	body, _ := createAqlBodyForBuildDependenciesWithExclusions(builds, nil)
+	return body
 }
 
-// createAqlBodyForBuildDependenciesWithExclusions creates an AQL body for build dependencies with optional exclusions.
-func createAqlBodyForBuildDependenciesWithExclusions(builds []Build, params *CommonParams) string {
-	buildDependenciesItem := `{"$and":[{"dependency.module.build.name":"%s","dependency.module.build.number":"%s"}]}`
-	var items []string
-	for _, build := range builds {
-		items = append(items, fmt.Sprintf(buildDependenciesItem, build.BuildName, build.BuildNumber))
+// createAqlBodyForBuildDependenciesWithExclusions builds the AQL body for build dependencies.
+// Matches the error-propagation behavior of its artifact-side sibling so malformed exclusions
+// surface consistently on both paths.
+func createAqlBodyForBuildDependenciesWithExclusions(builds []Build, params *CommonParams) (string, error) {
+	items := buildClauseItems(builds, "dependency")
+	excludeQuery, err := maybeBuildExcludeQuery(params)
+	if err != nil {
+		return "", err
 	}
+	return fmt.Sprintf(`{%s"$or":[%s]}`, excludeQuery, strings.Join(items, ",")), nil
+}
 
-	// Build the exclusion query if params with exclusions are provided
-	excludeQuery := ""
-	if params != nil && len(params.GetExclusions()) > 0 {
-		var err error
-		excludeQuery, err = buildExcludeQueryPart(params, true, params.Recursive)
-		if err != nil {
-			excludeQuery = ""
-		}
+// buildClauseItems returns the per-build AQL clauses used inside the outer "$or". kind is
+// either "artifact" or "dependency" and selects the AQL domain prefix.
+func buildClauseItems(builds []Build, kind string) []string {
+	items := make([]string, 0, len(builds))
+	for _, b := range builds {
+		items = append(items, fmt.Sprintf(
+			`{"$and":[{"%s.module.build.name":"%s","%s.module.build.number":"%s"}]}`,
+			kind, b.BuildName, kind, b.BuildNumber,
+		))
 	}
+	return items
+}
 
-	return `{` + excludeQuery + `"$or":[` + strings.Join(items, ",") + "]}"
+// maybeBuildExcludeQuery returns the exclusion AQL fragment for params (with trailing comma,
+// as consumed by callers) or an empty string when there are no exclusions. params may be nil.
+func maybeBuildExcludeQuery(params *CommonParams) (string, error) {
+	if params == nil || len(params.GetExclusions()) == 0 {
+		return "", nil
+	}
+	return buildExcludeQueryPart(params, true, params.Recursive)
 }
 
 func createAqlQueryForBuild(includeQueryPart string, artifactsQuery bool, builds []Build) string {

--- a/artifactory/services/utils/aqlquerybuilder_test.go
+++ b/artifactory/services/utils/aqlquerybuilder_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -295,7 +296,8 @@ func TestCreateAqlBodyForBuildArtifactsWithExclusions(t *testing.T) {
 		Exclusions: []string{"*.json"},
 		Recursive:  true,
 	}
-	aqlBodyWithExclusions := createAqlBodyForBuildArtifactsWithExclusions(builds, params)
+	aqlBodyWithExclusions, err := createAqlBodyForBuildArtifactsWithExclusions(builds, params)
+	assert.NoError(t, err)
 
 	assert.Contains(t, aqlBodyWithExclusions, `"$nmatch"`, "FIX VERIFIED: createAqlBodyForBuildArtifactsWithExclusions includes exclusions")
 	assert.Contains(t, aqlBodyWithExclusions, `*.json`)
@@ -313,7 +315,8 @@ func TestCreateAqlBodyForBuildDependenciesWithExclusions(t *testing.T) {
 		Exclusions: []string{"*.xml", "test-*"},
 		Recursive:  true,
 	}
-	aqlBody := createAqlBodyForBuildDependenciesWithExclusions(builds, params)
+	aqlBody, err := createAqlBodyForBuildDependenciesWithExclusions(builds, params)
+	assert.NoError(t, err)
 
 	assert.Contains(t, aqlBody, `"$nmatch"`)
 	assert.Contains(t, aqlBody, `*.xml`)
@@ -418,78 +421,137 @@ func TestGetSpecType_BuildWithPattern(t *testing.T) {
 	}
 }
 
-func TestAqlMatch(t *testing.T) {
-	tests := []struct {
-		name    string
-		value   string
-		pattern string
-		match   bool
-	}{
-		{"exact match", "repo-local", "repo-local", true},
-		{"exact mismatch", "repo-local", "other-repo", false},
-		{"wildcard all", "anything", "*", true},
-		{"wildcard suffix", "file.jar", "*.jar", true},
-		{"wildcard suffix mismatch", "file.txt", "*.jar", false},
-		{"wildcard prefix", "test-file", "test-*", true},
-		{"wildcard prefix mismatch", "prod-file", "test-*", false},
-		{"wildcard middle", "test-123-file", "test-*-file", true},
-		{"wildcard middle mismatch", "test-123-other", "test-*-file", false},
-		{"multiple wildcards", "a/b/c/d", "a/*/c/*", true},
-		{"dot path", ".", "*", true},
-	}
+func TestCreateAqlBodyForBuildArtifactsWithPattern(t *testing.T) {
+	builds := []Build{{BuildName: "my-build", BuildNumber: "1"}}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := aqlMatch(tt.value, tt.pattern)
-			assert.Equal(t, tt.match, result)
+	t.Run("no pattern: build-only filter, no $and wrapping", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.NotContains(t, body, `"$and":[{"$or"`)
+	})
+
+	t.Run("trivial '*' pattern: treated as no pattern", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{Pattern: "*"})
+		assert.NoError(t, err)
+		assert.NotContains(t, body, `"$and":[{"$or"`)
+	})
+
+	t.Run("pattern with virtual repo: server-side match via AQL", func(t *testing.T) {
+		// A client-side string compare on `Repo` cannot translate virtual → backing local,
+		// but AQL can. The pattern must go into the query itself.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "some-virtual-repo/com/jfrog/*/my-artifact-*.tgz",
+			Recursive: true,
 		})
-	}
-}
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.Contains(t, body, `"repo":"some-virtual-repo"`)
+		assert.Contains(t, body, `"$and":[{"$or"`, "build and pattern filters should be ANDed together")
+	})
 
-func TestMatchResultItemToTriples(t *testing.T) {
-	tests := []struct {
-		name    string
-		item    ResultItem
-		triples []RepoPathFile
-		match   bool
-	}{
-		{
-			name: "item matches single triple",
-			item: ResultItem{Repo: "docker-local-ash", Path: "path/to", Name: "file.jar"},
-			triples: []RepoPathFile{
-				{repo: "docker-local-ash", path: "*", file: "*"},
-			},
-			match: true,
-		},
-		{
-			name: "item does not match repo",
-			item: ResultItem{Repo: "other-repo", Path: "path/to", Name: "file.jar"},
-			triples: []RepoPathFile{
-				{repo: "docker-local-ash", path: "*", file: "*"},
-			},
-			match: false,
-		},
-		{
-			name: "item matches one of multiple triples",
-			item: ResultItem{Repo: "repo-b", Path: "some/path", Name: "test.txt"},
-			triples: []RepoPathFile{
-				{repo: "repo-a", path: "*", file: "*"},
-				{repo: "repo-b", path: "*", file: "*.txt"},
-			},
-			match: true,
-		},
-		{
-			name:    "empty triples matches nothing",
-			item:    ResultItem{Repo: "repo-a", Path: ".", Name: "file.jar"},
-			triples: []RepoPathFile{},
-			match:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := matchResultItemToTriples(&tt.item, tt.triples)
-			assert.Equal(t, tt.match, result)
+	t.Run("invalid pattern surfaces as error", func(t *testing.T) {
+		// Pattern starting with '/' is invalid — must start with a repo name or asterisk.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "/leading-slash-is-invalid",
+			Recursive: true,
 		})
-	}
+		assert.Error(t, err, "invalid patterns must not be silently swallowed")
+	})
+
+	t.Run("transitive + multi-repo pattern is rejected", func(t *testing.T) {
+		// Wildcards before the first slash expand to multiple repos, which transitive mode forbids.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "repo-*/com/jfrog/*.tgz",
+			Recursive:  true,
+			Transitive: true,
+		})
+		assert.Error(t, err, "transitive search with multi-repo wildcards must be rejected")
+		assert.Contains(t, err.Error(), "transitive", "error should mention transitive")
+	})
+
+	t.Run("transitive + single-repo pattern is accepted", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "one-repo/com/jfrog/*.tgz",
+			Recursive:  true,
+			Transitive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"repo":"one-repo"`)
+	})
+
+	t.Run("exclusions + pattern: both appear in AQL", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "some-repo/com/jfrog/*.jar",
+			Recursive:  true,
+			Exclusions: []string{"*test*.jar"},
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"$and":[{"$or"`, "pattern is still present under $and")
+		assert.Contains(t, body, `"$nmatch"`, "exclusion should produce $nmatch filter")
+		assert.Contains(t, body, `"repo":"some-repo"`)
+	})
+
+	t.Run("multi-triple pattern expands into $or", func(t *testing.T) {
+		// A recursive pattern with a wildcard mid-path produces multiple triples; each
+		// triple carries its own "repo" literal, so the count signals fan-out.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "some-repo/com/jfrog/*/files/*-linux-amd64.tgz",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, strings.Count(body, `"repo":"some-repo"`), 2, "recursive pattern should produce multiple triples")
+	})
+
+	t.Run("aggregated builds + pattern: all builds ANDed with pattern", func(t *testing.T) {
+		aggregated := []Build{
+			{BuildName: "my-build", BuildNumber: "1"},
+			{BuildName: "my-build", BuildNumber: "2"},
+			{BuildName: "upstream-build", BuildNumber: "5"},
+		}
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(aggregated, &CommonParams{
+			Pattern:   "some-repo/com/jfrog/*.jar",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build","artifact.module.build.number":"1"`)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build","artifact.module.build.number":"2"`)
+		assert.Contains(t, body, `"artifact.module.build.name":"upstream-build","artifact.module.build.number":"5"`)
+		assert.Contains(t, body, `"$and":[{"$or"`, "aggregated build list must be ANDed with pattern, not replaced")
+	})
+
+	t.Run("'*/path' pattern: repo wildcard not emitted as repo filter", func(t *testing.T) {
+		// buildInnerQueryPart skips the repo condition when the triple's repo is '*' or '**',
+		// so users writing '*/path/...' as a workaround don't get a literal `"repo":"*"` emitted.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "*/com/jfrog/foo/*.tgz",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"$and":[{"$or"`, "pattern should still be present")
+		assert.NotContains(t, body, `"repo":"*"`, "repo='*' must not be emitted as an AQL filter")
+	})
+
+	t.Run("nil-params wrapper: returns valid JSON with no pattern or exclusions", func(t *testing.T) {
+		// The wrapper at createAqlBodyForBuildArtifacts calls the underlying function with
+		// nil params and swallows the error; verify its output is a well-formed JSON body
+		// containing only the build filter.
+		body := createAqlBodyForBuildArtifacts(builds)
+		var parsed map[string]any
+		assert.NoError(t, json.Unmarshal([]byte(body), &parsed), "body must be valid JSON")
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.NotContains(t, body, `"$and":[{"$or"`, "no pattern → no $and wrapping")
+		assert.NotContains(t, body, `"$nmatch"`, "no exclusions → no $nmatch")
+	})
+
+	t.Run("malformed exclusion propagates as error", func(t *testing.T) {
+		// Guards the behavior change introduced by this fix: a malformed exclusion pattern
+		// used to silently produce a build-only AQL (exclusion dropped); now it aborts.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "some-repo/*",
+			Recursive:  true,
+			Exclusions: []string{"/leading-slash-is-invalid"},
+		})
+		assert.Error(t, err, "malformed exclusion must propagate, not be silently swallowed")
+	})
 }

--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -35,7 +35,9 @@ const (
 
 // Use this function when searching by build without pattern or aql.
 // Collect build artifacts and build dependencies separately, then merge the results into one reader.
-// If a pattern is also specified, results are post-filtered to match the pattern.
+// If a pattern is also specified, the pattern is applied server-side via AQL inside
+// getBuildArtifactsUsingAql → createAqlBodyForBuildArtifactsWithExclusions. This preserves
+// virtual-repo resolution (AQL translates virtual repo names to their backing locals).
 func SearchBySpecWithBuild(specFile *CommonParams, flags CommonConf) (readerContent *content.ContentReader, err error) {
 	log.Info("Searching items related to a build...")
 	buildName, buildNumber, err := GetBuildNameAndNumberFromBuildIdentifier(specFile.Build, specFile.Project, flags)
@@ -93,135 +95,15 @@ func SearchBySpecWithBuild(specFile *CommonParams, flags CommonConf) (readerCont
 		return nil, depErr
 	}
 	readerContent, err = filterBuildArtifactsAndDependencies(artifactsReader, dependenciesReader, specFile, flags, aggregatedBuilds)
-	if err != nil {
-		return
-	}
-
-	// If a pattern was specified alongside the build, filter results to only include
-	// items whose repo/path/name match the pattern. This supports the use case where
-	// users specify both "build" and "pattern" in a file spec to narrow down build
-	// artifacts to a specific repository or path.
-	if specFile.Pattern != "" && specFile.Pattern != "*" {
-		var filteredContent *content.ContentReader
-		filteredContent, err = filterBuildResultsByPattern(readerContent, specFile)
-		if err != nil {
-			return
-		}
-		// Close the unfiltered reader before replacing it with the filtered one.
-		err = errors.Join(err, errorutils.CheckError(readerContent.Close()))
-		readerContent = filteredContent
-	}
 	return
-}
-
-// patternMatcher holds pre-split wildcard segments for a repo/path/file triple,
-// so that matching against result items avoids repeated strings.Split calls.
-type patternMatcher struct {
-	repoParts []string
-	pathParts []string
-	fileParts []string
-}
-
-// buildPatternMatchers pre-splits the wildcard patterns in each triple into segments,
-// so that matching against N result items does not re-split patterns on every call.
-func buildPatternMatchers(triples []RepoPathFile) []patternMatcher {
-	matchers := make([]patternMatcher, len(triples))
-	for i, t := range triples {
-		matchers[i] = patternMatcher{
-			repoParts: strings.Split(t.repo, "*"),
-			pathParts: strings.Split(t.path, "*"),
-			fileParts: strings.Split(t.file, "*"),
-		}
-	}
-	return matchers
-}
-
-// filterBuildResultsByPattern filters build search results to only include items
-// matching the given file spec pattern. The pattern is in Artifactory format
-// (e.g., "repo-local/path/*") and is matched against each item's "repo/path/name".
-func filterBuildResultsByPattern(reader *content.ContentReader, specFile *CommonParams) (filteredReader *content.ContentReader, err error) {
-	writer, err := content.NewContentWriter(content.DefaultKey, true, false)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = errors.Join(err, errorutils.CheckError(writer.Close()))
-	}()
-
-	pattern := prepareSourceSearchPattern(specFile.Pattern, specFile.Target)
-	repoPathFileTriples, _, err := createRepoPathFileTriples(pattern, specFile.Recursive)
-	if err != nil {
-		return nil, err
-	}
-
-	// Build pattern matchers once so we don't re-split patterns for every result item.
-	matchers := buildPatternMatchers(repoPathFileTriples)
-
-	for resultItem := new(ResultItem); reader.NextRecord(resultItem) == nil; resultItem = new(ResultItem) {
-		if matchResultItemToPatterns(resultItem, matchers) {
-			writer.Write(*resultItem)
-		}
-	}
-	if err = reader.GetError(); err != nil {
-		return nil, err
-	}
-	filteredReader = content.NewContentReader(writer.GetFilePath(), writer.GetArrayKey())
-	return
-}
-
-// matchResultItemToPatterns checks whether a result item matches any of the
-// pre-built repo/path/file pattern matchers.
-func matchResultItemToPatterns(item *ResultItem, matchers []patternMatcher) bool {
-	for _, m := range matchers {
-		if wildcardMatch(item.Repo, m.repoParts) &&
-			wildcardMatch(item.Path, m.pathParts) &&
-			wildcardMatch(item.Name, m.fileParts) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchResultItemToTriples checks whether a result item matches any of the repo/path/file triples
-// derived from a pattern. Each triple contains AQL-style match expressions for repo, path, and name.
-func matchResultItemToTriples(item *ResultItem, triples []RepoPathFile) bool {
-	return matchResultItemToPatterns(item, buildPatternMatchers(triples))
-}
-
-// aqlMatch performs a simple wildcard match using the same semantics as AQL's $match operator.
-// The pattern supports "*" (matches any sequence of characters).
-func aqlMatch(value, pattern string) bool {
-	return wildcardMatch(value, strings.Split(pattern, "*"))
-}
-
-// wildcardMatch matches a value against pre-split pattern segments (split on "*").
-// A single-element slice means no wildcards — exact match is required.
-func wildcardMatch(value string, parts []string) bool {
-	if len(parts) == 1 {
-		return value == parts[0]
-	}
-	pos := 0
-	for i, part := range parts {
-		if part == "" {
-			continue
-		}
-		idx := strings.Index(value[pos:], part)
-		if idx < 0 {
-			return false
-		}
-		if i == 0 && idx != 0 {
-			return false
-		}
-		pos += idx + len(part)
-	}
-	if lastPart := parts[len(parts)-1]; lastPart != "" {
-		return strings.HasSuffix(value, lastPart)
-	}
-	return true
 }
 
 func getBuildDependenciesForBuildSearch(specFile CommonParams, flags CommonConf, builds []Build) (*content.ContentReader, error) {
-	specFile.Aql = Aql{ItemsFind: createAqlBodyForBuildDependenciesWithExclusions(builds, &specFile)}
+	aqlBody, err := createAqlBodyForBuildDependenciesWithExclusions(builds, &specFile)
+	if err != nil {
+		return nil, err
+	}
+	specFile.Aql = Aql{ItemsFind: aqlBody}
 	executionQuery := BuildQueryFromSpecFile(&specFile, ALL)
 	return aqlSearch(executionQuery, flags)
 }
@@ -253,7 +135,11 @@ func getBuildArtifactsForBuildSearch(specFile CommonParams, flags CommonConf, bu
 }
 
 func getBuildArtifactsUsingAql(specFile CommonParams, flags CommonConf, builds []Build) (*content.ContentReader, error) {
-	specFile.Aql = Aql{ItemsFind: createAqlBodyForBuildArtifactsWithExclusions(builds, &specFile)}
+	aqlBody, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &specFile)
+	if err != nil {
+		return nil, err
+	}
+	specFile.Aql = Aql{ItemsFind: aqlBody}
 	executionQuery := BuildQueryFromSpecFile(&specFile, ALL)
 	return aqlSearch(executionQuery, flags)
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Problem:
  PR #1329 routed `--build + pattern` through a new path that fetched all
  build artifacts and post-filtered in Go using a string compare on `Repo`,
  which cannot resolve a virtual repo to its backing local — every result
  was dropped and downloads returned 0 files.

Solution:
  Move the pattern match into the AQL query itself via an AND of the build
  filter and the repo/path/name triples, letting Artifactory resolve virtual
  repos server-side. Remove the now-redundant client-side filter and its
  dead helpers from searchutil.go.