### PR TITLE
Feature/RTECO-1015 Implement ListSkills method to fetch skills from repository

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -115,6 +115,8 @@ type ArtifactoryServicesManager interface {
 	GetPackageLeadFile(leadFileParams services.LeadFileParams) ([]byte, error)
 	UploadTrustedKey(params services.TrustedKeyParams) (*services.TrustedKeyResponse, error)
 	ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error)
+	ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error)
+	GetSkillDetail(repoKey, slug string) (*services.SkillDetail, error)
 	SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error)
 	SkillVersionExists(repoKey, slug, version string) (bool, error)
 	SearchSkillsByProperty(query string) ([]services.SkillPropertySearchResult, error)
@@ -532,6 +534,14 @@ func (esm *EmptyArtifactoryServicesManager) GetTokenDetails(string, string) ([]b
 }
 
 func (esm *EmptyArtifactoryServicesManager) ListSkillVersions(string, string) ([]services.SkillVersion, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) ListSkills(string, int, string, string) ([]services.SkillListItem, string, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) GetSkillDetail(string, string) (*services.SkillDetail, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -116,7 +116,6 @@ type ArtifactoryServicesManager interface {
 	UploadTrustedKey(params services.TrustedKeyParams) (*services.TrustedKeyResponse, error)
 	ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error)
 	ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error)
-	GetSkillDetail(repoKey, slug string) (*services.SkillDetail, error)
 	SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error)
 	SkillVersionExists(repoKey, slug, version string) (bool, error)
 	SearchSkillsByProperty(query string) ([]services.SkillPropertySearchResult, error)
@@ -538,10 +537,6 @@ func (esm *EmptyArtifactoryServicesManager) ListSkillVersions(string, string) ([
 }
 
 func (esm *EmptyArtifactoryServicesManager) ListSkills(string, int, string, string) ([]services.SkillListItem, string, error) {
-	panic("Failed: Method is not implemented")
-}
-
-func (esm *EmptyArtifactoryServicesManager) GetSkillDetail(string, string) (*services.SkillDetail, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -675,6 +675,18 @@ func buildJFrogHttpClient(config config.Config, authDetails auth.ServiceDetails)
 		Build()
 }
 
+func (sm *ArtifactoryServicesManagerImp) ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error) {
+	skillsService := services.NewSkillsService(sm.client)
+	skillsService.ArtDetails = sm.config.GetServiceDetails()
+	return skillsService.ListSkills(repoKey, limit, cursor, sortBy)
+}
+
+func (sm *ArtifactoryServicesManagerImp) GetSkillDetail(repoKey, slug string) (*services.SkillDetail, error) {
+	skillsService := services.NewSkillsService(sm.client)
+	skillsService.ArtDetails = sm.config.GetServiceDetails()
+	return skillsService.GetSkillDetail(repoKey, slug)
+}
+
 func (sm *ArtifactoryServicesManagerImp) ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error) {
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -681,12 +681,6 @@ func (sm *ArtifactoryServicesManagerImp) ListSkills(repoKey string, limit int, c
 	return skillsService.ListSkills(repoKey, limit, cursor, sortBy)
 }
 
-func (sm *ArtifactoryServicesManagerImp) GetSkillDetail(repoKey, slug string) (*services.SkillDetail, error) {
-	skillsService := services.NewSkillsService(sm.client)
-	skillsService.ArtDetails = sm.config.GetServiceDetails()
-	return skillsService.GetSkillDetail(repoKey, slug)
-}
-
 func (sm *ArtifactoryServicesManagerImp) ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error) {
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -76,19 +76,6 @@ func (ss *SkillsService) ListSkills(repoKey string, limit int, cursor, sortBy st
 	return wrapper.Items, wrapper.NextCursor, nil
 }
 
-func (ss *SkillsService) GetSkillDetail(repoKey, slug string) (*SkillDetail, error) {
-	log.Debug(fmt.Sprintf("Getting skill detail for '%s' in repo '%s'...", slug, repoKey))
-	body, err := ss.sendGet(repoKey, fmt.Sprintf("skills/%s", slug))
-	if err != nil {
-		return nil, err
-	}
-	var detail SkillDetail
-	if err = json.Unmarshal(body, &detail); err != nil {
-		return nil, errorutils.CheckErrorf("failed to parse skill detail response: %s", err.Error())
-	}
-	return &detail, nil
-}
-
 func (ss *SkillsService) SearchSkills(repoKey, query string, limit int) ([]SkillSearchResult, error) {
 	log.Debug(fmt.Sprintf("Searching skills in repo '%s' with query '%s'...", repoKey, query))
 	body, err := ss.sendGet(repoKey, fmt.Sprintf("search?q=%s&limit=%d", url.QueryEscape(query), limit))
@@ -228,15 +215,6 @@ type SkillPropertySearchResult struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	URI     string `json:"uri"`
-}
-
-type SkillDetail struct {
-	Slug          string `json:"slug"`
-	DisplayName   string `json:"displayName,omitempty"`
-	Summary       string `json:"summary,omitempty"`
-	LatestVersion string `json:"latestVersion,omitempty"`
-	Versions      int    `json:"versions,omitempty"`
-	Updated       string `json:"updated,omitempty"`
 }
 
 type SkillListItem struct {

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -57,6 +57,38 @@ func (ss *SkillsService) ListVersions(repoKey, slug string) ([]SkillVersion, err
 	return wrapper.Items, nil
 }
 
+func (ss *SkillsService) ListSkills(repoKey string, limit int, cursor, sortBy string) ([]SkillListItem, string, error) {
+	log.Debug(fmt.Sprintf("Listing skills in repo '%s'...", repoKey))
+	sort := "updated"
+	if sortBy == "downloads" {
+		sort = "downloads"
+	}
+	endpoint := fmt.Sprintf("skills?limit=%d&cursor=%s&sort=%s", limit, url.QueryEscape(cursor), sort)
+	body, err := ss.sendGet(repoKey, endpoint)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var wrapper skillListResponse
+	if err = json.Unmarshal(body, &wrapper); err != nil {
+		return nil, "", errorutils.CheckErrorf("failed to parse skill list response: %s", err.Error())
+	}
+	return wrapper.Items, wrapper.NextCursor, nil
+}
+
+func (ss *SkillsService) GetSkillDetail(repoKey, slug string) (*SkillDetail, error) {
+	log.Debug(fmt.Sprintf("Getting skill detail for '%s' in repo '%s'...", slug, repoKey))
+	body, err := ss.sendGet(repoKey, fmt.Sprintf("skills/%s", slug))
+	if err != nil {
+		return nil, err
+	}
+	var detail SkillDetail
+	if err = json.Unmarshal(body, &detail); err != nil {
+		return nil, errorutils.CheckErrorf("failed to parse skill detail response: %s", err.Error())
+	}
+	return &detail, nil
+}
+
 func (ss *SkillsService) SearchSkills(repoKey, query string, limit int) ([]SkillSearchResult, error) {
 	log.Debug(fmt.Sprintf("Searching skills in repo '%s' with query '%s'...", repoKey, query))
 	body, err := ss.sendGet(repoKey, fmt.Sprintf("search?q=%s&limit=%d", url.QueryEscape(query), limit))
@@ -196,6 +228,30 @@ type SkillPropertySearchResult struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	URI     string `json:"uri"`
+}
+
+type SkillDetail struct {
+	Slug          string `json:"slug"`
+	DisplayName   string `json:"displayName,omitempty"`
+	Summary       string `json:"summary,omitempty"`
+	LatestVersion string `json:"latestVersion,omitempty"`
+	Versions      int    `json:"versions,omitempty"`
+	Updated       string `json:"updated,omitempty"`
+}
+
+type SkillListItem struct {
+	Slug          string        `json:"slug"`
+	DisplayName   string        `json:"displayName,omitempty"`
+	Summary       string        `json:"summary,omitempty"`
+	LatestVersion *SkillVersion `json:"latestVersion,omitempty"`
+	Versions      int           `json:"versions,omitempty"`
+	Updated       string        `json:"updated,omitempty"`
+}
+
+type skillListResponse struct {
+	Items      []SkillListItem `json:"items"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+	Total      int             `json:"total,omitempty"`
 }
 
 type skillVersionsResponse struct {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

### Overview
Extends the Skills API service layer to support listing all skills in a repository, alongside the existing version listing and search capabilities.

### Changes
- Added ListSkills(repoKey, limit, cursor, sortBy) — makes a paginated GET /api/skills/<repo>/api/v1/skills?limit=&cursor=&sort= call and returns []SkillListItem + nextCursor
- Added SkillListItem struct — represents a skill entry (slug, displayName, summary, latestVersion *SkillVersion, versions, updated)
- Added skillListResponse struct — JSON wrapper (items, nextCursor, total)
- Added ListSkills() implementation on ArtifactoryServicesManagerImp
- Added ListSkills() to ArtifactoryServicesManager interface
- Added ListSkills() panic stub on EmptyArtifactoryServicesManager