### PR TITLE
Fix race in ContentReader causing 'send on closed channel' panic

### DIFF
--- a/utils/io/content/contentreader.go
+++ b/utils/io/content/contentreader.go
@@ -33,6 +33,16 @@ type ContentReader struct {
 	dataChannel chan map[string]interface{}
 	errorsQueue *utils.ErrorsQueue
 	once        *sync.Once
+	// mu guards reads/writes of dataChannel, once, and done across
+	// NextRecord/Reset, so a receiver and the producer goroutine always
+	// agree on which channel is in play, even if Reset is racing with
+	// NextRecord.
+	mu sync.Mutex
+	// done is closed by the current producer goroutine when it exits.
+	// Reset blocks on it to ensure the old producer finishes before the
+	// channel/once fields are swapped. A new done is created per cycle to
+	// avoid sync.WaitGroup reuse-during-Wait panics.
+	done chan struct{}
 	// Number of elements in the array (cache)
 	length int
 	empty  bool
@@ -71,14 +81,25 @@ func (cr *ContentReader) NextRecord(recordOutput interface{}) error {
 	if cr.empty {
 		return errorutils.CheckErrorf("Empty")
 	}
+	// Pair the once.Do (which spawns the producer and captures the active
+	// channel) with a snapshot of dataChannel under cr.mu, so the receiver
+	// on this call reads from the same channel the producer writes to even
+	// if Reset() races to swap dataChannel.
+	cr.mu.Lock()
 	cr.once.Do(func() {
+		ch := cr.dataChannel
+		done := make(chan struct{})
+		cr.done = done
 		go func() {
-			defer close(cr.dataChannel)
+			defer close(done)
+			defer close(ch)
 			cr.length = 0
-			cr.run()
+			cr.run(ch)
 		}()
 	})
-	record, ok := <-cr.dataChannel
+	ch := cr.dataChannel
+	cr.mu.Unlock()
+	record, ok := <-ch
 	if !ok {
 		return io.EOF
 	}
@@ -92,10 +113,23 @@ func (cr *ContentReader) NextRecord(recordOutput interface{}) error {
 	return err
 }
 
-// Prepare the reader to read the file all over again (not thread-safe).
+// Prepare the reader to read the file all over again.
+// Waits for any in-flight producer goroutine started by a previous NextRecord
+// cycle to finish (via the per-cycle done channel), then swaps the channel/once
+// under cr.mu so concurrent NextRecord receivers do not observe a half-swapped
+// state.
 func (cr *ContentReader) Reset() {
+	cr.mu.Lock()
+	done := cr.done
+	cr.mu.Unlock()
+	if done != nil {
+		<-done
+	}
+	cr.mu.Lock()
 	cr.dataChannel = make(chan map[string]interface{}, utils.MaxBufferSize)
 	cr.once = new(sync.Once)
+	cr.done = nil
+	cr.mu.Unlock()
 }
 
 func removeFile(filePath string) error {
@@ -173,13 +207,15 @@ func (cr *ContentReader) Length() (int, error) {
 
 // Open and read the files one by one. Push each array element into the channel.
 // The channel may block the thread, therefore should run async.
-func (cr *ContentReader) run() {
+// ch is captured at goroutine spawn time so concurrent Reset() does not affect
+// where this producer writes.
+func (cr *ContentReader) run(ch chan<- map[string]interface{}) {
 	for _, filePath := range cr.filesPaths {
-		cr.readSingleFile(filePath)
+		cr.readSingleFile(filePath, ch)
 	}
 }
 
-func (cr *ContentReader) readSingleFile(filePath string) {
+func (cr *ContentReader) readSingleFile(filePath string, ch chan<- map[string]interface{}) {
 	fd, err := os.Open(filePath)
 	if err != nil {
 		log.Error(err.Error())
@@ -213,7 +249,7 @@ func (cr *ContentReader) readSingleFile(filePath string) {
 			cr.errorsQueue.AddError(errorutils.CheckError(err))
 			return
 		}
-		cr.dataChannel <- ResultItem
+		ch <- ResultItem
 	}
 }
 

--- a/utils/io/content/contentreader_test.go
+++ b/utils/io/content/contentreader_test.go
@@ -191,7 +191,7 @@ func closeAndAssert(t *testing.T, reader *ContentReader) {
 func TestContentReaderResetRace(t *testing.T) {
 	tmp, err := os.CreateTemp("", "aql-race-*.json")
 	assert.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	payload := map[string]interface{}{
 		"results": []map[string]string{
 			{"repo": "r1"}, {"repo": "r2"}, {"repo": "r3"},

--- a/utils/io/content/contentreader_test.go
+++ b/utils/io/content/contentreader_test.go
@@ -1,10 +1,12 @@
 package content
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -181,6 +183,42 @@ func (rti ReaderTestItem) GetSortKey() string {
 
 func closeAndAssert(t *testing.T, reader *ContentReader) {
 	assert.NoError(t, reader.Close(), "Couldn't close reader")
+}
+
+// Regression test for "panic: send on closed channel" caused by Reset() racing
+// with an in-flight producer goroutine. Without the fix (local channel snapshot
+// in NextRecord + WaitGroup in Reset), this test panics under -race.
+func TestContentReaderResetRace(t *testing.T) {
+	tmp, err := os.CreateTemp("", "aql-race-*.json")
+	assert.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	payload := map[string]interface{}{
+		"results": []map[string]string{
+			{"repo": "r1"}, {"repo": "r2"}, {"repo": "r3"},
+			{"repo": "r4"}, {"repo": "r5"}, {"repo": "r6"},
+		},
+	}
+	assert.NoError(t, json.NewEncoder(tmp).Encode(payload))
+	assert.NoError(t, tmp.Close())
+
+	cr := NewContentReader(tmp.Name(), "results")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			var rec map[string]interface{}
+			_ = cr.NextRecord(&rec)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			cr.Reset()
+		}
+	}()
+	wg.Wait()
 }
 
 func getErrorAndAssert(t *testing.T, reader *ContentReader) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

## Summary                                                                                                                                                                           
                                                                                                                                                                                     
  Fixes `panic: send on closed channel` in `ContentReader` triggered intermittently by concurrent use of `NextRecord` and `Reset` (or by callers that invoke `Reset` internally, e.g.  
  `Length`, `SortContentReader`).
                                                                                                                                                                                       
  Resolves [RTECO-1263](https://jfrog-int.atlassian.net/browse/RTECO-1263).                                                                                                            
                                      
  ## Background                                                                                                                                                                        
                                                                                                                                                                                     
  `ContentReader.NextRecord` spawns a producer goroutine once (via `sync.Once`) that streams JSON array elements from one or more files into `cr.dataChannel`. The receiver in         
  `NextRecord` and the producer in `readSingleFile` both read `cr.dataChannel` from the struct field on each access.
                                                                                                                                                                                       
  `Reset()` replaces both `cr.dataChannel` and `cr.once` without any synchronization. This created three independent race conditions that together produce the panic:                  
                                      
  1. **Producer / Reset race** — a producer goroutine paused between sends (between files, or while blocked on a full buffer) could resume after `Reset()` had swapped the channel     
  field. The producer's next send would land on the new channel, which could already have been closed by the next cycle's `defer close`.                                             
  2. **Receiver / Reset race** — `NextRecord` could fire `once.Do` against the old `once`, then read `cr.dataChannel` *after* `Reset()` had swapped both fields, causing the receiver  
  and producer to operate on different channels (deadlock).                                                                                                                            
  3. **Defer / send mismatch** — `defer close(cr.dataChannel)` evaluates the channel argument at defer-registration time, but `cr.dataChannel <- item` re-reads the field on every
  send. The defer and the send could refer to two different channels.                                                                                                                  
                                                                                                                                                                                     
  The race is timing-dependent; it surfaces in CI under load (e.g. `TestPushFatManifestImageWithNestedPath` in the docker test suite) but is hard to reproduce locally without `-race` 
  and concurrent stress.                                                                                                                                                             
                                                                                                                                                                                       
  Stack trace from the failing CI run:                                                                                                                                               
                                      
  panic: send on closed channel
  goroutine 2699 [running]:
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).readSingleFile
      .../utils/io/content/contentreader.go:216 +0x492
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).run(...)
      .../utils/io/content/contentreader.go:178
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).NextRecord.func1.1()
      .../utils/io/content/contentreader.go:78 +0x7a