### PR TITLE
XRAY-132336 - Add get git scan results route api

### DIFF
--- a/tests/xscuiroute_test.go
+++ b/tests/xscuiroute_test.go
@@ -1,0 +1,149 @@
+//go:build itest
+
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/xsc/services"
+	"github.com/jfrog/jfrog-client-go/xsc/services/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	scanResultsUIRouteAPIPath = "/xray/api/v1/xsc/gitinfo/scanResultsUiRoute"
+	testGitRepoURL            = "https://github.com/jfrog/jfrog-client-go.git"
+	testBranchName            = "feature/XRAY-132336-add-git-route-api"
+	testCommitHash            = "abc123def456"
+	testPullRequestId         = 42
+	testScanResultsURL        = "https://example.jfrog.io/ui/scans-list/repositories/1/scan-desc"
+	testRepoId                = int64(101)
+	testBranchId              = int64(202)
+	testScanResultsPath       = "/ui/scans-list/repositories/1/scan-desc"
+)
+
+func TestXscGetScanResultsUIRoute(t *testing.T) {
+	initXscTest(t, "", utils.MinXrayVersionXscTransitionToXray)
+
+	baseGitInfo := func() *services.XscGitInfoContext {
+		return &services.XscGitInfoContext{
+			Source: services.CommitContext{
+				GitRepoHttpsCloneUrl: testGitRepoURL,
+				BranchName:           testBranchName,
+				CommitHash:           testCommitHash,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name         string
+		gitInfo      *services.XscGitInfoContext
+		serverStatus int
+		expectError  bool
+		expectPRId   bool
+	}{
+		{
+			name:         "branch only success",
+			gitInfo:      baseGitInfo(),
+			serverStatus: http.StatusOK,
+			expectError:  false,
+			expectPRId:   false,
+		},
+		{
+			name: "with pull request success",
+			gitInfo: func() *services.XscGitInfoContext {
+				gitInfo := baseGitInfo()
+				gitInfo.PullRequest = &services.PullRequestContext{PullRequestId: testPullRequestId}
+				return gitInfo
+			}(),
+			serverStatus: http.StatusOK,
+			expectError:  false,
+			expectPRId:   true,
+		},
+		{
+			name:         "non-200 response",
+			gitInfo:      baseGitInfo(),
+			serverStatus: http.StatusInternalServerError,
+			expectError:  true,
+			expectPRId:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockServer, routeService := createXscMockServerForScanResultsUIRoute(t, tc.serverStatus, tc.expectPRId)
+			defer mockServer.Close()
+
+			response, err := routeService.GetScanResultsUIRoute(tc.gitInfo)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, response)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, response)
+			assert.Equal(t, testScanResultsURL, response.Url)
+			assert.Equal(t, testRepoId, response.RepoId)
+			assert.Equal(t, testBranchId, response.BranchId)
+			assert.Equal(t, testScanResultsPath, response.Path)
+		})
+	}
+}
+
+func createXscMockServerForScanResultsUIRoute(t *testing.T, statusCode int, expectPRId bool) (mockServer *httptest.Server, routeService *services.ScanResultsRouteService) {
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != scanResultsUIRouteAPIPath || r.Method != http.MethodPost {
+			assert.Fail(t, "received an unexpected request: "+r.Method+" "+r.RequestURI)
+			return
+		}
+
+		var reqBody services.ScanResultsUIRouteRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.NoError(t, err, "Invalid JSON request body")
+		if err != nil {
+			return
+		}
+
+		assert.Equal(t, testGitRepoURL, reqBody.GitInfoUrl)
+		assert.Equal(t, testBranchName, reqBody.BranchName)
+		assert.Equal(t, testCommitHash, reqBody.CommitHash)
+		if expectPRId {
+			assert.Equal(t, int64(testPullRequestId), reqBody.PullRequestId)
+		} else {
+			assert.Zero(t, reqBody.PullRequestId)
+		}
+
+		w.WriteHeader(statusCode)
+		if statusCode != http.StatusOK {
+			_, err = w.Write([]byte(`{"error":"internal server error"}`))
+			assert.NoError(t, err)
+			return
+		}
+
+		response := services.ScanResultsUIRouteResponse{
+			Url:      testScanResultsURL,
+			RepoId:   testRepoId,
+			BranchId: testBranchId,
+			Path:     testScanResultsPath,
+		}
+		err = json.NewEncoder(w).Encode(response)
+		assert.NoError(t, err)
+	}))
+
+	xrayDetails := GetXrayDetails()
+	xrayDetails.SetUrl(mockServer.URL + "/xray")
+	xrayDetails.SetAccessToken("")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	assert.NoError(t, err)
+
+	routeService = services.NewScanResultsRouteService(client)
+	routeService.XrayDetails = xrayDetails
+	return
+}

--- a/tests/xscuiroute_test.go
+++ b/tests/xscuiroute_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/jfrog/jfrog-client-go/xsc/services"
-	"github.com/jfrog/jfrog-client-go/xsc/services/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +27,7 @@ const (
 )
 
 func TestXscGetScanResultsUIRoute(t *testing.T) {
-	initXscTest(t, "", utils.MinXrayVersionXscTransitionToXray)
+	initXscTest(t, "", services.GetUIRouteAPIMinXrayVersion)
 
 	baseGitInfo := func() *services.XscGitInfoContext {
 		return &services.XscGitInfoContext{

--- a/xray/services/xsc/xsc.go
+++ b/xray/services/xsc/xsc.go
@@ -60,6 +60,13 @@ func (xs *XscInnerService) GetAnalyticsGeneralEvent(msi string) (*services.XscAn
 	return eventService.GetGeneralEvent(msi)
 }
 
+func (xs *XscInnerService) GetScanResultsUIRoute(gitInfo *services.XscGitInfoContext) (*services.ScanResultsUIRouteResponse, error) {
+	scanResultsService := services.NewScanResultsRouteService(xs.client)
+	scanResultsService.XrayDetails = xs.XrayDetails
+	scanResultsService.ScopeProjectKey = xs.ScopeProjectKey
+	return scanResultsService.GetScanResultsUIRoute(gitInfo)
+}
+
 func (xs *XscInnerService) GetConfigProfileByName(profileName string) (*services.ConfigProfile, error) {
 	configProfileService := services.NewConfigurationProfileService(xs.client)
 	configProfileService.XrayDetails = xs.XrayDetails

--- a/xsc/manager.go
+++ b/xsc/manager.go
@@ -93,3 +93,9 @@ func (sm *XscServicesManager) SendGitIntegrationEvent(event services.GitIntegrat
 	// Empty implementation required for alignment with interface, implemented only at the new service inside the Xray service
 	return nil
 }
+
+// GetScanResultsUIRoute returns the UI route for the Git context provided scan results.
+func (sm *XscServicesManager) GetScanResultsUIRoute(gitInfo *services.XscGitInfoContext) (*services.ScanResultsUIRouteResponse, error) {
+	// Empty implementation required for alignment with interface, implemented only at the new service inside the Xray service
+	return nil, nil
+}

--- a/xsc/service.go
+++ b/xsc/service.go
@@ -15,6 +15,8 @@ type XscService interface {
 	UpdateAnalyticsGeneralEvent(event services.XscAnalyticsGeneralEventFinalize) error
 	// GetAnalyticsGeneralEvent returns general event that match the msi provided.
 	GetAnalyticsGeneralEvent(msi string) (*services.XscAnalyticsGeneralEvent, error)
+	// GetScanResultsUIRoute returns the UI route for the Git context provided scan results.
+	GetScanResultsUIRoute(gitInfo *services.XscGitInfoContext) (*services.ScanResultsUIRouteResponse, error)
 	// GetConfigProfileByName returns the configuration profile that match the profile name provided.
 	GetConfigProfileByName(profileName string) (*services.ConfigProfile, error)
 	// GetConfigProfileByUrl returns the configuration profile related to the provided repository url.

--- a/xsc/services/uiroute.go
+++ b/xsc/services/uiroute.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	xscutils "github.com/jfrog/jfrog-client-go/xsc/services/utils"
+)
+
+const (
+	scanResultsRouteAPIUrl = "gitinfo/scanResultsUiRoute"
+)
+
+type ScanResultsRouteService struct {
+	client          *jfroghttpclient.JfrogHttpClient
+	XrayDetails     auth.ServiceDetails
+	ScopeProjectKey string
+}
+
+func NewScanResultsRouteService(client *jfroghttpclient.JfrogHttpClient) *ScanResultsRouteService {
+	return &ScanResultsRouteService{client: client}
+}
+
+func (s *ScanResultsRouteService) GetScanResultsUIRoute(gitInfo *XscGitInfoContext) (*ScanResultsUIRouteResponse, error) {
+	httpClientsDetails := s.XrayDetails.CreateHttpClientDetails()
+	httpClientsDetails.SetContentTypeApplicationJson()
+
+	url := s.getScanResultsUIRouteURL()
+	request := ScanResultsUIRouteRequest{
+		GitInfoUrl: gitInfo.Source.GitRepoHttpsCloneUrl,
+		BranchName: gitInfo.Source.BranchName,
+		CommitHash: gitInfo.Source.CommitHash,
+	}
+	if gitInfo.PullRequest != nil {
+		request.PullRequestId = int64(gitInfo.PullRequest.PullRequestId)
+	}
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	resp, body, err := s.client.SendPost(url, requestBody, &httpClientsDetails)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return nil, err
+	}
+	var response ScanResultsUIRouteResponse
+	err = json.Unmarshal(body, &response)
+	return &response, errorutils.CheckError(err)
+}
+
+func (s *ScanResultsRouteService) getScanResultsUIRouteURL() string {
+	return utils.AppendScopedProjectKeyParam(utils.AddTrailingSlashIfNeeded(s.XrayDetails.GetUrl())+xscutils.XscInXraySuffix+scanResultsRouteAPIUrl, s.ScopeProjectKey)
+}
+
+type ScanResultsUIRouteRequest struct {
+	GitInfoUrl    string `json:"git_info_url"`
+	BranchName    string `json:"branch_name,omitempty"`
+	CommitHash    string `json:"commit_hash,omitempty"`
+	PullRequestId int64  `json:"pull_request_id,omitempty"`
+}
+
+type ScanResultsUIRouteResponse struct {
+	Url string `json:"url"`
+	// Metadata
+	RepoId   int64  `json:"repo_id"`
+	BranchId int64  `json:"branch_id"`
+	Path     string `json:"path"`
+}

--- a/xsc/services/uiroute.go
+++ b/xsc/services/uiroute.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	scanResultsRouteAPIUrl      = "gitinfo/scanResultsUiRoute"
-	GetUIRouteAPIMinXrayVersion = "3.76.0"
+	GetUIRouteAPIMinXrayVersion = "3.152.0"
 )
 
 type ScanResultsRouteService struct {

--- a/xsc/services/uiroute.go
+++ b/xsc/services/uiroute.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	scanResultsRouteAPIUrl         = "gitinfo/scanResultsUiRoute"
-	MinXrayVersionForGetUIRouteAPI = "3.76.0"
+	scanResultsRouteAPIUrl      = "gitinfo/scanResultsUiRoute"
+	GetUIRouteAPIMinXrayVersion = "3.76.0"
 )
 
 type ScanResultsRouteService struct {

--- a/xsc/services/uiroute.go
+++ b/xsc/services/uiroute.go
@@ -59,7 +59,7 @@ func (s *ScanResultsRouteService) GetScanResultsUIRoute(gitInfo *XscGitInfoConte
 }
 
 type ScanResultsUIRouteRequest struct {
-	GitInfoUrl    string `json:"git_info_url"`
+	GitInfoUrl    string `json:"git_repo_url"`
 	BranchName    string `json:"branch_name,omitempty"`
 	CommitHash    string `json:"commit_hash,omitempty"`
 	PullRequestId int64  `json:"pull_request_id,omitempty"`

--- a/xsc/services/uiroute.go
+++ b/xsc/services/uiroute.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	scanResultsRouteAPIUrl = "gitinfo/scanResultsUiRoute"
+	scanResultsRouteAPIUrl         = "gitinfo/scanResultsUiRoute"
+	MinXrayVersionForGetUIRouteAPI = "3.76.0"
 )
 
 type ScanResultsRouteService struct {
@@ -25,11 +26,14 @@ func NewScanResultsRouteService(client *jfroghttpclient.JfrogHttpClient) *ScanRe
 	return &ScanResultsRouteService{client: client}
 }
 
+func (s *ScanResultsRouteService) getScanResultsUIRouteURL() string {
+	return utils.AppendScopedProjectKeyParam(utils.AddTrailingSlashIfNeeded(s.XrayDetails.GetUrl())+xscutils.XscInXraySuffix+scanResultsRouteAPIUrl, s.ScopeProjectKey)
+}
+
 func (s *ScanResultsRouteService) GetScanResultsUIRoute(gitInfo *XscGitInfoContext) (*ScanResultsUIRouteResponse, error) {
 	httpClientsDetails := s.XrayDetails.CreateHttpClientDetails()
 	httpClientsDetails.SetContentTypeApplicationJson()
 
-	url := s.getScanResultsUIRouteURL()
 	request := ScanResultsUIRouteRequest{
 		GitInfoUrl: gitInfo.Source.GitRepoHttpsCloneUrl,
 		BranchName: gitInfo.Source.BranchName,
@@ -42,7 +46,7 @@ func (s *ScanResultsRouteService) GetScanResultsUIRoute(gitInfo *XscGitInfoConte
 	if err != nil {
 		return nil, errorutils.CheckError(err)
 	}
-	resp, body, err := s.client.SendPost(url, requestBody, &httpClientsDetails)
+	resp, body, err := s.client.SendPost(s.getScanResultsUIRouteURL(), requestBody, &httpClientsDetails)
 	if err != nil {
 		return nil, errorutils.CheckError(err)
 	}
@@ -52,10 +56,6 @@ func (s *ScanResultsRouteService) GetScanResultsUIRoute(gitInfo *XscGitInfoConte
 	var response ScanResultsUIRouteResponse
 	err = json.Unmarshal(body, &response)
 	return &response, errorutils.CheckError(err)
-}
-
-func (s *ScanResultsRouteService) getScanResultsUIRouteURL() string {
-	return utils.AppendScopedProjectKeyParam(utils.AddTrailingSlashIfNeeded(s.XrayDetails.GetUrl())+xscutils.XscInXraySuffix+scanResultsRouteAPIUrl, s.ScopeProjectKey)
 }
 
 type ScanResultsUIRouteRequest struct {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

## Support fetching Git scan results JPD URL given Git context

Depends on:
* https://jfrog-int.atlassian.net/browse/XRAY-132336
