### PR TITLE
Add RBv2 distribute and remote-delete priority support

### DIFF
--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -3,16 +3,20 @@ package lifecycle
 import (
 	"encoding/json"
 	"fmt"
-	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
-	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
-	lifecycle "github.com/jfrog/jfrog-client-go/lifecycle/services"
-	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	artifactoryAuth "github.com/jfrog/jfrog-client-go/artifactory/auth"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
+	lifecycle "github.com/jfrog/jfrog-client-go/lifecycle/services"
+	distributionUtils "github.com/jfrog/jfrog-client-go/utils/distribution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -246,6 +250,43 @@ func TestRemoteDeleteReleaseBundle(t *testing.T) {
 	defer mockServer.Close()
 
 	assert.NoError(t, rbService.RemoteDeleteReleaseBundle(testRb, lifecycle.ReleaseBundleRemoteDeleteParams{MaxWaitMinutes: 2}))
+}
+
+func TestRemoteDeleteReleaseBundleSendsPriority(t *testing.T) {
+	var capturedBody []byte
+	var capturedMethod string
+	mockServer, rbService := createMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/" + lifecycle.GetRemoteDeleteReleaseBundleApi(testRb, true)
+		if r.URL.Path == expectedPath {
+			capturedMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			capturedBody = body
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer mockServer.Close()
+
+	params := lifecycle.ReleaseBundleRemoteDeleteParams{
+		DistributionRules: []*distributionUtils.DistributionCommonParams{{SiteName: "edge1", Priority: "medium"}},
+		Priority:          "high",
+		DryRun:            true,
+	}
+	assert.NoError(t, rbService.RemoteDeleteReleaseBundle(testRb, params))
+	assert.Equal(t, http.MethodPost, capturedMethod)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(capturedBody, &body))
+	assert.Equal(t, "high", body["priority"])
+	rules, ok := body["distribution_rules"].([]any)
+	require.True(t, ok)
+	require.Len(t, rules, 1)
+	rule, ok := rules[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "edge1", rule["site_name"])
+	assert.Equal(t, "medium", rule["priority"])
 }
 
 func TestGetReleaseBundleVersionPromotions(t *testing.T) {

--- a/lifecycle/manager.go
+++ b/lifecycle/manager.go
@@ -182,6 +182,7 @@ func (lcs *LifecycleServicesManager) DistributeReleaseBundle(rbDetails lifecycle
 	distributeBundleService.Sync = distributeParams.Sync
 	distributeBundleService.MaxWaitMinutes = distributeParams.MaxWaitMinutes
 	distributeBundleService.ProjectKey = distributeParams.ProjectKey
+	distributeBundleService.Priority = distributeParams.Priority
 
 	mappings := &distributeBundleService.PathMappings
 	*mappings = []utils.PathMapping{}

--- a/lifecycle/services/delete.go
+++ b/lifecycle/services/delete.go
@@ -53,7 +53,7 @@ func (rbs *ReleaseBundlesService) RemoteDeleteReleaseBundle(rbDetails ReleaseBun
 	}
 	log.Info(dryRunStr + "Remote Deleting: " + rbDetails.ReleaseBundleName + "/" + rbDetails.ReleaseBundleVersion)
 
-	rbBody := distribution.CreateDistributeV1Body(params.DistributionRules, params.DryRun, false)
+	rbBody := distribution.CreateDistributeV1BodyWithPriority(params.DistributionRules, params.DryRun, false, params.Priority)
 	content, err := json.Marshal(rbBody)
 	if err != nil {
 		return errorutils.CheckError(err)
@@ -138,5 +138,7 @@ type ReleaseBundleRemoteDeleteParams struct {
 	DryRun            bool
 	// Max time in minutes to wait for sync distribution to finish.
 	MaxWaitMinutes int
+	// Priority is the optional base priority for RBv2 remote delete (low|medium|high).
+	Priority string
 	CommonOptionalQueryParams
 }

--- a/lifecycle/services/distribute.go
+++ b/lifecycle/services/distribute.go
@@ -29,6 +29,7 @@ type DistributeReleaseBundleService struct {
 	MaxWaitMinutes   int
 	DistributeParams distribution.DistributionParams
 	ProjectKey       string
+	Priority         string
 	Modifications
 }
 
@@ -39,6 +40,7 @@ type DistributeReleaseBundleParams struct {
 	DistributionRules []*distribution.DistributionCommonParams
 	PathMappings      []PathMapping
 	ProjectKey        string
+	Priority          string
 }
 
 func (dr *DistributeReleaseBundleService) GetHttpClient() *jfroghttpclient.JfrogHttpClient {
@@ -93,8 +95,9 @@ func (dr *DistributeReleaseBundleService) Distribute() error {
 
 func (dr *DistributeReleaseBundleService) createDistributeBody() ReleaseBundleDistributeBody {
 	return ReleaseBundleDistributeBody{
-		ReleaseBundleDistributeV1Body: distribution.CreateDistributeV1Body(dr.DistributeParams.DistributionRules, dr.DryRun, dr.AutoCreateRepo),
-		Modifications:                 dr.Modifications,
+		ReleaseBundleDistributeV1Body: distribution.CreateDistributeV1BodyWithPriority(
+			dr.DistributeParams.DistributionRules, dr.DryRun, dr.AutoCreateRepo, dr.Priority),
+		Modifications: dr.Modifications,
 	}
 }
 

--- a/utils/distribution/distribute.go
+++ b/utils/distribution/distribute.go
@@ -21,12 +21,19 @@ type DistributeReleaseBundleExecutor interface {
 }
 
 func CreateDistributeV1Body(distCommonParams []*DistributionCommonParams, dryRun, isAutoCreateRepo bool) ReleaseBundleDistributeV1Body {
+	return CreateDistributeV1BodyWithPriority(distCommonParams, dryRun, isAutoCreateRepo, "")
+}
+
+// CreateDistributeV1BodyWithPriority builds the Dist request body and sets an optional base priority
+// (low|medium|high). Empty priority is omitted from JSON.
+func CreateDistributeV1BodyWithPriority(distCommonParams []*DistributionCommonParams, dryRun, isAutoCreateRepo bool, priority string) ReleaseBundleDistributeV1Body {
 	var distributionRules []DistributionRulesBody
 	for i := range distCommonParams {
 		distributionRule := DistributionRulesBody{
 			SiteName:     distCommonParams[i].GetSiteName(),
 			CityName:     distCommonParams[i].GetCityName(),
 			CountryCodes: distCommonParams[i].GetCountryCodes(),
+			Priority:     distCommonParams[i].GetPriority(),
 		}
 		distributionRules = append(distributionRules, distributionRule)
 	}
@@ -34,6 +41,7 @@ func CreateDistributeV1Body(distCommonParams []*DistributionCommonParams, dryRun
 		DryRun:            dryRun,
 		DistributionRules: distributionRules,
 		AutoCreateRepo:    isAutoCreateRepo,
+		Priority:          priority,
 	}
 	return body
 }
@@ -97,12 +105,14 @@ type ReleaseBundleDistributeV1Body struct {
 	DryRun            bool                    `json:"dry_run"`
 	DistributionRules []DistributionRulesBody `json:"distribution_rules"`
 	AutoCreateRepo    bool                    `json:"auto_create_missing_repositories,omitempty"`
+	Priority          string                  `json:"priority,omitempty"`
 }
 
 type DistributionRulesBody struct {
 	SiteName     string   `json:"site_name,omitempty"`
 	CityName     string   `json:"city_name,omitempty"`
 	CountryCodes []string `json:"country_codes,omitempty"`
+	Priority     string   `json:"priority,omitempty"`
 }
 
 type DistributionResponseBody struct {

--- a/utils/distribution/distribute_priority_test.go
+++ b/utils/distribution/distribute_priority_test.go
@@ -1,0 +1,52 @@
+package distribution
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDistributeV1BodyWithPriority(t *testing.T) {
+	rules := []*DistributionCommonParams{
+		{SiteName: "edge1", Priority: "medium"},
+		{SiteName: "edge2", Priority: "low"},
+	}
+
+	body := CreateDistributeV1BodyWithPriority(rules, false, true, "high")
+	assert.Equal(t, "high", body.Priority)
+	assert.True(t, body.AutoCreateRepo)
+	assert.False(t, body.DryRun)
+	require.Len(t, body.DistributionRules, 2)
+	assert.Equal(t, "edge1", body.DistributionRules[0].SiteName)
+	assert.Equal(t, "medium", body.DistributionRules[0].Priority)
+	assert.Equal(t, "edge2", body.DistributionRules[1].SiteName)
+	assert.Equal(t, "low", body.DistributionRules[1].Priority)
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"priority":"high"`)
+	assert.Contains(t, string(raw), `"site_name":"edge1"`)
+	assert.Contains(t, string(raw), `"priority":"medium"`)
+	assert.Contains(t, string(raw), `"priority":"low"`)
+}
+
+func TestCreateDistributeV1BodyOmitsEmptyPriority(t *testing.T) {
+	body := CreateDistributeV1Body([]*DistributionCommonParams{{SiteName: "edge1"}}, true, false)
+	assert.Empty(t, body.Priority)
+	require.Len(t, body.DistributionRules, 1)
+	assert.Empty(t, body.DistributionRules[0].Priority)
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"priority"`)
+	assert.Contains(t, string(raw), `"dry_run":true`)
+}
+
+func TestDistributionCommonParamsPriorityAccessors(t *testing.T) {
+	params := &DistributionCommonParams{SiteName: "edge1"}
+	assert.Empty(t, params.GetPriority())
+	params.SetPriority("high")
+	assert.Equal(t, "high", params.GetPriority())
+}

--- a/utils/distribution/specutils.go
+++ b/utils/distribution/specutils.go
@@ -4,6 +4,7 @@ type DistributionCommonParams struct {
 	SiteName     string
 	CityName     string
 	CountryCodes []string
+	Priority     string
 }
 
 type DistributionGetter interface {
@@ -13,6 +14,8 @@ type DistributionGetter interface {
 	SetCityName(cityName string)
 	GetCountryCodes() []string
 	SetCountryCodes(countryCodes []string)
+	GetPriority() string
+	SetPriority(priority string)
 }
 
 func (params *DistributionCommonParams) GetSiteName() string {
@@ -37,4 +40,12 @@ func (params *DistributionCommonParams) GetCountryCodes() []string {
 
 func (params *DistributionCommonParams) SetCountryCodes(countryCodes []string) {
 	params.CountryCodes = countryCodes
+}
+
+func (params *DistributionCommonParams) GetPriority() string {
+	return params.Priority
+}
+
+func (params *DistributionCommonParams) SetPriority(priority string) {
+	params.Priority = priority
 }


### PR DESCRIPTION
## Summary
- Add optional `priority` (`low`|`medium`|`high`) on RBv2 distribute and remote-delete request bodies
- Support per-rule priority on `DistributionCommonParams` / distribution rules
- Wire priority through lifecycle distribute and remote-delete