### PR TITLE
Add `SAST Fast Diff Mode` option to configuration profile

### DIFF
--- a/xsc/services/profile.go
+++ b/xsc/services/profile.go
@@ -85,9 +85,10 @@ type CaScannerConfig struct {
 }
 
 type SastScannerConfig struct {
-	EnableSastScan  bool     `json:"enable_sast_scan,omitempty"`
-	ExcludePatterns []string `json:"exclude_patterns,omitempty"`
-	ExcludeRules    []string `json:"exclude_rules,omitempty"`
+	EnableSastScan     bool     `json:"enable_sast_scan,omitempty"`
+	EnableFastDiffMode bool     `json:"enable_differential_scanning,omitempty"`
+	ExcludePatterns    []string `json:"exclude_patterns,omitempty"`
+	ExcludeRules       []string `json:"exclude_rules,omitempty"`
 }
 
 type SecretsScannerConfig struct {


### PR DESCRIPTION
## `feat(xsc): add SAST fast diff mode to configuration profile`

## Summary

Exposes the **SAST fast diff / differential scanning** setting on the XSC profile model by adding `EnableFastDiffMode` to `SastScannerConfig`, serialized as `enable_differential_scanning` in JSON. This lets callers read and write the same flag the API uses for differential SAST scanning.

## Changes

- **`xsc/services/profile.go`**: Extend `SastScannerConfig` with `EnableFastDiffMode bool` and JSON tag `enable_differential_scanning,omitempty`; align field alignment/spacing with existing struct fields.

## Notes

**Breaking changes:** None expected — additive field with `omitempty`.