### PR TITLE
fix(searchutil): nil-guard ResultItem.ToArtifact against nil receiver

### DIFF
--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -455,6 +455,16 @@ func (item ResultItem) GetItemRelativeLocation() string {
 }
 
 func (item *ResultItem) ToArtifact() buildinfo.Artifact {
+	// Multi-arch container push callers (jfrog-cli-artifactory OCI
+	// buildinfo.createPushBuildProperties) reach ToArtifact on the
+	// zero-value element of a nil ResultItem pointer when the
+	// manifest-digest SHA lookup misses in Artifactory. The previous
+	// code then SIGSEGV'd on item.Name and took the whole build down.
+	// Return a zero Artifact instead so the caller sees an empty
+	// result and can handle it as "no matching artifact" upstream.
+	if item == nil {
+		return buildinfo.Artifact{}
+	}
 	return buildinfo.Artifact{
 		Name: item.Name,
 		Checksum: buildinfo.Checksum{


### PR DESCRIPTION
Addresses the downstream crash reported at jfrog/jfrog-cli#3450.

Multi-arch container push callers in jfrog-cli-artifactory (OCI `buildinfo.createPushBuildProperties`) reach `ToArtifact` on a nil `*ResultItem` when the manifest-digest SHA lookup misses in Artifactory. The direct `item.Name` deref crashes the build with:

```
panic: runtime error: invalid memory address or nil pointer dereference
artifactory/services/utils.(*ResultItem).ToArtifact(0x0) searchutil.go:580 +0x42
```

…and takes the Jenkins build down.

## Fix

Return a zero-value `buildinfo.Artifact` when `item` is nil so callers see an empty record and can treat it as "no matching artifact" upstream, rather than fatally panicking the process.

`go build ./artifactory/services/utils/...` clean.