### PR TITLE
RTDEV-94736 - Support evidence prepare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@
       - [Creating Evidence Service Config](#creating-evidence-service-config)
       - [Creating New Evidence Service Manager](#creating-new-evidence-service-manager)
     - [Using Evidence Services](#using-evidence-services)
+      - [Prepare Evidence](#prepare-evidence)
       - [Upload Evidence](#upload-evidence)
   - [Metadata APIs](#metadata-apis)
     - [Creating Metadata Service Manager](#creating-metadata-service-manager)
@@ -3391,6 +3392,27 @@ evidenceManager, err := evidence.New(serviceConfig)
 
 ### Using Evidence Services
 
+#### Prepare Evidence
+
+Prepare an in-toto statement for external signing. The response contains the base64-encoded DSSE payload and the URL to which the signed envelope should be posted.
+
+```go
+request := evidenceService.PrepareEvidenceRequest{
+    Predicate:     json.RawMessage(`{"result":"passed"}`),
+    PredicateType: "https://example.com/predicate/v1",
+    Subject: evidenceService.PrepareEvidenceSubject{
+        SubjectType: evidenceService.SubjectTypeEntity,
+        EntityType:  "gitCommit",
+        EntityID:    "57bb812f3733b80e270272ba063274e52c34bd23",
+    },
+    ProjectKey: "my-project",
+}
+
+response, err := evidenceManager.PrepareEvidence(request, true)
+// Sign response.DSSEPayload and construct the DSSE envelope.
+body, err := evidenceManager.UploadPreparedSignedEvidence(response.PostURL, signedEnvelope)
+```
+
 #### Upload Evidence
 
 ```go
@@ -3403,6 +3425,7 @@ evidenceDetails := evidenceService.EvidenceDetails{
 }
 body, err = evideceManager.UploadEvidence(evidenceDetails)
 ```
+
 ## Metadata APIs
 
 ### Creating Metadata Service Manager

--- a/evidence/manager.go
+++ b/evidence/manager.go
@@ -39,3 +39,13 @@ func (esm *EvidenceServicesManager) UploadEvidence(evidenceDetails services.Evid
 	evidenceService := services.NewEvidenceService(esm.config.GetServiceDetails(), esm.client)
 	return evidenceService.UploadEvidence(evidenceDetails)
 }
+
+func (esm *EvidenceServicesManager) PrepareEvidence(request services.PrepareEvidenceRequest, includePAE bool) (*services.PrepareEvidenceResponse, error) {
+	evidenceService := services.NewEvidenceService(esm.config.GetServiceDetails(), esm.client)
+	return evidenceService.PrepareEvidence(request, includePAE)
+}
+
+func (esm *EvidenceServicesManager) UploadPreparedSignedEvidence(postURL string, signedEnvelope []byte) ([]byte, error) {
+	evidenceService := services.NewEvidenceService(esm.config.GetServiceDetails(), esm.client)
+	return evidenceService.UploadPreparedSignedEvidence(postURL, signedEnvelope)
+}

--- a/evidence/prepare_test.go
+++ b/evidence/prepare_test.go
@@ -1,0 +1,143 @@
+package evidence
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
+	evidenceServices "github.com/jfrog/jfrog-client-go/evidence/services"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareEvidence(t *testing.T) {
+	tests := []struct {
+		name        string
+		includePAE  bool
+		expectedPAE string
+	}{
+		{name: "without PAE"},
+		{name: "with PAE", includePAE: true, expectedPAE: "DSSEv1 28 application/vnd.in-toto+json 7 payload"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/evidence/api/v1/evidence/prepare", r.URL.Path)
+				assert.Equal(t, test.includePAE, r.URL.Query().Get("include_pae") == "true")
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				assert.JSONEq(t, `{
+					"predicate": {"result": "passed"},
+					"predicate_type": "https://example.com/predicate/v1",
+					"provider_id": "ci",
+					"subject": {
+						"subject_type": "entity",
+						"entity_type": "gitCommit",
+						"entity_id": "abc123"
+					},
+					"project_key": "proj",
+					"attachments": [{
+						"repository": "reports-local",
+						"path": "reports/result.json"
+					}]
+				}`, string(body))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				response := map[string]any{
+					"post_url":          "/evidence/api/v1/entity/gitCommit/abc123?project=proj",
+					"dsse_payload":      "cGF5bG9hZA==",
+					"dsse_payload_type": "application/vnd.in-toto+json",
+					"attachments": []map[string]string{{
+						"repository": "reports-local",
+						"path":       "reports/result.json",
+						"sha256":     "abc",
+					}},
+				}
+				if test.expectedPAE != "" {
+					response["pre_authentication_encoding"] = test.expectedPAE
+				}
+				require.NoError(t, json.NewEncoder(w).Encode(response))
+			}))
+			defer testServer.Close()
+
+			serviceDetails := artifactoryAuth.NewArtifactoryDetails()
+			serviceDetails.SetUrl(testServer.URL + "/evidence/")
+			client, err := jfroghttpclient.JfrogClientBuilder().Build()
+			require.NoError(t, err)
+			service := evidenceServices.NewEvidenceService(serviceDetails, client)
+
+			response, err := service.PrepareEvidence(evidenceServices.PrepareEvidenceRequest{
+				Predicate:     json.RawMessage(`{"result":"passed"}`),
+				PredicateType: "https://example.com/predicate/v1",
+				ProviderID:    "ci",
+				Subject: evidenceServices.PrepareEvidenceSubject{
+					SubjectType: evidenceServices.SubjectTypeEntity,
+					EntityType:  "gitCommit",
+					EntityID:    "abc123",
+				},
+				ProjectKey: "proj",
+				Attachments: []evidenceServices.PrepareEvidenceAttachment{{
+					Repository: "reports-local",
+					Path:       "reports/result.json",
+				}},
+			}, test.includePAE)
+			require.NoError(t, err)
+			assert.Equal(t, "/evidence/api/v1/entity/gitCommit/abc123?project=proj", response.PostURL)
+			assert.Equal(t, "cGF5bG9hZA==", response.DSSEPayload)
+			assert.Equal(t, "application/vnd.in-toto+json", response.DSSEPayloadType)
+			assert.Equal(t, test.expectedPAE, response.PreAuthenticationEncoding)
+			require.Len(t, response.Attachments, 1)
+			assert.Equal(t, "abc", response.Attachments[0].SHA256)
+		})
+	}
+}
+
+func TestPrepareEvidence_ErrorResponse(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, err := w.Write([]byte(`{"errors":[{"message":"subject not found"}]}`))
+		require.NoError(t, err)
+	}))
+	defer testServer.Close()
+
+	serviceDetails := artifactoryAuth.NewArtifactoryDetails()
+	serviceDetails.SetUrl(testServer.URL + "/evidence/")
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	require.NoError(t, err)
+	service := evidenceServices.NewEvidenceService(serviceDetails, client)
+
+	_, err = service.PrepareEvidence(evidenceServices.PrepareEvidenceRequest{
+		Predicate:     json.RawMessage(`{}`),
+		PredicateType: "https://example.com/predicate/v1",
+		Subject: evidenceServices.PrepareEvidenceSubject{
+			SubjectType: evidenceServices.SubjectTypeArtifact,
+			RepoPath:    "repo/path/file",
+		},
+	}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, err.Error(), "subject not found")
+}
+
+func TestPrepareEvidence_InvalidPredicateJSON(t *testing.T) {
+	service := evidenceServices.NewEvidenceService(artifactoryAuth.NewArtifactoryDetails(), nil)
+
+	_, err := service.PrepareEvidence(evidenceServices.PrepareEvidenceRequest{
+		Predicate:     json.RawMessage(`{invalid`),
+		PredicateType: "https://example.com/predicate/v1",
+		Subject: evidenceServices.PrepareEvidenceSubject{
+			SubjectType: evidenceServices.SubjectTypeEntity,
+			EntityType:  "gitCommit",
+			EntityID:    "abc123",
+		},
+	}, false)
+	require.Error(t, err)
+}

--- a/evidence/services/operation.go
+++ b/evidence/services/operation.go
@@ -52,6 +52,18 @@ func (es *EvidenceService) doOperation(operation EvidenceOperation) ([]byte, err
 	return body, errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK, http.StatusCreated)
 }
 
+func (es *EvidenceService) uploadEvidenceBody(requestURL string, evidenceBody []byte) ([]byte, error) {
+	httpClientDetails := es.GetEvidenceDetails().CreateHttpClientDetails()
+	httpClientDetails.SetContentTypeApplicationJson()
+
+	log.Debug("Uploading Evidence")
+	resp, body, err := es.client.SendPost(requestURL, evidenceBody, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+	return body, errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK, http.StatusCreated)
+}
+
 type EvidenceDetails struct {
 	SubjectUri  string              `json:"subject_uri"`
 	DSSEFileRaw []byte              `json:"dsse_file_raw"`

--- a/evidence/services/prepare.go
+++ b/evidence/services/prepare.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const prepareEvidenceAPI = "api/v1/evidence/prepare"
+
+type SubjectType string
+
+const (
+	SubjectTypeArtifact           SubjectType = "artifact"
+	SubjectTypeBuild              SubjectType = "build"
+	SubjectTypePackage            SubjectType = "package"
+	SubjectTypeReleaseBundle      SubjectType = "release_bundle"
+	SubjectTypeApplicationVersion SubjectType = "application_version"
+	SubjectTypeEntity             SubjectType = "entity"
+)
+
+// PrepareEvidenceRequest contains the data used by Evidence to generate an in-toto statement for signing.
+// For entity subjects, at most one of EntityRepo, ProjectKey, and ApplicationKey may be set.
+type PrepareEvidenceRequest struct {
+	Predicate      json.RawMessage             `json:"predicate"`
+	PredicateType  string                      `json:"predicate_type"`
+	Markdown       string                      `json:"markdown,omitempty"`
+	ProviderID     string                      `json:"provider_id,omitempty"`
+	Subject        PrepareEvidenceSubject      `json:"subject"`
+	EntityRepo     string                      `json:"entity_repo,omitempty"`
+	ProjectKey     string                      `json:"project_key,omitempty"`
+	ApplicationKey string                      `json:"application_key,omitempty"`
+	Attachments    []PrepareEvidenceAttachment `json:"attachments,omitempty"`
+}
+
+// PrepareEvidenceSubject identifies the subject for which Evidence prepares the statement.
+// The fields required by Evidence depend on SubjectType.
+type PrepareEvidenceSubject struct {
+	SubjectType   SubjectType `json:"subject_type"`
+	SubjectSHA256 string      `json:"subject_sha256,omitempty"`
+
+	RepoPath string `json:"repo_path,omitempty"`
+
+	EntityType string `json:"entity_type,omitempty"`
+	EntityID   string `json:"entity_id,omitempty"`
+
+	BuildName      string `json:"build_name,omitempty"`
+	BuildNumber    string `json:"build_number,omitempty"`
+	BuildTimestamp string `json:"build_timestamp,omitempty"`
+
+	ReleaseBundleName    string `json:"release_bundle_name,omitempty"`
+	ReleaseBundleVersion string `json:"release_bundle_version,omitempty"`
+
+	ApplicationKey     string `json:"application_key,omitempty"`
+	ApplicationVersion string `json:"application_version,omitempty"`
+
+	PackageRepo    string `json:"package_repo,omitempty"`
+	PackageName    string `json:"package_name,omitempty"`
+	PackageVersion string `json:"package_version,omitempty"`
+}
+
+// PrepareEvidenceAttachment identifies an attachment in Artifactory.
+// SHA256 is optional in a prepare request and is resolved by Evidence.
+type PrepareEvidenceAttachment struct {
+	Repository string `json:"repository"`
+	Path       string `json:"path"`
+	SHA256     string `json:"sha256,omitempty"`
+}
+
+type PrepareEvidenceResponse struct {
+	PostURL                   string                      `json:"post_url"`
+	DSSEPayload               string                      `json:"dsse_payload"`
+	DSSEPayloadType           string                      `json:"dsse_payload_type"`
+	PreAuthenticationEncoding string                      `json:"pre_authentication_encoding,omitempty"`
+	Attachments               []PrepareEvidenceAttachment `json:"attachments,omitempty"`
+}
+
+// PrepareEvidence asks Evidence to generate an in-toto statement for external signing.
+// When includePAE is true, the response also contains the DSSE pre-authentication encoding.
+func (es *EvidenceService) PrepareEvidence(request PrepareEvidenceRequest, includePAE bool) (*PrepareEvidenceResponse, error) {
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	queryParams := make(map[string]string)
+	if includePAE {
+		queryParams["include_pae"] = "true"
+	}
+	requestFullURL, err := clientutils.BuildUrl(es.GetEvidenceDetails().GetUrl(), prepareEvidenceAPI, queryParams)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+
+	httpClientDetails := es.GetEvidenceDetails().CreateHttpClientDetails()
+	httpClientDetails.SetContentTypeApplicationJson()
+
+	log.Debug("Preparing Evidence for signing")
+	resp, body, err := es.client.SendPost(requestFullURL, requestBody, &httpClientDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var response PrepareEvidenceResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	return &response, nil
+}

--- a/evidence/services/upload_prepared.go
+++ b/evidence/services/upload_prepared.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+// UploadPreparedSignedEvidence uploads a signed DSSE envelope to the root-relative
+// post URL returned by PrepareEvidence.
+func (es *EvidenceService) UploadPreparedSignedEvidence(postURL string, signedEnvelope []byte) ([]byte, error) {
+	requestURL, err := es.resolvePreparedEvidencePostURL(postURL)
+	if err != nil {
+		return nil, err
+	}
+	return es.uploadEvidenceBody(requestURL, signedEnvelope)
+}
+
+func (es *EvidenceService) resolvePreparedEvidencePostURL(postURL string) (string, error) {
+	post, err := url.Parse(postURL)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if postURL == "" || post.IsAbs() || post.Host != "" || post.Path == "" || post.Path[0] != '/' {
+		return "", fmt.Errorf("prepared Evidence post URL must be a non-empty root-relative URL")
+	}
+
+	base, err := url.Parse(es.GetEvidenceDetails().GetUrl())
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("Evidence URL must include a scheme and host")
+	}
+
+	post.Scheme = base.Scheme
+	post.Host = base.Host
+	post.User = base.User
+	return post.String(), nil
+}

--- a/evidence/services/upload_prepared.go
+++ b/evidence/services/upload_prepared.go
@@ -31,7 +31,7 @@ func (es *EvidenceService) resolvePreparedEvidencePostURL(postURL string) (strin
 		return "", errorutils.CheckError(err)
 	}
 	if base.Scheme == "" || base.Host == "" {
-		return "", fmt.Errorf("Evidence URL must include a scheme and host")
+		return "", fmt.Errorf("evidence URL must include a scheme and host")
 	}
 
 	post.Scheme = base.Scheme

--- a/evidence/upload_prepared_test.go
+++ b/evidence/upload_prepared_test.go
@@ -1,0 +1,86 @@
+package evidence
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
+	evidenceServices "github.com/jfrog/jfrog-client-go/evidence/services"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadPreparedSignedEvidence(t *testing.T) {
+	signedEnvelope := []byte(`{"payload":"cGF5bG9hZA==","payloadType":"application/vnd.in-toto+json","signatures":[{"keyid":"key","sig":"signature"}]}`)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/evidence/api/v1/entity/gitCommit/abc123", r.URL.Path)
+		assert.Equal(t, "proj", r.URL.Query().Get("project"))
+		assert.Equal(t, "ci provider", r.URL.Query().Get("providerId"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, signedEnvelope, body)
+
+		w.WriteHeader(http.StatusCreated)
+		_, err = w.Write([]byte(`{"verified":true}`))
+		require.NoError(t, err)
+	}))
+	defer testServer.Close()
+
+	serviceDetails := artifactoryAuth.NewArtifactoryDetails()
+	serviceDetails.SetUrl(testServer.URL + "/evidence/")
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	require.NoError(t, err)
+	service := evidenceServices.NewEvidenceService(serviceDetails, client)
+
+	body, err := service.UploadPreparedSignedEvidence(
+		"/evidence/api/v1/entity/gitCommit/abc123?project=proj&providerId=ci+provider",
+		signedEnvelope,
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"verified":true}`, string(body))
+}
+
+func TestUploadPreparedSignedEvidence_ErrorResponse(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"errors":[{"message":"invalid signature"}]}`))
+		require.NoError(t, err)
+	}))
+	defer testServer.Close()
+
+	serviceDetails := artifactoryAuth.NewArtifactoryDetails()
+	serviceDetails.SetUrl(testServer.URL + "/evidence/")
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	require.NoError(t, err)
+	service := evidenceServices.NewEvidenceService(serviceDetails, client)
+
+	_, err = service.UploadPreparedSignedEvidence("/evidence/api/v1/subject/repo/file", []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "invalid signature")
+}
+
+func TestUploadPreparedSignedEvidence_RejectsNonRootRelativeURL(t *testing.T) {
+	serviceDetails := artifactoryAuth.NewArtifactoryDetails()
+	serviceDetails.SetUrl("https://example.jfrog.io/evidence/")
+	service := evidenceServices.NewEvidenceService(serviceDetails, nil)
+
+	for _, postURL := range []string{
+		"",
+		"api/v1/entity/gitCommit/abc123",
+		"https://other.example/evidence/api/v1/entity/gitCommit/abc123",
+		"//other.example/evidence/api/v1/entity/gitCommit/abc123",
+	} {
+		t.Run(postURL, func(t *testing.T) {
+			_, err := service.UploadPreparedSignedEvidence(postURL, []byte(`{}`))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "root-relative")
+		})
+	}
+}


### PR DESCRIPTION
- [V] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [V] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [V] This pull request is on the master branch.
- [V] I used gofmt for formatting the code before submitting the pull request.
-----

Add support for the Evidence service prepare API.
This will allow replacing a lot of code that is now in jfrog-cli-evidence with server side code this API already has
