### PR TITLE
XRAY-156301 Add generic bounded-redirect boundary validation

### DIFF
--- a/http/redirect/redirect.go
+++ b/http/redirect/redirect.go
@@ -1,0 +1,131 @@
+package redirect
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+)
+
+const MaxAuthenticatedRedirects = 3
+
+// EndpointBoundary represents an allowed scheme+host+path prefix that a request (and any
+// redirect it follows) must stay within. It has no notion of what the boundary represents -
+// callers decide what URL to construct it from.
+type EndpointBoundary struct {
+	scheme string
+	host   string
+	path   string
+}
+
+func NewEndpointBoundary(rawBaseURL string) (EndpointBoundary, error) {
+	u, err := url.Parse(rawBaseURL)
+	if err != nil || u.Host == "" || u.User != nil || u.RawPath != "" || u.RawQuery != "" || u.Fragment != "" ||
+		(!strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https")) {
+		return EndpointBoundary{}, fmt.Errorf("invalid endpoint boundary")
+	}
+	cleanPath, valid := normalizedBoundaryPath(u.Path)
+	if !valid {
+		return EndpointBoundary{}, fmt.Errorf("invalid endpoint boundary")
+	}
+	return EndpointBoundary{
+		scheme: strings.ToLower(u.Scheme),
+		host:   normalizedHost(u),
+		path:   cleanPath,
+	}, nil
+}
+
+func (b EndpointBoundary) Validate(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
+		return fmt.Errorf("invalid request URL")
+	}
+	if hasAmbiguousPathEscape(u.EscapedPath()) {
+		return fmt.Errorf("ambiguous escaped request path")
+	}
+	requestPath, valid := normalizedBoundaryPath(u.Path)
+	if !valid {
+		return fmt.Errorf("request URL escapes the configured endpoint")
+	}
+	if strings.ToLower(u.Scheme) != b.scheme || normalizedHost(u) != b.host ||
+		!strings.HasPrefix(requestPath, b.path) {
+		return fmt.Errorf("request URL escapes the configured endpoint")
+	}
+	return nil
+}
+
+func normalizedBoundaryPath(rawPath string) (string, bool) {
+	if rawPath == "" {
+		rawPath = "/"
+	}
+	cleanPath := strings.TrimSuffix(path.Clean(rawPath), "/") + "/"
+	return cleanPath, cleanPath == strings.TrimSuffix(rawPath, "/")+"/"
+}
+
+func hasAmbiguousPathEscape(escapedPath string) bool {
+	for {
+		lowerPath := strings.ToLower(escapedPath)
+		if strings.Contains(lowerPath, "%2f") || strings.Contains(lowerPath, "%2e") ||
+			strings.Contains(lowerPath, "%5c") {
+			return true
+		}
+		decoded, err := url.PathUnescape(escapedPath)
+		if err != nil {
+			return true
+		}
+		if decoded == escapedPath {
+			return false
+		}
+		escapedPath = decoded
+	}
+}
+
+func normalizedHost(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		if strings.EqualFold(u.Scheme, "http") {
+			port = "80"
+		} else if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		}
+	}
+	return strings.ToLower(u.Hostname()) + ":" + port
+}
+
+// SendWithBoundedRedirects sends requestURL and follows any redirect the server returns, but only
+// if each hop (including the initial URL) validates against boundary. Credentials are only ever
+// re-attached to a hop once it has been validated. Callers decide what boundary means to them -
+// this function only compares URLs against it.
+func SendWithBoundedRedirects(client *jfroghttpclient.JfrogHttpClient, method, requestURL string,
+	details *httputils.HttpClientDetails, boundary EndpointBoundary, maxRedirects int,
+) (*http.Response, []byte, error) {
+	// JfrogHttpClient has no per-request redirect hook, so validate each hop before forwarding auth.
+	if maxRedirects < 0 {
+		return nil, nil, fmt.Errorf("redirect limit must be non-negative")
+	}
+	// HttpClient.Send retries on CheckRedirect errors, which would desync this hop counter.
+	if retries := client.GetHttpClient().GetRetries(); retries != 0 {
+		return nil, nil, fmt.Errorf("bounded redirects require a zero-retry client, got %d retries configured", retries)
+	}
+	currentURL := requestURL
+	for redirects := 0; ; redirects++ {
+		if err := boundary.Validate(currentURL); err != nil {
+			return nil, nil, err
+		}
+		resp, body, redirectURL, err := client.Send(method, currentURL, nil, false, true, details.Clone(), "")
+		if redirectURL == "" {
+			return resp, body, err
+		}
+		if redirects == maxRedirects {
+			return resp, body, fmt.Errorf("redirect limit of %d exceeded", maxRedirects)
+		}
+		if err := boundary.Validate(redirectURL); err != nil {
+			return resp, body, fmt.Errorf("unsafe redirect: %w", err)
+		}
+		currentURL = redirectURL
+	}
+}

--- a/http/redirect/redirect_test.go
+++ b/http/redirect/redirect_test.go
@@ -1,0 +1,165 @@
+package redirect
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newZeroRetryClient(t *testing.T) *jfroghttpclient.JfrogHttpClient {
+	client, err := jfroghttpclient.JfrogClientBuilder().SetRetries(0).Build()
+	require.NoError(t, err)
+	return client
+}
+
+func TestNewEndpointBoundary(t *testing.T) {
+	t.Run("bare host covers root", func(t *testing.T) {
+		boundary, err := NewEndpointBoundary("https://example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "/", boundary.path)
+		assert.NoError(t, boundary.Validate("https://example.com"))
+		assert.NoError(t, boundary.Validate("https://example.com/api/pypi/repo/file.whl"))
+	})
+
+	t.Run("trailing slash is normalized", func(t *testing.T) {
+		withoutSlash, err := NewEndpointBoundary("https://example.com/api/pypi/repo")
+		require.NoError(t, err)
+		withSlash, err := NewEndpointBoundary("https://example.com/api/pypi/repo/")
+		require.NoError(t, err)
+		assert.Equal(t, withoutSlash, withSlash)
+	})
+
+	t.Run("IPv6 and default port are normalized", func(t *testing.T) {
+		boundary, err := NewEndpointBoundary("https://[2001:db8::1]/api/pypi/repo/")
+		require.NoError(t, err)
+		assert.NoError(t, boundary.Validate("https://[2001:db8::1]:443/api/pypi/repo/pkg.whl"))
+		assert.Error(t, boundary.Validate("https://[2001:db8::2]/api/pypi/repo/pkg.whl"))
+	})
+
+	for _, rawURL := range []string{
+		"https://user@example.com/api/pypi/repo/",
+		"https://example.com/api/pypi/repo/?token=value",
+		"https://example.com/api/pypi/repo/#fragment",
+		"ftp://example.com/api/pypi/repo/",
+	} {
+		t.Run("rejects invalid boundary "+rawURL, func(t *testing.T) {
+			_, err := NewEndpointBoundary(rawURL)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEndpointBoundaryValidateRejectsEscapes(t *testing.T) {
+	boundary, err := NewEndpointBoundary("https://example.com/api/pypi/repo/")
+	require.NoError(t, err)
+
+	for _, rawURL := range []string{
+		"https://example.com/api/pypi/repo/%2Fsecret",
+		"https://example.com/api/pypi/repo/%252Fsecret",
+		"https://example.com/api/pypi/repo/%25252e%25252e%25252fsecret",
+		"https://example.com/api/pypi/repo/%255csecret",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			err := boundary.Validate(rawURL)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ambiguous escaped request path")
+		})
+	}
+}
+
+func TestEndpointBoundaryValidateRejectsOutsideEndpoint(t *testing.T) {
+	boundary, err := NewEndpointBoundary("https://example.com/api/pypi/repo/")
+	require.NoError(t, err)
+
+	for _, rawURL := range []string{
+		"http://example.com/api/pypi/repo/pkg.whl",
+		"https://other.example.com/api/pypi/repo/pkg.whl",
+		"https://example.com/api/pypi/other/pkg.whl",
+		"https://user@example.com/api/pypi/repo/pkg.whl",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			assert.Error(t, boundary.Validate(rawURL))
+		})
+	}
+}
+
+func TestSendWithBoundedRedirectsLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		redirects    int32
+		wantErr      bool
+		wantRequests int32
+	}{
+		{name: "three redirects succeed", redirects: MaxAuthenticatedRedirects, wantRequests: 4},
+		{name: "fourth redirect is rejected", redirects: MaxAuthenticatedRedirects + 1, wantErr: true, wantRequests: 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestNumber := requests.Add(1)
+				if requestNumber <= test.redirects {
+					http.Redirect(w, r, fmt.Sprintf("/api/pypi/repo/%d", requestNumber), http.StatusFound)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte("ok")); err != nil {
+					t.Errorf("failed writing response: %v", err)
+				}
+			}))
+			defer server.Close()
+			// Zero retries required; see SendWithBoundedRedirects.
+			client := newZeroRetryClient(t)
+			boundary, err := NewEndpointBoundary(server.URL + "/api/pypi/repo/")
+			require.NoError(t, err)
+			details := httputils.HttpClientDetails{}
+
+			resp, body, err := SendWithBoundedRedirects(client, http.MethodGet,
+				server.URL+"/api/pypi/repo/0", &details, boundary, MaxAuthenticatedRedirects)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "redirect limit")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, "ok", string(body))
+			}
+			assert.Equal(t, test.wantRequests, requests.Load())
+		})
+	}
+}
+
+func TestSendWithBoundedRedirectsRejectsLateHopEscape(t *testing.T) {
+	// The first redirect is legitimate; only the second hop escapes the boundary.
+	// Every hop must be validated, not just the initial request.
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			http.Redirect(w, r, "/api/pypi/repo/inner", http.StatusFound)
+		case 2:
+			http.Redirect(w, r, "/api/pypi/other-repo/secret", http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+	client := newZeroRetryClient(t)
+	boundary, err := NewEndpointBoundary(server.URL + "/api/pypi/repo/")
+	require.NoError(t, err)
+	details := httputils.HttpClientDetails{}
+
+	_, _, err = SendWithBoundedRedirects(client, http.MethodGet,
+		server.URL+"/api/pypi/repo/start", &details, boundary, MaxAuthenticatedRedirects)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe redirect")
+	assert.Equal(t, int32(2), requests.Load(), "must stop at the escaping hop, not follow it")
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Companion PR: jfrog/jfrog-cli-security#818

Adds a new http/redirect package with EndpointBoundary and SendWithBoundedRedirects, ported as-is from cli-security's utils/http_redirect.go (used there to stop curation requests from following a redirect outside a configured repo before re-attaching credentials).

Fully generic — takes a URL and a boundary as parameters, with no knowledge of curation or any specific caller. No change to existing client behavior; this only wraps the existing Send(..., followRedirect=false, ...) primitive.