### PR TITLE
Add proportional refresh threshold for platform access tokens

### DIFF
--- a/auth/authutils.go
+++ b/auth/authutils.go
@@ -174,7 +174,39 @@ type TokenPayload struct {
 // Artifactory's refresh token mechanism creates tokens that expire in 60 minutes. We want to refresh them when 10 minutes are left.
 var RefreshArtifactoryTokenBeforeExpiryMinutes = int64(10)
 
-// Platform's access token are created with 1 year expiry. We want to refresh the token a week before expiry.
+// Platform's access tokens are historically created with 1 year expiry, refreshed a week before expiry.
+// Kept as the upper cap for CalculateProportionalRefreshThreshold, so tokens with long lifetimes keep this behavior.
 var RefreshPlatformTokenBeforeExpiryMinutes = int64(7 * 24 * 60)
 
+// Never refresh a platform token more than this many minutes before it expires, regardless of its lifetime.
+const MinRefreshBeforeExpiryMinutes = int64(30)
+
+// Refresh a platform token once this fraction of its total lifetime remains.
+const refreshThresholdFraction = 0.10
+
 const WaitBeforeRefreshSeconds = 15
+
+// CalculateProportionalRefreshThreshold returns the number of minutes before expiry that a platform
+// access token should be refreshed, proportional to its total lifetime. This avoids refreshing on
+// every command for tokens issued with a shorter-than-1-year lifetime (e.g. 7 days), since the fixed
+// RefreshPlatformTokenBeforeExpiryMinutes threshold would otherwise exceed the token's entire lifetime.
+func CalculateProportionalRefreshThreshold(tokenLifetimeMinutes int64) int64 {
+	threshold := int64(float64(tokenLifetimeMinutes) * refreshThresholdFraction)
+	if threshold < MinRefreshBeforeExpiryMinutes {
+		return MinRefreshBeforeExpiryMinutes
+	}
+	if threshold > RefreshPlatformTokenBeforeExpiryMinutes {
+		return RefreshPlatformTokenBeforeExpiryMinutes
+	}
+	return threshold
+}
+
+// GetPlatformTokenRefreshThreshold extracts a platform access token's total lifetime (exp - iat) and
+// returns its proportional refresh threshold, in minutes. See CalculateProportionalRefreshThreshold.
+func GetPlatformTokenRefreshThreshold(token string) (int64, error) {
+	expirySeconds, err := ExtractExpiryFromAccessToken(token)
+	if err != nil {
+		return 0, err
+	}
+	return CalculateProportionalRefreshThreshold(int64(expirySeconds) / 60), nil
+}

--- a/auth/authutils_test.go
+++ b/auth/authutils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/utils/tests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -105,7 +106,7 @@ func TestGetPlatformTokenRefreshThreshold(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			token := buildTestAccessToken(1000, 1000+testCase.lifetimeSeconds)
+			token := buildTestAccessToken(t, 1000, 1000+testCase.lifetimeSeconds)
 			threshold, err := GetPlatformTokenRefreshThreshold(token)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expectedThresholdMins, threshold)
@@ -120,8 +121,9 @@ func TestGetPlatformTokenRefreshThreshold(t *testing.T) {
 
 // buildTestAccessToken builds an unsigned JWT-shaped token with the given iat/exp claims,
 // matching the header.payload.signature decoding done by extractPayloadFromAccessToken.
-func buildTestAccessToken(iat, exp int64) string {
-	payload, _ := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+func buildTestAccessToken(t *testing.T, iat, exp int64) string {
+	payload, err := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+	require.NoError(t, err)
 	encodedPayload := base64.RawStdEncoding.EncodeToString(payload)
 	return "header." + encodedPayload + ".signature"
 }

--- a/auth/authutils_test.go
+++ b/auth/authutils_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -68,4 +70,58 @@ func TestExtractSubjectFromAccessToken(t *testing.T) {
 		}
 		assert.Equal(t, testCase.expectedSubject, subject)
 	}
+}
+
+func TestCalculateProportionalRefreshThreshold(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		tokenLifetimeMinutes  int64
+		expectedThresholdMins int64
+	}{
+		{"1 year lifetime is capped", 365 * 24 * 60, RefreshPlatformTokenBeforeExpiryMinutes},
+		{"30 day lifetime uses 10%", 30 * 24 * 60, 4320},
+		{"7 day lifetime uses 10%", 7 * 24 * 60, 1008},
+		{"1 hour lifetime is floored", 60, MinRefreshBeforeExpiryMinutes},
+		{"zero lifetime is floored", 0, MinRefreshBeforeExpiryMinutes},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedThresholdMins, CalculateProportionalRefreshThreshold(testCase.tokenLifetimeMinutes))
+		})
+	}
+}
+
+func TestGetPlatformTokenRefreshThreshold(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		lifetimeSeconds       int64
+		expectedThresholdMins int64
+	}{
+		{"1 year token is capped", 365 * 24 * 60 * 60, RefreshPlatformTokenBeforeExpiryMinutes},
+		{"7 day token uses 10%", 7 * 24 * 60 * 60, 1008},
+		{"1 hour token is floored", 60 * 60, MinRefreshBeforeExpiryMinutes},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			token := buildTestAccessToken(1000, 1000+testCase.lifetimeSeconds)
+			threshold, err := GetPlatformTokenRefreshThreshold(token)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedThresholdMins, threshold)
+		})
+	}
+
+	t.Run("invalid token returns error", func(t *testing.T) {
+		_, err := GetPlatformTokenRefreshThreshold(token3)
+		assert.Error(t, err)
+	})
+}
+
+// buildTestAccessToken builds an unsigned JWT-shaped token with the given iat/exp claims,
+// matching the header.payload.signature decoding done by extractPayloadFromAccessToken.
+func buildTestAccessToken(iat, exp int64) string {
+	payload, _ := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+	encodedPayload := base64.RawStdEncoding.EncodeToString(payload)
+	return "header." + encodedPayload + ".signature"
 }


### PR DESCRIPTION
## Summary
- RefreshPlatformTokenBeforeExpiryMinutes was a hardcoded 7-day (10080-minute) threshold, assuming every platform access token has a 1-year lifetime. Tokens issued with a shorter lifetime (e.g. 7 days) had their entire lifetime below that threshold, so the CLI entered the refresh path on every single command.
- Adds CalculateProportionalRefreshThreshold and GetPlatformTokenRefreshThreshold: the refresh threshold is now 10% of a token's own lifetime, floored at 30 minutes and capped at the existing RefreshPlatformTokenBeforeExpiryMinutes — so 1-year tokens keep refreshing ~7 days before expiry, unchanged.
- Purely additive: no existing exported symbol was removed or changed in signature.

## Scope
- Related to JGC-519.
- Companion PR in jfrog-cli-core wires this into the token-refresh interceptor.

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
