### PR TITLE
artifactory: skip download when local file matches Sha256

### DIFF
--- a/artifactory/services/download.go
+++ b/artifactory/services/download.go
@@ -594,6 +594,12 @@ func (ds *DownloadService) downloadFileIfNeeded(downloadPath, localPath, localFi
 	if err != nil {
 		return err
 	}
+	if !isEqual && downloadData.Dependency.Sha256 != "" {
+		isEqual, err = fileutils.IsEqualToLocalFileBySha256(localFilePath, downloadData.Dependency.Sha256, downloadData.Dependency.Size)
+		if err != nil {
+			return err
+		}
+	}
 	if isEqual {
 		log.Debug(logMsgPrefix+"File already exists locally:", localFilePath)
 		if ds.Progress != nil {

--- a/utils/io/fileutils/files.go
+++ b/utils/io/fileutils/files.go
@@ -569,6 +569,28 @@ func IsEqualToLocalFile(localFilePath, md5, sha1 string) (bool, error) {
 	return localFileDetails.Checksum.Md5 == md5 && localFileDetails.Checksum.Sha1 == sha1, nil
 }
 
+// Compares provided Sha256 (and optional size) to those of a local file.
+func IsEqualToLocalFileBySha256(localFilePath, sha256 string, size int64) (bool, error) {
+	if sha256 == "" {
+		return false, nil
+	}
+	exists, err := IsFileExists(localFilePath, false)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	localFileDetails, err := GetFileDetails(localFilePath, true)
+	if err != nil {
+		return false, err
+	}
+	if size > 0 && localFileDetails.Size != size {
+		return false, nil
+	}
+	return localFileDetails.Checksum.Sha256 == sha256, nil
+}
+
 // Move directory content from one path to another.
 func MoveDir(fromPath, toPath string) error {
 	err := CreateDirIfNotExist(toPath)

--- a/utils/io/fileutils/files_test.go
+++ b/utils/io/fileutils/files_test.go
@@ -266,6 +266,43 @@ func TestIsEqualToLocalFile(t *testing.T) {
 	}
 }
 
+func TestIsEqualToLocalFileBySha256(t *testing.T) {
+	localFilePath := filepath.Join("testdata", "files", "comparisonFile")
+
+	localFileDetails, err := GetFileDetails(localFilePath, true)
+	if err != nil {
+		assert.NoError(t, err)
+		return
+	}
+
+	actualSha256 := localFileDetails.Checksum.Sha256
+	actualSize := localFileDetails.Size
+	tests := []struct {
+		name           string
+		localPath      string
+		remoteSha256   string
+		size           int64
+		expectedResult bool
+	}{
+		{"realEquality", localFilePath, actualSha256, actualSize, true},
+		{"unequalPath", "non/existing/path", actualSha256, actualSize, false},
+		{"unequalChecksum", localFilePath, "wrongSha256", actualSize, false},
+		{"unequalSize", localFilePath, actualSha256, actualSize + 1, false},
+		{"emptySha256", localFilePath, "", actualSize, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isEqual, err := IsEqualToLocalFileBySha256(test.localPath, test.remoteSha256, test.size)
+			if err != nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Equal(t, test.expectedResult, isEqual)
+		})
+	}
+}
+
 func TestListFilesByFilterFunc(t *testing.T) {
 	testDir := filepath.Join("testdata", "listextension")
 	expected := []string{filepath.Join(testDir, "a.proj"),


### PR DESCRIPTION
Fixes #1384

DownloadFiles now compares local files by Sha256 (and size when available) when Md5/Sha1 are not known, so downloads that bypass AQL no longer re-fetch existing files.

## Test plan
- [x] go test ./utils/io/fileutils/... -count=1 -run TestIsEqualToLocalFile (pass)