### PR TITLE
Add build-gate orchestrator and convert workflows to reusable

### DIFF
--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+permissions:
+  pull-requests: write
+  contents: read
 jobs:
   gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -1,0 +1,46 @@
+name: Build Gate
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request_target' && 'build-gate' || '' }}
+    steps:
+      - run: echo "Approved — releasing frogbot and test suites."
+
+  frogbot:
+    needs: gate
+    uses: ./.github/workflows/frogbot-scan-pull-request.yml
+    secrets: inherit
+
+  tests:
+    needs: gate
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+
+  # Single, stable required status check. Point branch protection at
+  # "Build Gate / build-gate-success" instead of the matrix-expanded suite checks.
+  build-gate-success:
+    name: build-gate-success
+    if: always()
+    needs:
+      - gate
+      - frogbot
+      - tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no suite failed or was cancelled
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::One or more suites failed or were cancelled."
+            exit 1
+          fi
+          echo "All suites succeeded (skipped suites are allowed)."

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -1,23 +1,17 @@
 name: "Frogbot Scan Pull Request"
 on:
-  pull_request_target:
-    types: [opened, synchronize]
-    branches:
-      - "master"
-
+  workflow_call:
 permissions:
   pull-requests: write
   contents: read
 jobs:
   scan-pull-request:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       matrix:
         os:
           - name: ubuntu
             version: 24.04
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
-    environment: frogbot
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,28 +1,11 @@
 name: JFrog Client Go Tests
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - "master"
-  pull_request_target:
-    types: [labeled]
-
-# Ensures that only the latest commit is running for each PR at a time.
-# Ignores this rule for push events.
-concurrency:
-  group: ${{ github.event.pull_request.number || github.sha }}-tests
-  cancel-in-progress: true
 jobs:
   Pretest:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     steps:
-      - name: Unlabel 'safe to test'
-        if: contains(github.event.pull_request.labels.*.name, 'safe to test')
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: "safe to test"
-
       - name: Checkout code
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Replaces the `safe to test` label gate with a single GitHub Environment deployment
approval (`build-gate`). One maintainer approval per PR now releases both frogbot
and the test suite in a single run.

### Changes
- **`build-gate.yml`** (new) — orchestrator with a `gate` job that requires the
  `build-gate` environment approval on `pull_request_target` runs (push and
  `workflow_dispatch` skip the gate). Frogbot and the test suite fan out behind
  `needs: gate`. A `build-gate-success` aggregator job provides a single stable
  required status check for branch protection.
- **`tests.yml`** — converted to `workflow_call` + `workflow_dispatch`; removed
  `push` and `pull_request_target: [labeled]` triggers; removed `Pretest` label
  condition and the `Unlabel 'safe to test'` step (vet step preserved).
- **`frogbot-scan-pull-request.yml`** — converted to `workflow_call`; removed
  standalone `environment: frogbot` and `dependabot[bot]` skip condition (gate job
  now holds the approval).

### Required follow-up (repo settings)
- Create the `build-gate` GitHub Environment with Required reviewers.
- Repoint required status checks in branch protection to `Build Gate / build-gate-success`.