### PR TITLE
Expose full HTTP response in case of error

### DIFF
--- a/utils/errorutils/errorutils.go
+++ b/utils/errorutils/errorutils.go
@@ -23,6 +23,25 @@ func CheckErrorf(format string, a ...interface{}) error {
 	return CheckError(errors.New(format))
 }
 
+// HttpResponseError is returned by CheckResponseStatus and CheckResponseStatusWithBody
+// when the server returns an unexpected status code. It preserves the raw response so
+// callers can produce structured error output (e.g. JSON to stderr) via errors.As,
+// while Error() still produces the legacy "server response: ..." string for
+// backward compatibility with existing string-matching callers and tests.
+type HttpResponseError struct {
+	StatusCode int
+	Status     string
+	Body       []byte
+}
+
+func (e *HttpResponseError) Error() string {
+	msg := "server response: " + e.Status
+	if len(e.Body) > 0 {
+		msg += "\n" + GenerateErrorString(e.Body)
+	}
+	return msg
+}
+
 // Check expected status codes and return error if needed
 func CheckResponseStatus(resp *http.Response, expectedStatusCodes ...int) error {
 	for _, statusCode := range expectedStatusCodes {
@@ -32,7 +51,11 @@ func CheckResponseStatus(resp *http.Response, expectedStatusCodes ...int) error 
 	}
 	// Add resp.Body to error response if exists
 	errorBody, _ := io.ReadAll(resp.Body)
-	return CheckError(GenerateResponseError(resp.Status, string(errorBody)))
+	return CheckError(&HttpResponseError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       errorBody,
+	})
 }
 
 // Check expected status codes and return error with body if needed
@@ -44,7 +67,11 @@ func CheckResponseStatusWithBody(resp *http.Response, body []byte, expectedStatu
 			return nil
 		}
 	}
-	return CheckError(GenerateResponseError(resp.Status, GenerateErrorString(body)))
+	return CheckError(&HttpResponseError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       body,
+	})
 }
 
 func GenerateResponseError(status, body string) error {

--- a/utils/errorutils/errorutils_test.go
+++ b/utils/errorutils/errorutils_test.go
@@ -1,0 +1,61 @@
+package errorutils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckResponseStatusWithBody_ReturnsTypedHttpResponseError(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"}
+	body := []byte(`{"errors":[{"code":"UNAUTHORIZED","message":"bad credentials"}]}`)
+
+	err := CheckResponseStatusWithBody(resp, body, http.StatusOK)
+	assert.Error(t, err)
+
+	var httpErr *HttpResponseError
+	assert.True(t, errors.As(err, &httpErr), "expected error to unwrap to *HttpResponseError")
+	assert.Equal(t, http.StatusUnauthorized, httpErr.StatusCode)
+	assert.Equal(t, "401 Unauthorized", httpErr.Status)
+	assert.Equal(t, body, httpErr.Body)
+
+	// Error() preserves the legacy human-readable format.
+	assert.True(t, strings.HasPrefix(err.Error(), "server response: 401 Unauthorized\n"),
+		"legacy text format must be preserved, got: %q", err.Error())
+}
+
+func TestCheckResponseStatusWithBody_HappyPathReturnsNil(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusOK, Status: "200 OK"}
+	assert.NoError(t, CheckResponseStatusWithBody(resp, []byte(`{}`), http.StatusOK))
+}
+
+func TestCheckResponseStatus_ReadsBodyAndReturnsTyped(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(strings.NewReader("not-json")),
+	}
+	err := CheckResponseStatus(resp, http.StatusOK)
+	assert.Error(t, err)
+
+	var httpErr *HttpResponseError
+	assert.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, 500, httpErr.StatusCode)
+	assert.Equal(t, []byte("not-json"), httpErr.Body)
+}
+
+func TestHttpResponseError_UnwrapsThroughFmtErrorf(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"}
+	inner := CheckResponseStatusWithBody(resp, []byte(`{"msg":"nope"}`), http.StatusOK)
+	wrapped := fmt.Errorf("failed to exchange OIDC token: %w", inner)
+
+	var httpErr *HttpResponseError
+	assert.True(t, errors.As(wrapped, &httpErr),
+		"errors.As must walk through fmt.Errorf %%w wrapping (OIDC code path)")
+	assert.Equal(t, 403, httpErr.StatusCode)
+}


### PR DESCRIPTION
### Summary

Introduces `errorutils.HttpResponseError`, a typed error returned by `CheckResponseStatus` and `CheckResponseStatusWithBody` when the server returns an unexpected status code. The error preserves the raw HTTP response (status code, status text, body bytes) so downstream consumers can produce structured output (e.g. JSON for scripts/CI) via `errors.As`, instead of regex-parsing the legacy text message.

### Backward compatibility

The change is strictly additive. `Error()` returns the exact same `"server response: <STATUS>\n<indented body>"` string as before, so every caller and test that string-matches on the legacy prefix keeps passing. `GenerateResponseError` and `GenerateErrorString` are untouched. No call-site changes are required upstream — new callers can opt in to the richer behavior via `errors.As`.

### Why

Driven by `jfrog-cli` `JGC-437`: when a user opts in via `JFROG_CLI_ERROR_OUTPUT_FORMAT=json` (or `--format=json`), the CLI emits HTTP errors as a parseable JSON object on stdout. To produce that reliably it needs the status code and raw body as values, not a pre-formatted string. Because every JFrog product surface (Artifactory, Access, Xray, Pipelines, OIDC) funnels HTTP errors through `CheckResponseStatus*`, exposing the typed error in one place covers all of those code paths — OIDC token exchange already wraps with `%w`, so the type propagates to the top level.

### Tests

New `errorutils_test.go` covers: typed return shape, `errors.As` matching (direct and through `fmt.Errorf %w` wrapping), the legacy text format preservation, and the happy path.

---

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----