### PR TITLE
RTECO-1574 - RTECO-1574 - Implementation of Nuget Support for client -

### DIFF
--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -17,6 +17,7 @@ jobs:
           - name: ubuntu
             version: 24.04
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    environment: frogbot
     steps:
       - uses: actions/checkout@v4
         with:

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -115,9 +115,11 @@ type ArtifactoryServicesManager interface {
 	GetPackageLeadFile(leadFileParams services.LeadFileParams) ([]byte, error)
 	UploadTrustedKey(params services.TrustedKeyParams) (*services.TrustedKeyResponse, error)
 	ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error)
+	ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error)
 	SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error)
 	SkillVersionExists(repoKey, slug, version string) (bool, error)
 	SearchSkillsByProperty(query string) ([]services.SkillPropertySearchResult, error)
+	GetSkillXrayStatus(repoKey, artifactPath string) (*services.SkillXrayStatusResponse, error)
 }
 
 // By using this struct, you have the option of overriding only some of the ArtifactoryServicesManager
@@ -534,6 +536,10 @@ func (esm *EmptyArtifactoryServicesManager) ListSkillVersions(string, string) ([
 	panic("Failed: Method is not implemented")
 }
 
+func (esm *EmptyArtifactoryServicesManager) ListSkills(string, int, string, string) ([]services.SkillListItem, string, error) {
+	panic("Failed: Method is not implemented")
+}
+
 func (esm *EmptyArtifactoryServicesManager) SearchSkills(string, string, int) ([]services.SkillSearchResult, error) {
 	panic("Failed: Method is not implemented")
 }
@@ -543,6 +549,10 @@ func (esm *EmptyArtifactoryServicesManager) SkillVersionExists(string, string, s
 }
 
 func (esm *EmptyArtifactoryServicesManager) SearchSkillsByProperty(string) ([]services.SkillPropertySearchResult, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) GetSkillXrayStatus(string, string) (*services.SkillXrayStatusResponse, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -675,6 +675,12 @@ func buildJFrogHttpClient(config config.Config, authDetails auth.ServiceDetails)
 		Build()
 }
 
+func (sm *ArtifactoryServicesManagerImp) ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error) {
+	skillsService := services.NewSkillsService(sm.client)
+	skillsService.ArtDetails = sm.config.GetServiceDetails()
+	return skillsService.ListSkills(repoKey, limit, cursor, sortBy)
+}
+
 func (sm *ArtifactoryServicesManagerImp) ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error) {
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()
@@ -697,4 +703,10 @@ func (sm *ArtifactoryServicesManagerImp) SearchSkillsByProperty(query string) ([
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()
 	return skillsService.SearchByProperty(query)
+}
+
+func (sm *ArtifactoryServicesManagerImp) GetSkillXrayStatus(repoKey, artifactPath string) (*services.SkillXrayStatusResponse, error) {
+	skillsService := services.NewSkillsService(sm.client)
+	skillsService.ArtDetails = sm.config.GetServiceDetails()
+	return skillsService.GetXrayStatus(repoKey, artifactPath)
 }

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/jfrog/jfrog-client-go/auth"
@@ -12,6 +13,25 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
+
+// Xray gate status values returned by the Skills xrayStatus endpoint.
+const (
+	SkillXrayStatusNotInEntitlement = "NOT_IN_ENTITLEMENT"
+	SkillXrayStatusDisabledForRepo  = "XRAY_DISABLED_FOR_REPO"
+	SkillXrayStatusScanInProgress   = "SCAN_IN_PROGRESS"
+	SkillXrayStatusBlocked          = "BLOCKED"
+	SkillXrayStatusApproved         = "APPROVED"
+
+	SkillSortByUpdated   = "updated"
+	SkillSortByDownloads = "downloads"
+)
+
+// SkillXrayStatusResponse is the response from the Skills Xray gate status endpoint.
+type SkillXrayStatusResponse struct {
+	Status  string `json:"status"`
+	RepoKey string `json:"repoKey"`
+	Path    string `json:"path"`
+}
 
 type SkillsService struct {
 	client     *jfroghttpclient.JfrogHttpClient
@@ -40,9 +60,28 @@ func (ss *SkillsService) ListVersions(repoKey, slug string) ([]SkillVersion, err
 	return wrapper.Items, nil
 }
 
+func (ss *SkillsService) ListSkills(repoKey string, limit int, cursor, sortBy string) ([]SkillListItem, string, error) {
+	log.Debug(fmt.Sprintf("Listing skills in repo '%s'...", repoKey))
+	sort := SkillSortByUpdated
+	if sortBy == SkillSortByDownloads {
+		sort = sortBy
+	}
+	endpoint := fmt.Sprintf("skills?limit=%d&cursor=%s&sort=%s", limit, url.QueryEscape(cursor), sort)
+	body, err := ss.sendGet(repoKey, endpoint)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var wrapper skillListResponse
+	if err = json.Unmarshal(body, &wrapper); err != nil {
+		return nil, "", errorutils.CheckErrorf("failed to parse skill list response: %s", err.Error())
+	}
+	return wrapper.Items, wrapper.NextCursor, nil
+}
+
 func (ss *SkillsService) SearchSkills(repoKey, query string, limit int) ([]SkillSearchResult, error) {
 	log.Debug(fmt.Sprintf("Searching skills in repo '%s' with query '%s'...", repoKey, query))
-	body, err := ss.sendGet(repoKey, fmt.Sprintf("search?q=%s&limit=%d", query, limit))
+	body, err := ss.sendGet(repoKey, fmt.Sprintf("search?q=%s&limit=%d", url.QueryEscape(query), limit))
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +161,29 @@ func parsePropSearchURI(uri string) (SkillPropertySearchResult, bool) {
 	}, true
 }
 
+// GetXrayStatus calls the Skills Xray gate endpoint to check the scan status of a skill artifact.
+// This endpoint uses api/skills/{repoKey}/xrayStatus (no /api/v1/ segment).
+func (ss *SkillsService) GetXrayStatus(repoKey, artifactPath string) (*SkillXrayStatusResponse, error) {
+	baseURL := utils.AddTrailingSlashIfNeeded(ss.ArtDetails.GetUrl())
+	requestURL := fmt.Sprintf("%sapi/skills/%s/xrayStatus?path=%s", baseURL, repoKey, url.QueryEscape(artifactPath))
+	log.Debug("Skills Xray status request:", requestURL)
+
+	httpDetails := ss.ArtDetails.CreateHttpClientDetails()
+	resp, body, _, err := ss.client.SendGet(requestURL, true, &httpDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var result SkillXrayStatusResponse
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, errorutils.CheckErrorf("failed to parse xray status response: %s", err.Error())
+	}
+	return &result, nil
+}
+
 func (ss *SkillsService) sendGet(repoKey, endpoint string) ([]byte, error) {
 	baseURL := utils.AddTrailingSlashIfNeeded(ss.ArtDetails.GetUrl())
 	url := fmt.Sprintf("%sapi/skills/%s/api/v1/%s", baseURL, repoKey, endpoint)
@@ -156,6 +218,21 @@ type SkillPropertySearchResult struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	URI     string `json:"uri"`
+}
+
+type SkillListItem struct {
+	Slug          string        `json:"slug"`
+	DisplayName   string        `json:"displayName,omitempty"`
+	Summary       string        `json:"summary,omitempty"`
+	LatestVersion *SkillVersion `json:"latestVersion,omitempty"`
+	Versions      int           `json:"versions,omitempty"`
+	Updated       string        `json:"updated,omitempty"`
+}
+
+type skillListResponse struct {
+	Items      []SkillListItem `json:"items"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+	Total      int             `json:"total,omitempty"`
 }
 
 type skillVersionsResponse struct {

--- a/artifactory/services/utils/aqlquerybuilder.go
+++ b/artifactory/services/utils/aqlquerybuilder.go
@@ -14,6 +14,10 @@ import (
 
 const spaceEncoding = "%20"
 
+// errTransitiveMultiRepoMsg is shared by both pattern-based and build-with-pattern AQL
+// builders so the validation and its error text stay in lockstep.
+const errTransitiveMultiRepoMsg = "when searching or downloading with the transitive setting, the pattern must include a single repository only, meaning wildcards are allowed only after the first slash"
+
 var specialAqlCharacters = map[rune]string{
 	'/':  "%2F",
 	'\\': "%5C",
@@ -34,7 +38,7 @@ func CreateAqlBodyForSpecWithPattern(params *CommonParams) (string, error) {
 		return "", err
 	}
 	if params.Transitive && !singleRepo {
-		return "", errorutils.CheckErrorf("when searching or downloading with the transitive setting, the pattern must include a single repository only, meaning wildcards are allowed only after the first slash.")
+		return "", errorutils.CheckErrorf(errTransitiveMultiRepoMsg)
 	}
 	includeRoot := strings.Count(searchPattern, "/") < 2
 	triplesSize := len(repoPathFileTriples)
@@ -108,54 +112,98 @@ func handleArchiveSearch(triple RepoPathFile, archivePathFilePairs []RepoPathFil
 	return query
 }
 
+// createAqlBodyForBuildArtifacts builds the AQL body for build artifacts with no pattern or
+// exclusions. Safe wrapper: the underlying function only errors on user-supplied input, which
+// is nil here.
 func createAqlBodyForBuildArtifacts(builds []Build) string {
-	return createAqlBodyForBuildArtifactsWithExclusions(builds, nil)
+	body, _ := createAqlBodyForBuildArtifactsWithExclusions(builds, nil)
+	return body
 }
 
-// createAqlBodyForBuildArtifactsWithExclusions creates an AQL body for build artifacts with optional exclusions.
-func createAqlBodyForBuildArtifactsWithExclusions(builds []Build, params *CommonParams) string {
-	buildArtifactsItem := `{"$and":[{"artifact.module.build.name":"%s","artifact.module.build.number":"%s"}]}`
-	var items []string
-	for _, build := range builds {
-		items = append(items, fmt.Sprintf(buildArtifactsItem, build.BuildName, build.BuildNumber))
+// createAqlBodyForBuildArtifactsWithExclusions builds the AQL body for build artifacts.
+// When a non-trivial pattern is supplied, its repo/path/name triples are included in the AQL
+// so Artifactory performs the match server-side; this preserves virtual-repo resolution that
+// a client-side string compare on the result's Repo cannot do.
+func createAqlBodyForBuildArtifactsWithExclusions(builds []Build, params *CommonParams) (string, error) {
+	items := buildClauseItems(builds, "artifact")
+	buildOr := fmt.Sprintf(`"$or":[%s]`, strings.Join(items, ","))
+
+	excludeQuery, err := maybeBuildExcludeQuery(params)
+	if err != nil {
+		return "", err
 	}
 
-	// Build the exclusion query if params with exclusions are provided
-	excludeQuery := ""
-	if params != nil && len(params.GetExclusions()) > 0 {
-		var err error
-		excludeQuery, err = buildExcludeQueryPart(params, true, params.Recursive)
-		if err != nil {
-			excludeQuery = ""
-		}
+	patternOr, err := buildPatternFilterForBuildArtifacts(params)
+	if err != nil {
+		return "", err
 	}
-
-	return `{` + excludeQuery + `"$or":[` + strings.Join(items, ",") + "]}"
+	if patternOr != "" {
+		return fmt.Sprintf(`{%s"$and":[{%s},{%s}]}`, excludeQuery, buildOr, patternOr), nil
+	}
+	return fmt.Sprintf(`{%s%s}`, excludeQuery, buildOr), nil
 }
 
+// buildPatternFilterForBuildArtifacts returns an AQL "$or" clause matching the pattern's
+// repo/path/name triples, or an empty string when no non-trivial pattern is supplied. Callers
+// compose it with the build-name/build-number filter under "$and".
+func buildPatternFilterForBuildArtifacts(params *CommonParams) (string, error) {
+	if params == nil || params.Pattern == "" || params.Pattern == "*" {
+		return "", nil
+	}
+	searchPattern := prepareSourceSearchPattern(params.Pattern, params.Target)
+	triples, singleRepo, err := createRepoPathFileTriples(searchPattern, params.Recursive)
+	if err != nil {
+		return "", err
+	}
+	if params.Transitive && !singleRepo {
+		return "", errorutils.CheckErrorf(errTransitiveMultiRepoMsg)
+	}
+	if len(triples) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf(`"$or":[%s]`, handleRepoPathFileTriples(triples, nil, len(triples))), nil
+}
+
+// createAqlBodyForBuildDependencies builds the AQL body for build dependencies with no
+// exclusions. Safe wrapper: the underlying function only errors on user-supplied exclusions,
+// which are nil here.
 func createAqlBodyForBuildDependencies(builds []Build) string {
-	return createAqlBodyForBuildDependenciesWithExclusions(builds, nil)
+	body, _ := createAqlBodyForBuildDependenciesWithExclusions(builds, nil)
+	return body
 }
 
-// createAqlBodyForBuildDependenciesWithExclusions creates an AQL body for build dependencies with optional exclusions.
-func createAqlBodyForBuildDependenciesWithExclusions(builds []Build, params *CommonParams) string {
-	buildDependenciesItem := `{"$and":[{"dependency.module.build.name":"%s","dependency.module.build.number":"%s"}]}`
-	var items []string
-	for _, build := range builds {
-		items = append(items, fmt.Sprintf(buildDependenciesItem, build.BuildName, build.BuildNumber))
+// createAqlBodyForBuildDependenciesWithExclusions builds the AQL body for build dependencies.
+// Matches the error-propagation behavior of its artifact-side sibling so malformed exclusions
+// surface consistently on both paths.
+func createAqlBodyForBuildDependenciesWithExclusions(builds []Build, params *CommonParams) (string, error) {
+	items := buildClauseItems(builds, "dependency")
+	excludeQuery, err := maybeBuildExcludeQuery(params)
+	if err != nil {
+		return "", err
 	}
+	return fmt.Sprintf(`{%s"$or":[%s]}`, excludeQuery, strings.Join(items, ",")), nil
+}
 
-	// Build the exclusion query if params with exclusions are provided
-	excludeQuery := ""
-	if params != nil && len(params.GetExclusions()) > 0 {
-		var err error
-		excludeQuery, err = buildExcludeQueryPart(params, true, params.Recursive)
-		if err != nil {
-			excludeQuery = ""
-		}
+// buildClauseItems returns the per-build AQL clauses used inside the outer "$or". kind is
+// either "artifact" or "dependency" and selects the AQL domain prefix.
+func buildClauseItems(builds []Build, kind string) []string {
+	items := make([]string, 0, len(builds))
+	for _, b := range builds {
+		items = append(items, fmt.Sprintf(
+			`{"$and":[{"%s.module.build.name":"%s","%s.module.build.number":"%s"}]}`,
+			kind, b.BuildName, kind, b.BuildNumber,
+		))
 	}
+	return items
+}
 
-	return `{` + excludeQuery + `"$or":[` + strings.Join(items, ",") + "]}"
+// maybeBuildExcludeQuery returns the exclusion AQL fragment for params (with trailing comma,
+// as consumed by callers) or an empty string when there are no exclusions. params may be nil.
+func maybeBuildExcludeQuery(params *CommonParams) (string, error) {
+	if params == nil || len(params.GetExclusions()) == 0 {
+		return "", nil
+	}
+	return buildExcludeQueryPart(params, true, params.Recursive)
 }
 
 func createAqlQueryForBuild(includeQueryPart string, artifactsQuery bool, builds []Build) string {

--- a/artifactory/services/utils/aqlquerybuilder_test.go
+++ b/artifactory/services/utils/aqlquerybuilder_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -295,7 +296,8 @@ func TestCreateAqlBodyForBuildArtifactsWithExclusions(t *testing.T) {
 		Exclusions: []string{"*.json"},
 		Recursive:  true,
 	}
-	aqlBodyWithExclusions := createAqlBodyForBuildArtifactsWithExclusions(builds, params)
+	aqlBodyWithExclusions, err := createAqlBodyForBuildArtifactsWithExclusions(builds, params)
+	assert.NoError(t, err)
 
 	assert.Contains(t, aqlBodyWithExclusions, `"$nmatch"`, "FIX VERIFIED: createAqlBodyForBuildArtifactsWithExclusions includes exclusions")
 	assert.Contains(t, aqlBodyWithExclusions, `*.json`)
@@ -313,11 +315,243 @@ func TestCreateAqlBodyForBuildDependenciesWithExclusions(t *testing.T) {
 		Exclusions: []string{"*.xml", "test-*"},
 		Recursive:  true,
 	}
-	aqlBody := createAqlBodyForBuildDependenciesWithExclusions(builds, params)
+	aqlBody, err := createAqlBodyForBuildDependenciesWithExclusions(builds, params)
+	assert.NoError(t, err)
 
 	assert.Contains(t, aqlBody, `"$nmatch"`)
 	assert.Contains(t, aqlBody, `*.xml`)
 	assert.Contains(t, aqlBody, `test-*`)
 	assert.Contains(t, aqlBody, `dependency.module.build.name`)
 	assert.Contains(t, aqlBody, `dependency.module.build.number`)
+}
+
+func TestGetSpecType_BuildWithPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   CommonParams
+		expected SpecType
+	}{
+		{
+			name:     "build only routes to BUILD",
+			params:   CommonParams{Build: "my-build/1"},
+			expected: BUILD,
+		},
+		{
+			name:     "build with empty pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Pattern: ""},
+			expected: BUILD,
+		},
+		{
+			name:     "build with wildcard-all pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "*"},
+			expected: BUILD,
+		},
+		{
+			name:     "build with specific pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "docker-local-ash/*"},
+			expected: BUILD,
+		},
+		{
+			name:     "build with repo path pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "repo-local/path/to/*.jar"},
+			expected: BUILD,
+		},
+		{
+			name:     "pattern only routes to WILDCARD",
+			params:   CommonParams{Pattern: "repo-local/*"},
+			expected: WILDCARD,
+		},
+		{
+			name:     "aql routes to AQL",
+			params:   CommonParams{Aql: Aql{ItemsFind: `{"repo":"test"}`}},
+			expected: AQL,
+		},
+		{
+			name:     "aql with build routes to AQL (AQL takes precedence)",
+			params:   CommonParams{Aql: Aql{ItemsFind: `{"repo":"test"}`}, Build: "my-build/1"},
+			expected: AQL,
+		},
+		{
+			name:     "build with IncludeDeps and pattern routes to WILDCARD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "repo-local/*", IncludeDeps: true},
+			expected: WILDCARD,
+		},
+		{
+			name:     "build with IncludeDeps and no pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", IncludeDeps: true},
+			expected: BUILD,
+		},
+		{
+			name:     "build with IncludeDeps and wildcard pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "*", IncludeDeps: true},
+			expected: BUILD,
+		},
+		{
+			name:     "build with ExcludeArtifacts but no IncludeDeps routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", ExcludeArtifacts: true},
+			expected: BUILD,
+		},
+		{
+			name:     "build with pattern and props routes to WILDCARD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "repo-local/*", Props: "key=value"},
+			expected: WILDCARD,
+		},
+		{
+			name:     "build with pattern and excludeProps routes to WILDCARD",
+			params:   CommonParams{Build: "my-build/1", Pattern: "repo-local/*", ExcludeProps: "key=value"},
+			expected: WILDCARD,
+		},
+		{
+			name:     "build with props but no pattern routes to BUILD",
+			params:   CommonParams{Build: "my-build/1", Props: "key=value"},
+			expected: BUILD,
+		},
+		{
+			name:     "empty params routes to WILDCARD",
+			params:   CommonParams{},
+			expected: WILDCARD,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.params.GetSpecType()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreateAqlBodyForBuildArtifactsWithPattern(t *testing.T) {
+	builds := []Build{{BuildName: "my-build", BuildNumber: "1"}}
+
+	t.Run("no pattern: build-only filter, no $and wrapping", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.NotContains(t, body, `"$and":[{"$or"`)
+	})
+
+	t.Run("trivial '*' pattern: treated as no pattern", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{Pattern: "*"})
+		assert.NoError(t, err)
+		assert.NotContains(t, body, `"$and":[{"$or"`)
+	})
+
+	t.Run("pattern with virtual repo: server-side match via AQL", func(t *testing.T) {
+		// A client-side string compare on `Repo` cannot translate virtual → backing local,
+		// but AQL can. The pattern must go into the query itself.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "some-virtual-repo/com/jfrog/*/my-artifact-*.tgz",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.Contains(t, body, `"repo":"some-virtual-repo"`)
+		assert.Contains(t, body, `"$and":[{"$or"`, "build and pattern filters should be ANDed together")
+	})
+
+	t.Run("invalid pattern surfaces as error", func(t *testing.T) {
+		// Pattern starting with '/' is invalid — must start with a repo name or asterisk.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "/leading-slash-is-invalid",
+			Recursive: true,
+		})
+		assert.Error(t, err, "invalid patterns must not be silently swallowed")
+	})
+
+	t.Run("transitive + multi-repo pattern is rejected", func(t *testing.T) {
+		// Wildcards before the first slash expand to multiple repos, which transitive mode forbids.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "repo-*/com/jfrog/*.tgz",
+			Recursive:  true,
+			Transitive: true,
+		})
+		assert.Error(t, err, "transitive search with multi-repo wildcards must be rejected")
+		assert.Contains(t, err.Error(), "transitive", "error should mention transitive")
+	})
+
+	t.Run("transitive + single-repo pattern is accepted", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "one-repo/com/jfrog/*.tgz",
+			Recursive:  true,
+			Transitive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"repo":"one-repo"`)
+	})
+
+	t.Run("exclusions + pattern: both appear in AQL", func(t *testing.T) {
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "some-repo/com/jfrog/*.jar",
+			Recursive:  true,
+			Exclusions: []string{"*test*.jar"},
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"$and":[{"$or"`, "pattern is still present under $and")
+		assert.Contains(t, body, `"$nmatch"`, "exclusion should produce $nmatch filter")
+		assert.Contains(t, body, `"repo":"some-repo"`)
+	})
+
+	t.Run("multi-triple pattern expands into $or", func(t *testing.T) {
+		// A recursive pattern with a wildcard mid-path produces multiple triples; each
+		// triple carries its own "repo" literal, so the count signals fan-out.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "some-repo/com/jfrog/*/files/*-linux-amd64.tgz",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, strings.Count(body, `"repo":"some-repo"`), 2, "recursive pattern should produce multiple triples")
+	})
+
+	t.Run("aggregated builds + pattern: all builds ANDed with pattern", func(t *testing.T) {
+		aggregated := []Build{
+			{BuildName: "my-build", BuildNumber: "1"},
+			{BuildName: "my-build", BuildNumber: "2"},
+			{BuildName: "upstream-build", BuildNumber: "5"},
+		}
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(aggregated, &CommonParams{
+			Pattern:   "some-repo/com/jfrog/*.jar",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build","artifact.module.build.number":"1"`)
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build","artifact.module.build.number":"2"`)
+		assert.Contains(t, body, `"artifact.module.build.name":"upstream-build","artifact.module.build.number":"5"`)
+		assert.Contains(t, body, `"$and":[{"$or"`, "aggregated build list must be ANDed with pattern, not replaced")
+	})
+
+	t.Run("'*/path' pattern: repo wildcard not emitted as repo filter", func(t *testing.T) {
+		// buildInnerQueryPart skips the repo condition when the triple's repo is '*' or '**',
+		// so users writing '*/path/...' as a workaround don't get a literal `"repo":"*"` emitted.
+		body, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:   "*/com/jfrog/foo/*.tgz",
+			Recursive: true,
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, body, `"$and":[{"$or"`, "pattern should still be present")
+		assert.NotContains(t, body, `"repo":"*"`, "repo='*' must not be emitted as an AQL filter")
+	})
+
+	t.Run("nil-params wrapper: returns valid JSON with no pattern or exclusions", func(t *testing.T) {
+		// The wrapper at createAqlBodyForBuildArtifacts calls the underlying function with
+		// nil params and swallows the error; verify its output is a well-formed JSON body
+		// containing only the build filter.
+		body := createAqlBodyForBuildArtifacts(builds)
+		var parsed map[string]any
+		assert.NoError(t, json.Unmarshal([]byte(body), &parsed), "body must be valid JSON")
+		assert.Contains(t, body, `"artifact.module.build.name":"my-build"`)
+		assert.NotContains(t, body, `"$and":[{"$or"`, "no pattern → no $and wrapping")
+		assert.NotContains(t, body, `"$nmatch"`, "no exclusions → no $nmatch")
+	})
+
+	t.Run("malformed exclusion propagates as error", func(t *testing.T) {
+		// Guards the behavior change introduced by this fix: a malformed exclusion pattern
+		// used to silently produce a build-only AQL (exclusion dropped); now it aborts.
+		_, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &CommonParams{
+			Pattern:    "some-repo/*",
+			Recursive:  true,
+			Exclusions: []string{"/leading-slash-is-invalid"},
+		})
+		assert.Error(t, err, "malformed exclusion must propagate, not be silently swallowed")
+	})
 }

--- a/artifactory/services/utils/searchutil.go
+++ b/artifactory/services/utils/searchutil.go
@@ -35,6 +35,9 @@ const (
 
 // Use this function when searching by build without pattern or aql.
 // Collect build artifacts and build dependencies separately, then merge the results into one reader.
+// If a pattern is also specified, the pattern is applied server-side via AQL inside
+// getBuildArtifactsUsingAql → createAqlBodyForBuildArtifactsWithExclusions. This preserves
+// virtual-repo resolution (AQL translates virtual repo names to their backing locals).
 func SearchBySpecWithBuild(specFile *CommonParams, flags CommonConf) (readerContent *content.ContentReader, err error) {
 	log.Info("Searching items related to a build...")
 	buildName, buildNumber, err := GetBuildNameAndNumberFromBuildIdentifier(specFile.Build, specFile.Project, flags)
@@ -96,7 +99,11 @@ func SearchBySpecWithBuild(specFile *CommonParams, flags CommonConf) (readerCont
 }
 
 func getBuildDependenciesForBuildSearch(specFile CommonParams, flags CommonConf, builds []Build) (*content.ContentReader, error) {
-	specFile.Aql = Aql{ItemsFind: createAqlBodyForBuildDependenciesWithExclusions(builds, &specFile)}
+	aqlBody, err := createAqlBodyForBuildDependenciesWithExclusions(builds, &specFile)
+	if err != nil {
+		return nil, err
+	}
+	specFile.Aql = Aql{ItemsFind: aqlBody}
 	executionQuery := BuildQueryFromSpecFile(&specFile, ALL)
 	return aqlSearch(executionQuery, flags)
 }
@@ -105,6 +112,12 @@ func getBuildArtifactsForBuildSearch(specFile CommonParams, flags CommonConf, bu
 	// When sort or limit is specified, fall back to AQL since the API doesn't support these flags.
 	if !includePropertiesInAqlForSpec(&specFile) {
 		log.Debug("Sort/limit specified, using AQL for build artifacts search")
+		return getBuildArtifactsUsingAql(specFile, flags, builds)
+	}
+
+	// When a specific pattern is provided alongside the build, use AQL directly
+	if specFile.Pattern != "" && specFile.Pattern != "*" {
+		log.Debug("Pattern specified with build, using AQL for build artifacts search")
 		return getBuildArtifactsUsingAql(specFile, flags, builds)
 	}
 
@@ -122,7 +135,11 @@ func getBuildArtifactsForBuildSearch(specFile CommonParams, flags CommonConf, bu
 }
 
 func getBuildArtifactsUsingAql(specFile CommonParams, flags CommonConf, builds []Build) (*content.ContentReader, error) {
-	specFile.Aql = Aql{ItemsFind: createAqlBodyForBuildArtifactsWithExclusions(builds, &specFile)}
+	aqlBody, err := createAqlBodyForBuildArtifactsWithExclusions(builds, &specFile)
+	if err != nil {
+		return nil, err
+	}
+	specFile.Aql = Aql{ItemsFind: aqlBody}
 	executionQuery := BuildQueryFromSpecFile(&specFile, ALL)
 	return aqlSearch(executionQuery, flags)
 }

--- a/artifactory/services/utils/specutils.go
+++ b/artifactory/services/utils/specutils.go
@@ -156,8 +156,18 @@ func (aql *Aql) UnmarshalJSON(value []byte) error {
 }
 
 func (params CommonParams) GetSpecType() (specType SpecType) {
+	hasNonTrivialPattern := params.Pattern != "" && params.Pattern != "*"
+	// When a non-trivial pattern is combined with features that the BUILD path's AQL
+	// does not support, fall through to WILDCARD which handles them correctly:
+	//   - IncludeDeps: local deps (added from filesystem) need SHA1-based post-filtering.
+	//   - Props/ExcludeProps: the BUILD path's AQL does not include property filters.
+	patternRequiresWildcard := hasNonTrivialPattern && (params.IncludeDeps || params.Props != "" || params.ExcludeProps != "")
 	switch {
-	case params.Build != "" && params.Aql.ItemsFind == "" && (params.Pattern == "*" || params.Pattern == ""):
+	case params.Build != "" && params.Aql.ItemsFind == "" && !patternRequiresWildcard:
+		// When a build is specified, use the BUILD path. The BUILD path uses the
+		// dedicated build-artifacts API (fast, no AQL JOINs) and handles aggregated
+		// builds. If a pattern is also specified, results are post-filtered by the
+		// pattern in SearchBySpecWithBuild.
 		specType = BUILD
 	case params.Aql.ItemsFind != "":
 		specType = AQL

--- a/utils/io/content/contentreader.go
+++ b/utils/io/content/contentreader.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jfrog/gofrog/http/retryexecutor"
 	"github.com/jfrog/jfrog-client-go/utils"
@@ -33,6 +34,11 @@ type ContentReader struct {
 	dataChannel chan map[string]interface{}
 	errorsQueue *utils.ErrorsQueue
 	once        *sync.Once
+	// producerStarted indicates whether the goroutine spawned inside
+	// NextRecord (via once.Do) was ever started. Reset() uses this to
+	// know whether it must drain dataChannel and wait for the goroutine
+	// to exit before swapping in a fresh channel.
+	producerStarted atomic.Bool
 	// Number of elements in the array (cache)
 	length int
 	empty  bool
@@ -72,6 +78,7 @@ func (cr *ContentReader) NextRecord(recordOutput interface{}) error {
 		return errorutils.CheckErrorf("Empty")
 	}
 	cr.once.Do(func() {
+		cr.producerStarted.Store(true)
 		go func() {
 			defer close(cr.dataChannel)
 			cr.length = 0
@@ -93,9 +100,23 @@ func (cr *ContentReader) NextRecord(recordOutput interface{}) error {
 }
 
 // Prepare the reader to read the file all over again (not thread-safe).
+//
+// If a producer goroutine was previously started by NextRecord and has not
+// yet finished, Reset drains dataChannel until the producer closes it. This
+// is required because the producer dereferences cr.dataChannel on every send
+// (contentreader.go readSingleFile loop), so if Reset swapped the channel out
+// while the producer was still alive, the producer would switch to the new
+// channel mid-flight and eventually close it — racing a fresh producer
+// goroutine spawned by the next NextRecord call and causing
+// "send on closed channel" / "close of closed channel" panics.
 func (cr *ContentReader) Reset() {
+	if cr.producerStarted.Load() {
+		for range cr.dataChannel {
+		}
+	}
 	cr.dataChannel = make(chan map[string]interface{}, utils.MaxBufferSize)
 	cr.once = new(sync.Once)
+	cr.producerStarted.Store(false)
 }
 
 func removeFile(filePath string) error {

--- a/utils/io/content/contentreader_race_repro_test.go
+++ b/utils/io/content/contentreader_race_repro_test.go
@@ -1,0 +1,108 @@
+package content
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestPeekResetRaceReproduction reproduces the production panic:
+//
+//	panic: send on closed channel
+//	  contentreader.go:216 (cr.dataChannel <- ResultItem)
+//	  contentreader.go:178 (run -> readSingleFile)
+//	  contentreader.go:78  (NextRecord.func1.1 -> run)
+//	  contentreader.go:75  (NextRecord.func1   -> go func)
+//
+// The pattern that triggers it (used in
+// artifactory/services/utils/searchutil.go:filterBuildArtifactsAndDependencies):
+//
+//  1. NextRecord(item)        // peeks one record; spawns producer G1 via sync.Once
+//  2. reader.Reset()           // swaps cr.dataChannel and cr.once *without* waiting for G1
+//  3. NextRecord(item) ...     // spawns producer G2 (new sync.Once); G1 and G2 now share C2,
+//                              // and whichever finishes first closes C2 while the other sends.
+//
+// Run with: go test -race -run TestPeekResetRaceReproduction ./utils/io/content/
+func TestPeekResetRaceReproduction(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "records.json")
+
+	// Write enough records that the producer goroutine is still actively
+	// pumping when the test calls Reset()/NextRecord() again. We stay under
+	// MaxBufferSize so the producer never blocks (blocking the producer would
+	// just leak the goroutine instead of triggering the panic).
+	const records = 20000
+	if err := writeRecordsFile(filePath, records); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Trigger the race repeatedly. The exact ordering of G1/G2 finishing is
+	// timing-dependent, so one attempt isn't always enough on a fast machine;
+	// looping makes the panic deterministic in practice.
+	for attempt := 0; attempt < 50; attempt++ {
+		reader := NewContentReader(filePath, DefaultKey)
+
+		// Step 1: peek (mimics filterBuildArtifactsAndDependencies).
+		var peeked map[string]interface{}
+		if err := reader.NextRecord(&peeked); err != nil {
+			t.Fatalf("attempt %d: peek: %v", attempt, err)
+		}
+
+		// Step 2: Reset() while producer G1 is almost certainly still running.
+		reader.Reset()
+
+		// Step 3: drive a second consumer pass; this spawns G2 because Reset()
+		// installed a fresh sync.Once. Now G1 and G2 race over the same channel.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := new(map[string]interface{}); ; item = new(map[string]interface{}) {
+				if err := reader.NextRecord(item); err != nil {
+					if err == io.EOF {
+						return
+					}
+					return
+				}
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+func writeRecordsFile(path string, n int) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(`{"results":[`); err != nil {
+		return err
+	}
+	enc := json.NewEncoder(f)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			if _, err := f.WriteString(","); err != nil {
+				return err
+			}
+		}
+		if err := enc.Encode(map[string]any{
+			"repo":        "some-virtual-repo",
+			"path":        "org/example",
+			"name":        "artifact.jar",
+			"actual_sha1": "0123456789abcdef0123456789abcdef01234567",
+			"size":        1234,
+			"index":       i,
+		}); err != nil {
+			return err
+		}
+	}
+	if _, err := f.WriteString(`]}`); err != nil {
+		return err
+	}
+	return nil
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -85,6 +85,25 @@ func ValidateMinimumVersion(product MinVersionProduct, currentVersion, minimumVe
 	return nil
 }
 
+// hasRegexPattern checks if a path section contains actual regex patterns.
+// It distinguishes between literal dots in filenames (e.g., "my.folder", "file.txt")
+// and regex metacharacters/patterns (e.g., ".*", ".+", "[0-9]", "(group)").
+// Returns true if the section appears to contain regex syntax.
+func hasRegexPattern(section string) bool {
+	// Check for regex quantifiers and patterns
+	if strings.ContainsAny(section, `*+?[{(|`) {
+		return true
+	}
+
+	// Check for escaped characters (backslash indicates regex mode)
+	// e.g., "file\.txt", "\d+", "\w*"
+	if strings.Contains(section, `\`) {
+		return true
+	}
+
+	return false
+}
+
 // Get the local root path, from which to start collecting artifacts to be used for:
 // 1. Uploaded to Artifactory,
 // 2. Adding to the local build-info, to be later published to Artifactory.
@@ -108,7 +127,10 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 			continue
 		}
 		if patternType == RegExp {
-			if strings.Contains(section, "(") {
+			// Break when we encounter actual regex patterns, not just any dot.
+			// A literal dot in a directory/file name (e.g., "my.folder", "file.txt") is valid.
+			// We only break on regex constructs like ".*", ".+", "[...]", "(..)", etc.
+			if hasRegexPattern(section) {
 				break
 			}
 		} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -263,6 +263,46 @@ func TestReplacePlaceHolders(t *testing.T) {
 	}
 }
 
+func TestGetRootPath(t *testing.T) {
+	emptyParentheses := NewParenthesesSlice([]Parentheses{})
+	tests := []struct {
+		name        string
+		path        string
+		patternType PatternType
+		expected    string
+	}{
+		// RegExp without capture groups: the fix — root path must stop before regex metacharacters
+		{"regexp dot-star", "dir/.*\\.txt", RegExp, "dir"},
+		{"regexp dot-star no extension", "dir/.*", RegExp, "dir"},
+		{"regexp char class", "dir/[0-9]+/file", RegExp, "dir"},
+		{"regexp plus quantifier", "dir/prefix.+suffix", RegExp, "dir"},
+		{"regexp question mark", "dir/colou?r", RegExp, "dir"},
+		{"regexp alternation pipe", "dir/foo|bar", RegExp, "dir"},
+		{"regexp backslash escape", "dir/file\\.txt", RegExp, "dir"},
+		{"regexp nested dirs no metachar", "a/b/c", RegExp, "a/b/c"},
+		{"regexp starts with metachar", ".*\\.txt", RegExp, "."},
+		{"regexp multi-level prefix", "a/b/c/.*", RegExp, "a/b/c"},
+		// Literal dots in directory/file names should NOT trigger regex detection
+		{"regexp literal dot in dirname", "/tmp/jfrog.cli.temp.-1775042212-1894730057/(.*)", RegExp, "/tmp/jfrog.cli.temp.-1775042212-1894730057"},
+		{"regexp literal dots in filename", "my.folder/file.txt/(.*)", RegExp, "my.folder/file.txt"},
+		{"regexp multiple literal dots", "archive.tar.gz.backup/.*", RegExp, "archive.tar.gz.backup"},
+		{"regexp dots with numbers", "dir.1.2.3/test.file/(.*)", RegExp, "dir.1.2.3/test.file"},
+		// RegExp with capture groups: existing behaviour preserved
+		{"regexp with capture group", "dir/(.*)/file", RegExp, "dir"},
+		{"regexp capture at root", "(.*)/file", RegExp, "."},
+		// Wildcard: existing behaviour unchanged
+		{"wildcard star", "dir/*/file.txt", WildCardPattern, "dir"},
+		{"wildcard multi-level", "a/b/*/c", WildCardPattern, "a/b"},
+		{"wildcard no star", "a/b/c", WildCardPattern, "a/b/c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetRootPath(tt.path, tt.patternType, emptyParentheses)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestValidateMinimumVersion(t *testing.T) {
 	minTestVersion := "6.9.0"
 	tests := []struct {

--- a/xray/services/utils/policybody.go
+++ b/xray/services/utils/policybody.go
@@ -16,6 +16,8 @@ const (
 	Pending     Severity = "Pending"
 	Information Severity = "Information"
 	Unknown     Severity = "Unknown"
+	// ScannedNoIssues indicates the target was scanned and no issues were found (Xray server severity value).
+	ScannedNoIssues Severity = "Scanned - No Issues"
 )
 
 type PolicyType string

--- a/xsc/services/analytics.go
+++ b/xsc/services/analytics.go
@@ -209,11 +209,17 @@ type XscAnalyticsGeneralEvent struct {
 }
 
 type XscGitInfoContext struct {
-	Source       CommitContext       `json:"source"`
+	GitDiffContext
+	Source       CommitContext `json:"source"`
+	GitProvider  string        `json:"git_provider,omitempty"`
+	Technologies []string      `json:"technologies,omitempty"`
+}
+
+// Optional fields for git diff context
+type GitDiffContext struct {
 	Target       *CommitContext      `json:"target,omitempty"`
 	PullRequest  *PullRequestContext `json:"pull_request,omitempty"`
-	GitProvider  string              `json:"git_provider,omitempty"`
-	Technologies []string            `json:"technologies,omitempty"`
+	ChangedFiles []string            `json:"-"`
 }
 
 type CommitContext struct {

--- a/xsc/services/profile.go
+++ b/xsc/services/profile.go
@@ -85,9 +85,10 @@ type CaScannerConfig struct {
 }
 
 type SastScannerConfig struct {
-	EnableSastScan  bool     `json:"enable_sast_scan,omitempty"`
-	ExcludePatterns []string `json:"exclude_patterns,omitempty"`
-	ExcludeRules    []string `json:"exclude_rules,omitempty"`
+	EnableSastScan     bool     `json:"enable_sast_scan,omitempty"`
+	EnableFastDiffMode bool     `json:"enable_differential_scanning,omitempty"`
+	ExcludePatterns    []string `json:"exclude_patterns,omitempty"`
+	ExcludeRules       []string `json:"exclude_rules,omitempty"`
 }
 
 type SecretsScannerConfig struct {


### PR DESCRIPTION
Generated by workbench RTECO-1574.

## RTECO-1574 - Implementation of Nuget Support for client -

**Source:** https://jfrog-int.atlassian.net/browse/RTECO-1574
- Start working on Nuget V2, V3 support for Nuget package manager in jfrog cli. 
- Make sure PRs are manageable and code is written in a way it can be reused across the clients 
- Add support for nugetV3 and nugetV2
- refer to [unsupported block: inlineCard]
## Things to consider while implementing
- Use JFROG_CLI_NATIVE_IMPLEMENTATION support since nuget is already supported when this is set it routes via native package manager(flexpack).
- BuildInfo collection in build-info-go
- check sum calculation
- Original Deployment Repository calculation
- Requested By calculation for dependencies
- Easy authentication using nuget’s credentials like mentioned in above Atlassian wiki.
- Build Info collection for both dependencies and artifacts for all the commands eligible listed in above wiki.
- Set properties clearly on artifacts published.
- Make sure the buildinfo is figuring out and showing show in tree in build info section when published to artifactory.
## Not to implement
- nuget-config support is not required since this is flexpack implementation.
**Parent:** RTECO-395
**Components:** jfrog-cli-nuget

---
Evidence: see Artifactory bundle for RTECO-1574.

Jira: https://jfrog-int.atlassian.net/browse/RTECO-1574
