### PR TITLE
RTDEV-97165 - Add limit/cursor params to ListVersions

### DIFF
--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -118,6 +118,7 @@ type ArtifactoryServicesManager interface {
 	ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error)
 	SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error)
 	SkillVersionExists(repoKey, slug, version string) (bool, error)
+	SkillExists(repoKey, slug string) (bool, error)
 	SearchSkillsByProperty(query string) ([]services.SkillPropertySearchResult, error)
 	GetSkillXrayStatus(repoKey, artifactPath string) (*services.SkillXrayStatusResponse, error)
 }
@@ -545,6 +546,10 @@ func (esm *EmptyArtifactoryServicesManager) SearchSkills(string, string, int) ([
 }
 
 func (esm *EmptyArtifactoryServicesManager) SkillVersionExists(string, string, string) (bool, error) {
+	panic("Failed: Method is not implemented")
+}
+
+func (esm *EmptyArtifactoryServicesManager) SkillExists(string, string) (bool, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/emptymanager.go
+++ b/artifactory/emptymanager.go
@@ -114,7 +114,7 @@ type ArtifactoryServicesManager interface {
 	ImportReleaseBundle(string) error
 	GetPackageLeadFile(leadFileParams services.LeadFileParams) ([]byte, error)
 	UploadTrustedKey(params services.TrustedKeyParams) (*services.TrustedKeyResponse, error)
-	ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error)
+	ListSkillVersions(repoKey, slug string, limit int, cursor string) ([]services.SkillVersion, string, error)
 	ListSkills(repoKey string, limit int, cursor, sortBy string) ([]services.SkillListItem, string, error)
 	SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error)
 	SkillVersionExists(repoKey, slug, version string) (bool, error)
@@ -532,7 +532,7 @@ func (esm *EmptyArtifactoryServicesManager) GetTokenDetails(string, string) ([]b
 	panic("Failed: Method is not implemented")
 }
 
-func (esm *EmptyArtifactoryServicesManager) ListSkillVersions(string, string) ([]services.SkillVersion, error) {
+func (esm *EmptyArtifactoryServicesManager) ListSkillVersions(string, string, int, string) ([]services.SkillVersion, string, error) {
 	panic("Failed: Method is not implemented")
 }
 

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -699,6 +699,12 @@ func (sm *ArtifactoryServicesManagerImp) SkillVersionExists(repoKey, slug, versi
 	return skillsService.VersionExists(repoKey, slug, version)
 }
 
+func (sm *ArtifactoryServicesManagerImp) SkillExists(repoKey, slug string) (bool, error) {
+	skillsService := services.NewSkillsService(sm.client)
+	skillsService.ArtDetails = sm.config.GetServiceDetails()
+	return skillsService.SkillExists(repoKey, slug)
+}
+
 func (sm *ArtifactoryServicesManagerImp) SearchSkillsByProperty(query string) ([]services.SkillPropertySearchResult, error) {
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()

--- a/artifactory/manager.go
+++ b/artifactory/manager.go
@@ -681,10 +681,10 @@ func (sm *ArtifactoryServicesManagerImp) ListSkills(repoKey string, limit int, c
 	return skillsService.ListSkills(repoKey, limit, cursor, sortBy)
 }
 
-func (sm *ArtifactoryServicesManagerImp) ListSkillVersions(repoKey, slug string) ([]services.SkillVersion, error) {
+func (sm *ArtifactoryServicesManagerImp) ListSkillVersions(repoKey, slug string, limit int, cursor string) ([]services.SkillVersion, string, error) {
 	skillsService := services.NewSkillsService(sm.client)
 	skillsService.ArtDetails = sm.config.GetServiceDetails()
-	return skillsService.ListVersions(repoKey, slug)
+	return skillsService.ListVersions(repoKey, slug, limit, cursor)
 }
 
 func (sm *ArtifactoryServicesManagerImp) SearchSkills(repoKey, query string, limit int) ([]services.SkillSearchResult, error) {

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -25,10 +25,10 @@ const (
 	SkillSortByUpdated   = "updated"
 	SkillSortByDownloads = "downloads"
 
-	// DefaultSkillVersionsLimit is the per-call page size ListVersions/VersionExists
-	// fall back to when the caller doesn't specify one (limit <= 0). Callers that want
-	// a different page size - e.g. jfrog-cli-artifactory - should pass their own limit
-	// explicitly rather than relying on this value.
+	// DefaultSkillVersionsLimit is the per-call page size ListVersions falls back to
+	// when the caller doesn't specify one (limit <= 0). Callers that want a different
+	// page size - e.g. jfrog-cli-artifactory - should pass their own limit explicitly
+	// rather than relying on this value.
 	DefaultSkillVersionsLimit = 200
 )
 
@@ -105,24 +105,27 @@ func (ss *SkillsService) SearchSkills(repoKey, query string, limit int) ([]Skill
 	return wrapper.Results, nil
 }
 
-// VersionExists reports whether version is published for repoKey/slug, paginating through all pages.
+// VersionExists reports whether version is published for repoKey/slug.
+// It hits the version-detail endpoint directly (a single request, 200 or 404)
+// rather than listing versions and paginating through them.
 func (ss *SkillsService) VersionExists(repoKey, slug, version string) (bool, error) {
-	cursor := ""
-	for {
-		versions, nextCursor, err := ss.ListVersions(repoKey, slug, DefaultSkillVersionsLimit, cursor)
-		if err != nil {
-			return false, err
-		}
-		for _, v := range versions {
-			if v.Version == version {
-				return true, nil
-			}
-		}
-		if nextCursor == "" || nextCursor == cursor {
-			return false, nil
-		}
-		cursor = nextCursor
+	log.Debug(fmt.Sprintf("Checking whether version '%s' exists for skill '%s' in repo '%s'...", version, slug, repoKey))
+	baseURL := utils.AddTrailingSlashIfNeeded(ss.ArtDetails.GetUrl())
+	requestURL := fmt.Sprintf("%sapi/skills/%s/api/v1/skills/%s/versions/%s", baseURL, repoKey, url.PathEscape(slug), url.PathEscape(version))
+	log.Debug("Skills API request:", requestURL)
+
+	httpDetails := ss.ArtDetails.CreateHttpClientDetails()
+	resp, body, _, err := ss.client.SendGet(requestURL, true, &httpDetails)
+	if err != nil {
+		return false, err
 	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // SearchByProperty uses the Artifactory property search API to find skills

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -24,6 +24,12 @@ const (
 
 	SkillSortByUpdated   = "updated"
 	SkillSortByDownloads = "downloads"
+
+	// DefaultSkillVersionsLimit is the per-call page size ListVersions/VersionExists
+	// fall back to when the caller doesn't specify one (limit <= 0). Callers that want
+	// a different page size - e.g. jfrog-cli-artifactory - should pass their own limit
+	// explicitly rather than relying on this value.
+	DefaultSkillVersionsLimit = 200
 )
 
 // SkillXrayStatusResponse is the response from the Skills Xray gate status endpoint.
@@ -46,18 +52,24 @@ func (ss *SkillsService) GetJfrogHttpClient() *jfroghttpclient.JfrogHttpClient {
 	return ss.client
 }
 
-func (ss *SkillsService) ListVersions(repoKey, slug string) ([]SkillVersion, error) {
+// ListVersions lists the versions published for repoKey/slug.
+// limit <= 0 falls back to DefaultSkillVersionsLimit; cursor resumes from previous page ("" starts from beginning).
+func (ss *SkillsService) ListVersions(repoKey, slug string, limit int, cursor string) ([]SkillVersion, string, error) {
 	log.Debug(fmt.Sprintf("Listing versions for skill '%s' in repo '%s'...", slug, repoKey))
-	body, err := ss.sendGet(repoKey, fmt.Sprintf("skills/%s/versions", slug))
+	if limit <= 0 {
+		limit = DefaultSkillVersionsLimit
+	}
+	endpoint := fmt.Sprintf("skills/%s/versions?limit=%d&cursor=%s", url.PathEscape(slug), limit, url.QueryEscape(cursor))
+	body, err := ss.sendGet(repoKey, endpoint)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	var wrapper skillVersionsResponse
 	if err = json.Unmarshal(body, &wrapper); err != nil {
-		return nil, errorutils.CheckErrorf("failed to parse skill versions response: %s", err.Error())
+		return nil, "", errorutils.CheckErrorf("failed to parse skill versions response: %s", err.Error())
 	}
-	return wrapper.Items, nil
+	return wrapper.Items, wrapper.NextCursor, nil
 }
 
 func (ss *SkillsService) ListSkills(repoKey string, limit int, cursor, sortBy string) ([]SkillListItem, string, error) {
@@ -93,17 +105,24 @@ func (ss *SkillsService) SearchSkills(repoKey, query string, limit int) ([]Skill
 	return wrapper.Results, nil
 }
 
+// VersionExists reports whether version is published for repoKey/slug, paginating through all pages.
 func (ss *SkillsService) VersionExists(repoKey, slug, version string) (bool, error) {
-	versions, err := ss.ListVersions(repoKey, slug)
-	if err != nil {
-		return false, err
-	}
-	for _, v := range versions {
-		if v.Version == version {
-			return true, nil
+	cursor := ""
+	for {
+		versions, nextCursor, err := ss.ListVersions(repoKey, slug, DefaultSkillVersionsLimit, cursor)
+		if err != nil {
+			return false, err
 		}
+		for _, v := range versions {
+			if v.Version == version {
+				return true, nil
+			}
+		}
+		if nextCursor == "" || nextCursor == cursor {
+			return false, nil
+		}
+		cursor = nextCursor
 	}
-	return false, nil
 }
 
 // SearchByProperty uses the Artifactory property search API to find skills
@@ -201,6 +220,7 @@ func (ss *SkillsService) sendGet(repoKey, endpoint string) ([]byte, error) {
 	return body, nil
 }
 
+// SkillVersion describes one published version of a skill.
 type SkillVersion struct {
 	Version   string `json:"version"`
 	CreatedAt int64  `json:"createdAt,omitempty"`
@@ -236,7 +256,8 @@ type skillListResponse struct {
 }
 
 type skillVersionsResponse struct {
-	Items []SkillVersion `json:"items"`
+	Items      []SkillVersion `json:"items"`
+	NextCursor string         `json:"nextCursor,omitempty"`
 }
 
 type skillSearchResponse struct {

--- a/artifactory/services/skills.go
+++ b/artifactory/services/skills.go
@@ -128,6 +128,29 @@ func (ss *SkillsService) VersionExists(repoKey, slug, version string) (bool, err
 	return true, nil
 }
 
+// SkillExists reports whether slug is published in repoKey.
+// It hits the skill-metadata endpoint directly (a single request, 200 or 404)
+// rather than listing versions to infer existence.
+func (ss *SkillsService) SkillExists(repoKey, slug string) (bool, error) {
+	log.Debug(fmt.Sprintf("Checking whether skill '%s' exists in repo '%s'...", slug, repoKey))
+	baseURL := utils.AddTrailingSlashIfNeeded(ss.ArtDetails.GetUrl())
+	requestURL := fmt.Sprintf("%sapi/skills/%s/api/v1/skills/%s", baseURL, repoKey, url.PathEscape(slug))
+	log.Debug("Skills API request:", requestURL)
+
+	httpDetails := ss.ArtDetails.CreateHttpClientDetails()
+	resp, body, _, err := ss.client.SendGet(requestURL, true, &httpDetails)
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // SearchByProperty uses the Artifactory property search API to find skills
 // by their skill.name property across all repositories.
 func (ss *SkillsService) SearchByProperty(query string) ([]SkillPropertySearchResult, error) {

--- a/artifactory/services/skills_test.go
+++ b/artifactory/services/skills_test.go
@@ -1,9 +1,17 @@
 package services
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePropSearchURI(t *testing.T) {
@@ -48,4 +56,263 @@ func TestParsePropSearchURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+// testServiceDetails is a minimal auth.ServiceDetails good enough to point a service
+// at an httptest.Server. It can't import artifactory/auth's real implementation here:
+// that package imports this one (artifactory/services), which would be a cycle.
+type testServiceDetails struct {
+	auth.CommonConfigFields
+}
+
+func (d *testServiceDetails) GetVersion() (string, error) { return "", nil }
+
+// newMockSkillsServer wires a SkillsService to an httptest.Server driven by handler.
+// The returned server must be closed by the caller.
+func newMockSkillsServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *SkillsService) {
+	t.Helper()
+	testServer := httptest.NewServer(handler)
+
+	details := &testServiceDetails{}
+	details.SetUrl(testServer.URL + "/")
+
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
+	require.NoError(t, err)
+
+	svc := NewSkillsService(client)
+	svc.ArtDetails = details
+	return testServer, svc
+}
+
+// pagedVersionsHandler serves a fixed set of versions (newest first, matching real
+// server order) with real limit/cursor pagination semantics: cursor is the version
+// string to resume after, and nextCursor is omitted (not empty-stringed) once the
+// last page has been served - mirroring the live behavior confirmed against
+// agent-skills/readme-standard on bukgradlefix.jfrogdev.org.
+func pagedVersionsHandler(t *testing.T, all []SkillVersion) (http.HandlerFunc, *[]*recordedRequest) {
+	t.Helper()
+	var requests []*recordedRequest
+	return func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, &recordedRequest{RawQuery: r.URL.RawQuery})
+
+		limit := 0
+		if l := r.URL.Query().Get("limit"); l != "" {
+			_, err := fmt.Sscanf(l, "%d", &limit)
+			require.NoError(t, err)
+		}
+		cursor := r.URL.Query().Get("cursor")
+
+		start := 0
+		if cursor != "" {
+			for i, v := range all {
+				if v.Version == cursor {
+					start = i + 1
+					break
+				}
+			}
+		}
+		end := start + limit
+		if limit <= 0 || end > len(all) {
+			end = len(all)
+		}
+		page := all[start:end]
+
+		resp := skillVersionsResponse{Items: page}
+		if end < len(all) {
+			resp.NextCursor = page[len(page)-1].Version
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}, &requests
+}
+
+// recordedRequest captures just what these tests assert on.
+type recordedRequest struct {
+	RawQuery string
+}
+
+func TestSkillsService_ListVersions_DefaultsLimitWhenNonPositive(t *testing.T) {
+	all := []SkillVersion{{Version: "1.0.1", CreatedAt: 1}}
+	handler, requests := pagedVersionsHandler(t, all)
+	server, svc := newMockSkillsServer(t, handler)
+	defer server.Close()
+
+	versions, nextCursor, err := svc.ListVersions("repo", "my-skill", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, all, versions)
+	assert.Empty(t, nextCursor)
+	require.Len(t, *requests, 1)
+	assert.Contains(t, (*requests)[0].RawQuery, fmt.Sprintf("limit=%d", DefaultSkillVersionsLimit))
+}
+
+func TestSkillsService_ListVersions_TruncatesAndReturnsCursor(t *testing.T) {
+	all := []SkillVersion{
+		{Version: "1.0.3", CreatedAt: 3},
+		{Version: "1.0.2", CreatedAt: 2},
+		{Version: "1.0.1", CreatedAt: 1},
+	}
+	handler, _ := pagedVersionsHandler(t, all)
+	server, svc := newMockSkillsServer(t, handler)
+	defer server.Close()
+
+	versions, nextCursor, err := svc.ListVersions("repo", "my-skill", 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, all[:2], versions)
+	assert.Equal(t, "1.0.2", nextCursor)
+}
+
+func TestSkillsService_ListVersions_CursorResumesAfterLastItem(t *testing.T) {
+	all := []SkillVersion{
+		{Version: "1.0.3", CreatedAt: 3},
+		{Version: "1.0.2", CreatedAt: 2},
+		{Version: "1.0.1", CreatedAt: 1},
+	}
+	handler, _ := pagedVersionsHandler(t, all)
+	server, svc := newMockSkillsServer(t, handler)
+	defer server.Close()
+
+	versions, nextCursor, err := svc.ListVersions("repo", "my-skill", 2, "1.0.2")
+	require.NoError(t, err)
+	assert.Equal(t, all[2:], versions)
+	assert.Empty(t, nextCursor)
+}
+
+func TestSkillsService_ListVersions_PaginatesUntilExhausted(t *testing.T) {
+	// Simulates a skill with more versions than a single page: the caller must loop
+	// on nextCursor to see all of them, and the loop must terminate (no infinite spin).
+	all := make([]SkillVersion, 5)
+	for i := range all {
+		all[i] = SkillVersion{Version: fmt.Sprintf("1.0.%d", len(all)-i), CreatedAt: int64(len(all) - i)}
+	}
+	handler, requests := pagedVersionsHandler(t, all)
+	server, svc := newMockSkillsServer(t, handler)
+	defer server.Close()
+
+	var collected []SkillVersion
+	cursor := ""
+	for i := 0; i < len(all)+1; i++ { // hard cap so a broken loop fails the test instead of hanging
+		page, next, err := svc.ListVersions("repo", "my-skill", 2, cursor)
+		require.NoError(t, err)
+		collected = append(collected, page...)
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	assert.Equal(t, all, collected)
+	assert.Equal(t, 3, len(*requests)) // 2 + 2 + 1, minimum calls for 5 items at page size 2
+}
+
+func TestSkillsService_ListVersions_NotFound(t *testing.T) {
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	versions, nextCursor, err := svc.ListVersions("repo", "missing-skill", DefaultSkillVersionsLimit, "")
+	require.Error(t, err)
+	assert.Nil(t, versions)
+	assert.Empty(t, nextCursor)
+}
+
+func TestSkillsService_VersionExists(t *testing.T) {
+	all := []SkillVersion{{Version: "1.0.2"}, {Version: "1.0.1"}}
+	handler, _ := pagedVersionsHandler(t, all)
+	server, svc := newMockSkillsServer(t, handler)
+	defer server.Close()
+
+	exists, err := svc.VersionExists("repo", "my-skill", "1.0.1")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = svc.VersionExists("repo", "my-skill", "9.9.9")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// fixedPageSizeVersionsHandler ignores the requested limit and always serves exactly
+// one item per call, regardless of DefaultSkillVersionsLimit. This simulates a server
+// whose real version count exceeds a single page, so VersionExists is forced to
+// follow nextCursor across multiple calls to find (or rule out) the target version.
+func fixedPageSizeVersionsHandler(t *testing.T, all []SkillVersion) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		start := 0
+		if cursor != "" {
+			for i, v := range all {
+				if v.Version == cursor {
+					start = i + 1
+					break
+				}
+			}
+		}
+		resp := skillVersionsResponse{}
+		if start < len(all) {
+			resp.Items = all[start : start+1]
+			if start+1 < len(all) {
+				resp.NextCursor = resp.Items[0].Version
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}
+}
+
+func TestSkillsService_VersionExists_SearchesBeyondFirstPage(t *testing.T) {
+	all := []SkillVersion{{Version: "1.0.3"}, {Version: "1.0.2"}, {Version: "1.0.1"}}
+	server, svc := newMockSkillsServer(t, fixedPageSizeVersionsHandler(t, all))
+	defer server.Close()
+
+	exists, err := svc.VersionExists("repo", "my-skill", "1.0.1")
+	require.NoError(t, err, "must not stop after the first (single-item) page")
+	assert.True(t, exists)
+
+	exists, err = svc.VersionExists("repo", "my-skill", "9.9.9")
+	require.NoError(t, err)
+	assert.False(t, exists, "must exhaust all pages before concluding the version is absent")
+}
+
+func TestSkillsService_VersionExists_StopsOnNonAdvancingCursor(t *testing.T) {
+	// A server bug returning the same cursor forever must not hang the caller.
+	calls := 0
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 3 {
+			t.Fatalf("VersionExists did not stop on a non-advancing cursor")
+		}
+		resp := skillVersionsResponse{
+			Items:      []SkillVersion{{Version: "1.0.1"}},
+			NextCursor: "stuck-cursor",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	})
+	defer server.Close()
+
+	exists, err := svc.VersionExists("repo", "my-skill", "9.9.9")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.LessOrEqual(t, calls, 2, "must stop as soon as the cursor repeats")
+}
+
+func TestSkillsService_ListVersions_EscapesSlugInRequestPath(t *testing.T) {
+	// r.URL.Path is decoded by net/http before the handler sees it, so the raw wire
+	// form (r.RequestURI) is what actually proves the slug was escaped on the way out.
+	var capturedRequestURI string
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(skillVersionsResponse{}))
+	})
+	defer server.Close()
+
+	_, _, err := svc.ListVersions("repo", "weird/slug name", 1, "")
+	require.NoError(t, err)
+	assert.Contains(t, capturedRequestURI, url.PathEscape("weird/slug name"))
+	assert.NotContains(t, capturedRequestURI, "skills/weird/slug name/versions", "an unescaped slash would target a different path entirely")
 }

--- a/artifactory/services/skills_test.go
+++ b/artifactory/services/skills_test.go
@@ -288,6 +288,54 @@ func TestSkillsService_VersionExists_EscapesSlugAndVersionInRequestPath(t *testi
 	assert.Contains(t, capturedRequestURI, url.PathEscape("weird/version"))
 }
 
+func TestSkillsService_SkillExists(t *testing.T) {
+	var requests int
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if strings.HasSuffix(r.URL.Path, "/my-skill") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	exists, err := svc.SkillExists("repo", "my-skill")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = svc.SkillExists("repo", "missing-skill")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// A single targeted request per check.
+	assert.Equal(t, 2, requests)
+}
+
+func TestSkillsService_SkillExists_ServerError(t *testing.T) {
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	exists, err := svc.SkillExists("repo", "my-skill")
+	require.Error(t, err)
+	assert.False(t, exists)
+}
+
+func TestSkillsService_SkillExists_EscapesSlugInRequestPath(t *testing.T) {
+	var capturedRequestURI string
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	_, err := svc.SkillExists("repo", "weird/slug name")
+	require.NoError(t, err)
+	assert.Contains(t, capturedRequestURI, url.PathEscape("weird/slug name"))
+}
+
 func TestSkillsService_ListVersions_EscapesSlugInRequestPath(t *testing.T) {
 	// r.URL.Path is decoded by net/http before the handler sees it, so the raw wire
 	// form (r.RequestURI) is what actually proves the slug was escaped on the way out.

--- a/artifactory/services/skills_test.go
+++ b/artifactory/services/skills_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/jfrog/jfrog-client-go/auth"
@@ -216,9 +217,37 @@ func TestSkillsService_ListVersions_NotFound(t *testing.T) {
 	assert.Empty(t, nextCursor)
 }
 
+// versionDetailHandler serves the single-version detail endpoint
+// (skills/{slug}/versions/{version}): 200 with the version body when it's in `all`,
+// 404 otherwise - matching live behavior confirmed against
+// agent-skills/readme-standard on bukgradlefix.jfrogdev.org.
+func versionDetailHandler(t *testing.T, all []SkillVersion) (http.HandlerFunc, *[]*recordedRequest) {
+	t.Helper()
+	var requests []*recordedRequest
+	return func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, &recordedRequest{RawQuery: r.URL.RawQuery})
+
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		requested := parts[len(parts)-1]
+		for _, v := range all {
+			if v.Version == requested {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				require.NoError(t, json.NewEncoder(w).Encode(v))
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{{"status": http.StatusNotFound, "message": "Not found"}},
+		}))
+	}, &requests
+}
+
 func TestSkillsService_VersionExists(t *testing.T) {
 	all := []SkillVersion{{Version: "1.0.2"}, {Version: "1.0.1"}}
-	handler, _ := pagedVersionsHandler(t, all)
+	handler, requests := versionDetailHandler(t, all)
 	server, svc := newMockSkillsServer(t, handler)
 	defer server.Close()
 
@@ -229,74 +258,34 @@ func TestSkillsService_VersionExists(t *testing.T) {
 	exists, err = svc.VersionExists("repo", "my-skill", "9.9.9")
 	require.NoError(t, err)
 	assert.False(t, exists)
+
+	// A single targeted request per check - no pagination/listing involved.
+	assert.Len(t, *requests, 2)
 }
 
-// fixedPageSizeVersionsHandler ignores the requested limit and always serves exactly
-// one item per call, regardless of DefaultSkillVersionsLimit. This simulates a server
-// whose real version count exceeds a single page, so VersionExists is forced to
-// follow nextCursor across multiple calls to find (or rule out) the target version.
-func fixedPageSizeVersionsHandler(t *testing.T, all []SkillVersion) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		cursor := r.URL.Query().Get("cursor")
-		start := 0
-		if cursor != "" {
-			for i, v := range all {
-				if v.Version == cursor {
-					start = i + 1
-					break
-				}
-			}
-		}
-		resp := skillVersionsResponse{}
-		if start < len(all) {
-			resp.Items = all[start : start+1]
-			if start+1 < len(all) {
-				resp.NextCursor = resp.Items[0].Version
-			}
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
-	}
-}
-
-func TestSkillsService_VersionExists_SearchesBeyondFirstPage(t *testing.T) {
-	all := []SkillVersion{{Version: "1.0.3"}, {Version: "1.0.2"}, {Version: "1.0.1"}}
-	server, svc := newMockSkillsServer(t, fixedPageSizeVersionsHandler(t, all))
-	defer server.Close()
-
-	exists, err := svc.VersionExists("repo", "my-skill", "1.0.1")
-	require.NoError(t, err, "must not stop after the first (single-item) page")
-	assert.True(t, exists)
-
-	exists, err = svc.VersionExists("repo", "my-skill", "9.9.9")
-	require.NoError(t, err)
-	assert.False(t, exists, "must exhaust all pages before concluding the version is absent")
-}
-
-func TestSkillsService_VersionExists_StopsOnNonAdvancingCursor(t *testing.T) {
-	// A server bug returning the same cursor forever must not hang the caller.
-	calls := 0
+func TestSkillsService_VersionExists_ServerError(t *testing.T) {
 	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls > 3 {
-			t.Fatalf("VersionExists did not stop on a non-advancing cursor")
-		}
-		resp := skillVersionsResponse{
-			Items:      []SkillVersion{{Version: "1.0.1"}},
-			NextCursor: "stuck-cursor",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
+		w.WriteHeader(http.StatusInternalServerError)
 	})
 	defer server.Close()
 
-	exists, err := svc.VersionExists("repo", "my-skill", "9.9.9")
-	require.NoError(t, err)
+	exists, err := svc.VersionExists("repo", "my-skill", "1.0.1")
+	require.Error(t, err)
 	assert.False(t, exists)
-	assert.LessOrEqual(t, calls, 2, "must stop as soon as the cursor repeats")
+}
+
+func TestSkillsService_VersionExists_EscapesSlugAndVersionInRequestPath(t *testing.T) {
+	var capturedRequestURI string
+	server, svc := newMockSkillsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	_, err := svc.VersionExists("repo", "weird/slug name", "weird/version")
+	require.NoError(t, err)
+	assert.Contains(t, capturedRequestURI, url.PathEscape("weird/slug name"))
+	assert.Contains(t, capturedRequestURI, url.PathEscape("weird/version"))
 }
 
 func TestSkillsService_ListVersions_EscapesSlugInRequestPath(t *testing.T) {


### PR DESCRIPTION
The Skills API versions endpoint (/api/v1/skills/{slug}/versions) does not support a sort parameter at all, confirmed by decompiling the server's SkillsResource.listSkillVersions bytecode — it has only 3 parameters: slug, limit, cursor. Remove the dead sortBy parameter and its callers.

ListVersions now takes (repoKey, slug string, limit int, cursor string), returning ([]SkillVersion, nextCursor string, error).

Mirrors ListSkills' pagination pattern for the versions endpoint using only the confirmed parameters (limit, cursor). The returned nextCursor is the next page's cursor, or "" when the current page is the last one (the server omits nextCursor from the JSON entirely in that case).

limit/cursor behavior verified empirically against a live Artifactory instance (agent-skills/readme-standard on bukgradlefix.jfrogdev.org): a short limit truncates the result and returns a real nextCursor; passing that cursor back resumes correctly after the last item.

Code review fixes from decompiling the actual server:
  - slug is url.PathEscape'd before being interpolated into request path
  - VersionExists now paginates across all pages to avoid false negatives on skills with unusually large version histories
  - Pagination loop stops if server returns non-advancing cursor

Adds comprehensive unit test coverage via httptest mock server.

- [x] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-client-go/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----